### PR TITLE
[IOTCELL-282] Code cleanup/simplification and rules

### DIFF
--- a/TESTS/lorawan/basic/main.cpp
+++ b/TESTS/lorawan/basic/main.cpp
@@ -42,7 +42,7 @@ bool connect_lora()
     link_check_response = false;
 
     ret = lorawan.connect();
-    if (ret != LORA_MAC_STATUS_OK && ret != LORA_MAC_STATUS_CONNECT_IN_PROGRESS) {
+    if (ret != LORAWAN_STATUS_OK && ret != LORAWAN_STATUS_CONNECT_IN_PROGRESS) {
         TEST_ASSERT_MESSAGE(false, "Connect failed");
         return false;
     }
@@ -67,7 +67,7 @@ bool connect_lora()
 bool disconnect_lora()
 {
     int16_t ret = lorawan.disconnect();
-    if (ret != LORA_MAC_STATUS_OK) {
+    if (ret != LORAWAN_STATUS_OK) {
         TEST_ASSERT_MESSAGE(false, "Disconnect failed");
         return false;
     }
@@ -507,7 +507,7 @@ void lora_send_MAC_command_linkcheckreq()
 
     // set a link check request command
     ret = lorawan.add_link_check_request();
-    if (ret != LORA_MAC_STATUS_OK) {
+    if (ret != LORAWAN_STATUS_OK) {
         TEST_ASSERT_MESSAGE(false, "Adding link check req failed!");
         return;
     }
@@ -1124,7 +1124,7 @@ void lora_send_MAC_command_DlChannelReq()
 
 void lora_connect_with_params_otaa_wrong()
 {
-    lora_mac_status_t ret;
+    lorawan_status_t ret;
     lorawan_connect_t params;
     uint8_t counter = 0;
 
@@ -1143,7 +1143,7 @@ void lora_connect_with_params_otaa_wrong()
     params.connection_u.otaa.nb_trials = MBED_CONF_LORA_NB_TRIALS;
 
     ret = lorawan.connect(params);
-    TEST_ASSERT_MESSAGE(ret == LORA_MAC_STATUS_OK || ret == LORA_MAC_STATUS_CONNECT_IN_PROGRESS, "MAC status incorrect");
+    TEST_ASSERT_MESSAGE(ret == LORAWAN_STATUS_OK || ret == LORAWAN_STATUS_CONNECT_IN_PROGRESS, "MAC status incorrect");
 
     // Wait for CONNECTED event
     while (1) {
@@ -1177,7 +1177,7 @@ void lora_adr_enable_disable()
     connect_lora();
 
     ret = lorawan.enable_adaptive_datarate();
-    TEST_ASSERT_MESSAGE(ret == LORA_MAC_STATUS_OK, "MAC status incorrect");
+    TEST_ASSERT_MESSAGE(ret == LORAWAN_STATUS_OK, "MAC status incorrect");
 
     ret = lorawan.send(MBED_CONF_LORA_APP_PORT, tx_data, sizeof(tx_data), MSG_CONFIRMED_FLAG);
     if (ret != sizeof(tx_data)) {
@@ -1232,7 +1232,7 @@ void lora_adr_enable_disable()
     }
 
     ret = lorawan.disable_adaptive_datarate();
-    TEST_ASSERT_MESSAGE(ret == LORA_MAC_STATUS_OK, "MAC status incorrect");
+    TEST_ASSERT_MESSAGE(ret == LORAWAN_STATUS_OK, "MAC status incorrect");
 
     ret = lorawan.send(MBED_CONF_LORA_APP_PORT, tx_data, sizeof(tx_data), MSG_CONFIRMED_FLAG);
     if (ret != sizeof(tx_data)) {
@@ -1368,16 +1368,16 @@ void lora_set_data_rate()
 
     // ADR must be disabled to set the datarate
     ret = lorawan.disable_adaptive_datarate();
-    TEST_ASSERT_MESSAGE(ret == LORA_MAC_STATUS_OK, "Incorrect MAC status");
+    TEST_ASSERT_MESSAGE(ret == LORAWAN_STATUS_OK, "Incorrect MAC status");
 
     connect_lora();
 
     // Set data rate to 1 -> Expected SF11BW125
     data_rate = 1;
     ret = lorawan.set_datarate(data_rate);
-    if(ret == LORA_MAC_STATUS_PARAMETER_INVALID) {
+    if(ret == LORAWAN_STATUS_PARAMETER_INVALID) {
         TEST_ASSERT_MESSAGE(false, "Invalid parameter: ADR not disabled or invalid data rate");
-    } else if(ret != LORA_MAC_STATUS_OK) {
+    } else if(ret != LORAWAN_STATUS_OK) {
         TEST_ASSERT_MESSAGE(false, "Incorrect MAC status");
     }
 
@@ -1389,9 +1389,9 @@ void lora_set_data_rate()
     strcpy((char*)tx_data, "DR3");
 
     ret = lorawan.set_datarate(data_rate);
-    if(ret == LORA_MAC_STATUS_PARAMETER_INVALID) {
+    if(ret == LORAWAN_STATUS_PARAMETER_INVALID) {
         TEST_ASSERT_MESSAGE(false, "Invalid parameter: ADR not disabled or invalid data rate");
-    } else if(ret != LORA_MAC_STATUS_OK) {
+    } else if(ret != LORAWAN_STATUS_OK) {
         TEST_ASSERT_MESSAGE(false, "Incorrect MAC status");
     }
 
@@ -1402,9 +1402,9 @@ void lora_set_data_rate()
     data_rate = 5;
     strcpy((char*)tx_data, "DR5");
     ret = lorawan.set_datarate(data_rate);
-    if(ret == LORA_MAC_STATUS_PARAMETER_INVALID) {
+    if(ret == LORAWAN_STATUS_PARAMETER_INVALID) {
         TEST_ASSERT_MESSAGE(false, "Invalid parameter: ADR not disabled or invalid data rate");
-    } else if(ret != LORA_MAC_STATUS_OK) {
+    } else if(ret != LORAWAN_STATUS_OK) {
         TEST_ASSERT_MESSAGE(false, "Incorrect MAC status");
     }
 
@@ -1441,7 +1441,7 @@ utest::v1::status_t greentea_test_setup(const size_t number_of_cases) {
     return greentea_test_setup_handler(number_of_cases);
 }
 
-static void lora_event_handler(lora_events_t events)
+static void lora_event_handler(lorawan_events_t events)
 {
     if (lora_helper.event_lock) {
         return;
@@ -1463,7 +1463,7 @@ int main() {
     lorawan.add_app_callbacks(&callbacks);
 
     int16_t ret = lorawan.initialize(&ev_queue);
-    if (ret != LORA_MAC_STATUS_OK) {
+    if (ret != LORAWAN_STATUS_OK) {
         TEST_ASSERT_MESSAGE(false, "Initialization failed");
         return ret;
     }

--- a/TESTS/lorawan/connection_without_params_abp_success/main.cpp
+++ b/TESTS/lorawan/connection_without_params_abp_success/main.cpp
@@ -34,13 +34,13 @@ void connection_without_params_abp_success()
     uint8_t tx_data[] = "test_unconfirmed_message";
 
     ret = lorawan.initialize(&ev_queue);
-    if (ret != LORA_MAC_STATUS_OK) {
+    if (ret != LORAWAN_STATUS_OK) {
         TEST_ASSERT_MESSAGE(false, "Initialization failed");
         return;
     }
 
     ret = lorawan.connect();
-    if (ret != LORA_MAC_STATUS_OK && ret != LORA_MAC_STATUS_CONNECT_IN_PROGRESS) {
+    if (ret != LORAWAN_STATUS_OK && ret != LORAWAN_STATUS_CONNECT_IN_PROGRESS) {
         TEST_ASSERT_MESSAGE(false, "Connect failed");
         return;
     }
@@ -140,7 +140,7 @@ utest::v1::status_t greentea_test_setup(const size_t number_of_cases) {
     return greentea_test_setup_handler(number_of_cases);
 }
 
-void lora_event_handler(lora_events_t events)
+void lora_event_handler(lorawan_events_t events)
 {
     if (lora_helper.event_lock) {
         return;

--- a/TESTS/lorawan/connection_without_params_abp_wrong_keys/main.cpp
+++ b/TESTS/lorawan/connection_without_params_abp_wrong_keys/main.cpp
@@ -33,13 +33,13 @@ void connection_without_params_abp_wrong_keys()
     uint8_t tx_data[] = "test_unconfirmed_message";
 
     ret = lorawan.initialize(&ev_queue);
-    if (ret != LORA_MAC_STATUS_OK) {
+    if (ret != LORAWAN_STATUS_OK) {
         TEST_ASSERT_MESSAGE(false, "Initialization failed");
         return;
     }
 
     ret = lorawan.connect();
-    if (ret != LORA_MAC_STATUS_OK && ret != LORA_MAC_STATUS_CONNECT_IN_PROGRESS) {
+    if (ret != LORAWAN_STATUS_OK && ret != LORAWAN_STATUS_CONNECT_IN_PROGRESS) {
         TEST_ASSERT_MESSAGE(false, "Connect failed");
         return;
     }
@@ -119,7 +119,7 @@ utest::v1::status_t greentea_test_setup(const size_t number_of_cases) {
     return greentea_test_setup_handler(number_of_cases);
 }
 
-void lora_event_handler(lora_events_t events)
+void lora_event_handler(lorawan_events_t events)
 {
     if (lora_helper.event_lock) {
         return;

--- a/TESTS/lorawan/connection_without_params_otaa_private_true/main.cpp
+++ b/TESTS/lorawan/connection_without_params_otaa_private_true/main.cpp
@@ -27,17 +27,17 @@ LoRaTestHelper lora_helper;
 
 void connection_without_params_otaa_private_true()
 {
-    lora_mac_status_t ret;
+    lorawan_status_t ret;
     uint8_t counter = 0;
 
     ret = lorawan.initialize(&ev_queue);
-    if (ret != LORA_MAC_STATUS_OK) {
+    if (ret != LORAWAN_STATUS_OK) {
         TEST_ASSERT_MESSAGE(false, "Initialization failed");
         return;
     }
 
     ret = lorawan.connect();
-    if (ret != LORA_MAC_STATUS_OK && ret != LORA_MAC_STATUS_CONNECT_IN_PROGRESS) {
+    if (ret != LORAWAN_STATUS_OK && ret != LORAWAN_STATUS_CONNECT_IN_PROGRESS) {
         TEST_ASSERT_MESSAGE(false, "Connect failed");
         return;
     }
@@ -72,7 +72,7 @@ utest::v1::status_t greentea_test_setup(const size_t number_of_cases) {
     return greentea_test_setup_handler(number_of_cases);
 }
 
-void lora_event_handler(lora_events_t events)
+void lora_event_handler(lorawan_events_t events)
 {
     if (lora_helper.event_lock) {
         return;

--- a/TESTS/lorawan/connection_without_params_otaa_with_json_incorrect/main.cpp
+++ b/TESTS/lorawan/connection_without_params_otaa_with_json_incorrect/main.cpp
@@ -27,17 +27,17 @@ LoRaTestHelper lora_helper;
 
 void connection_without_params_otaa_with_json_incorrect()
 {
-    lora_mac_status_t ret;
+    lorawan_status_t ret;
     uint8_t counter = 0;
 
     ret = lorawan.initialize(&ev_queue);
-    if (ret != LORA_MAC_STATUS_OK) {
+    if (ret != LORAWAN_STATUS_OK) {
         TEST_ASSERT_MESSAGE(false, "Initialization failed");
         return;
     }
 
     ret = lorawan.connect();
-    if (ret != LORA_MAC_STATUS_OK && ret != LORA_MAC_STATUS_CONNECT_IN_PROGRESS) {
+    if (ret != LORAWAN_STATUS_OK && ret != LORAWAN_STATUS_CONNECT_IN_PROGRESS) {
         TEST_ASSERT_MESSAGE(false, "Connect failed");
         return;
     }
@@ -70,7 +70,7 @@ utest::v1::status_t greentea_test_setup(const size_t number_of_cases) {
     return greentea_test_setup_handler(number_of_cases);
 }
 
-void lora_event_handler(lora_events_t events)
+void lora_event_handler(lorawan_events_t events)
 {
     if (lora_helper.event_lock) {
         return;

--- a/TESTS/lorawan/extended/main.cpp
+++ b/TESTS/lorawan/extended/main.cpp
@@ -27,14 +27,14 @@ static LoRaTestHelper lora_helper;
 
 void lora_connect()
 {
-    lora_mac_status_t ret;
+    lorawan_status_t ret;
     uint8_t counter = 0;
 
     //Allow upcoming events
     lora_helper.event_lock = false;
 
     ret = lorawan.connect();
-    TEST_ASSERT_MESSAGE(ret == LORA_MAC_STATUS_OK || ret == LORA_MAC_STATUS_CONNECT_IN_PROGRESS, "Connect failed");
+    TEST_ASSERT_MESSAGE(ret == LORAWAN_STATUS_OK || ret == LORAWAN_STATUS_CONNECT_IN_PROGRESS, "Connect failed");
 
     // Wait for CONNECTED event
     while (1) {
@@ -52,7 +52,7 @@ void lora_connect()
     }
 
     ret = lorawan.disconnect();
-    TEST_ASSERT_MESSAGE(ret == LORA_MAC_STATUS_OK, "Disconnect failed");
+    TEST_ASSERT_MESSAGE(ret == LORAWAN_STATUS_OK, "Disconnect failed");
 
     //Prevent upcoming events between tests
     lora_helper.event_lock = true;
@@ -62,7 +62,7 @@ void lora_connect()
 
 void lora_connect_with_params_wrong_type()
 {
-    lora_mac_status_t ret;
+    lorawan_status_t ret;
     lorawan_connect_t params;
 
     //Allow upcoming events
@@ -70,7 +70,7 @@ void lora_connect_with_params_wrong_type()
 
     params.connect_type = (lorawan_connect_type_t)100;
     ret = lorawan.connect(params);
-    TEST_ASSERT_MESSAGE(ret == LORA_MAC_STATUS_PARAMETER_INVALID, "Incorrect return value, expected LORA_MAC_STATUS_PARAMETER_INVALID");
+    TEST_ASSERT_MESSAGE(ret == LORAWAN_STATUS_PARAMETER_INVALID, "Incorrect return value, expected LORAWAN_STATUS_PARAMETER_INVALID");
 
     //Prevent upcoming events between tests
     lora_helper.event_lock = true;
@@ -80,7 +80,7 @@ void lora_connect_with_params_wrong_type()
 
 void lora_connect_with_params_otaa_ok()
 {
-    lora_mac_status_t ret;
+    lorawan_status_t ret;
     lorawan_connect_t params;
     uint8_t counter = 0;
 
@@ -101,7 +101,7 @@ void lora_connect_with_params_otaa_ok()
     params.connection_u.otaa.app_key = my_app_key;
 
     ret = lorawan.connect(params);
-    TEST_ASSERT_MESSAGE(ret == LORA_MAC_STATUS_OK || ret == LORA_MAC_STATUS_CONNECT_IN_PROGRESS, "Connect failed");
+    TEST_ASSERT_MESSAGE(ret == LORAWAN_STATUS_OK || ret == LORAWAN_STATUS_CONNECT_IN_PROGRESS, "Connect failed");
 
     // Wait for CONNECTED event
     while (1) {
@@ -119,7 +119,7 @@ void lora_connect_with_params_otaa_ok()
     }
 
     ret = lorawan.disconnect();
-    TEST_ASSERT_MESSAGE(ret == LORA_MAC_STATUS_OK, "Disconnect failed");
+    TEST_ASSERT_MESSAGE(ret == LORAWAN_STATUS_OK, "Disconnect failed");
 
     //Prevent upcoming events between tests
     lora_helper.event_lock = true;
@@ -129,7 +129,7 @@ void lora_connect_with_params_otaa_ok()
 
 void lora_connect_with_params_abp_ok()
 {
-    lora_mac_status_t ret;
+    lorawan_status_t ret;
     lorawan_connect_t params;
     uint8_t counter = 0;
 
@@ -149,7 +149,7 @@ void lora_connect_with_params_abp_ok()
     params.connection_u.abp.app_skey = my_app_skey;
 
     ret = lorawan.connect(params);
-    TEST_ASSERT_MESSAGE(ret == LORA_MAC_STATUS_OK || ret == LORA_MAC_STATUS_CONNECT_IN_PROGRESS, "Connect failed");
+    TEST_ASSERT_MESSAGE(ret == LORAWAN_STATUS_OK || ret == LORAWAN_STATUS_CONNECT_IN_PROGRESS, "Connect failed");
 
     // Wait for CONNECTED event
     while (1) {
@@ -167,7 +167,7 @@ void lora_connect_with_params_abp_ok()
     }
 
     ret = lorawan.disconnect();
-    TEST_ASSERT_MESSAGE(ret == LORA_MAC_STATUS_OK, "Disconnect failed");
+    TEST_ASSERT_MESSAGE(ret == LORAWAN_STATUS_OK, "Disconnect failed");
 
     //Prevent upcoming events between tests
     lora_helper.event_lock = true;
@@ -177,14 +177,14 @@ void lora_connect_with_params_abp_ok()
 
 void lora_disconnected()
 {
-    lora_mac_status_t ret;
+    lorawan_status_t ret;
     uint8_t counter = 0;
 
     //Allow upcoming events
     lora_helper.event_lock = false;
 
     ret = lorawan.connect();
-    TEST_ASSERT_MESSAGE(ret == LORA_MAC_STATUS_OK || ret == LORA_MAC_STATUS_CONNECT_IN_PROGRESS, "Connect failed");
+    TEST_ASSERT_MESSAGE(ret == LORAWAN_STATUS_OK || ret == LORAWAN_STATUS_CONNECT_IN_PROGRESS, "Connect failed");
 
     // Wait for CONNECTED event
     while (1) {
@@ -205,7 +205,7 @@ void lora_disconnected()
     wait_ms(2000);
 
     ret = lorawan.disconnect();
-    TEST_ASSERT_MESSAGE(ret == LORA_MAC_STATUS_OK, "Disconnect failed");
+    TEST_ASSERT_MESSAGE(ret == LORAWAN_STATUS_OK, "Disconnect failed");
 
     // Wait for DISCONNECTED event
     while (1) {
@@ -239,7 +239,7 @@ void lora_tx_send_incorrect_type()
     lora_helper.event_lock = false;
 
     ret = lorawan.connect();
-    TEST_ASSERT_MESSAGE(ret == LORA_MAC_STATUS_OK || ret == LORA_MAC_STATUS_CONNECT_IN_PROGRESS, "Connect failed");
+    TEST_ASSERT_MESSAGE(ret == LORAWAN_STATUS_OK || ret == LORAWAN_STATUS_CONNECT_IN_PROGRESS, "Connect failed");
 
     // Wait for CONNECTED event
     while (1) {
@@ -258,10 +258,10 @@ void lora_tx_send_incorrect_type()
 
     //ret = lorawan.send(session, message);
     ret = lorawan.send(MBED_CONF_LORA_APP_PORT, tx_data, sizeof(tx_data), type_incorrect);
-    TEST_ASSERT_MESSAGE(ret == LORA_MAC_STATUS_PARAMETER_INVALID, "Incorrect return value, expected LORA_MAC_STATUS_PARAMETER_INVALID");
+    TEST_ASSERT_MESSAGE(ret == LORAWAN_STATUS_PARAMETER_INVALID, "Incorrect return value, expected LORAWAN_STATUS_PARAMETER_INVALID");
 
     ret = lorawan.disconnect();
-    TEST_ASSERT_MESSAGE(ret == LORA_MAC_STATUS_OK, "Disconnect failed");
+    TEST_ASSERT_MESSAGE(ret == LORAWAN_STATUS_OK, "Disconnect failed");
 
     //Prevent upcoming events between tests
     lora_helper.event_lock = true;
@@ -279,7 +279,7 @@ void lora_tx_send_fill_buffer()
     lora_helper.event_lock = false;
 
     ret = lorawan.connect();
-    TEST_ASSERT_MESSAGE(ret == LORA_MAC_STATUS_OK || ret == LORA_MAC_STATUS_CONNECT_IN_PROGRESS, "Connect failed");
+    TEST_ASSERT_MESSAGE(ret == LORAWAN_STATUS_OK || ret == LORAWAN_STATUS_CONNECT_IN_PROGRESS, "Connect failed");
 
     // Wait for CONNECTED event
     while (1) {
@@ -300,10 +300,10 @@ void lora_tx_send_fill_buffer()
     TEST_ASSERT_MESSAGE(ret == sizeof(tx_data), "Incorrect return value");
 
     ret = lorawan.send(MBED_CONF_LORA_APP_PORT, tx_data, sizeof(tx_data), MSG_UNCONFIRMED_FLAG);
-    TEST_ASSERT_MESSAGE(LORA_MAC_STATUS_WOULD_BLOCK, "Incorrect return value, expected LORA_MAC_STATUS_OK");
+    TEST_ASSERT_MESSAGE(LORAWAN_STATUS_WOULD_BLOCK, "Incorrect return value, expected LORAWAN_STATUS_OK");
 
     ret = lorawan.disconnect();
-    TEST_ASSERT_MESSAGE(ret == LORA_MAC_STATUS_OK, "Disconnect failed");
+    TEST_ASSERT_MESSAGE(ret == LORAWAN_STATUS_OK, "Disconnect failed");
 
     //Prevent upcoming events between tests
     lora_helper.event_lock = true;
@@ -320,7 +320,7 @@ void lora_tx_send_without_connect()
     lora_helper.event_lock = false;
 
     ret = lorawan.send(MBED_CONF_LORA_APP_PORT, tx_data, sizeof(tx_data), MSG_UNCONFIRMED_FLAG);
-    TEST_ASSERT_MESSAGE(ret == LORA_MAC_STATUS_NO_ACTIVE_SESSIONS, "Incorrect return value");
+    TEST_ASSERT_MESSAGE(ret == LORAWAN_STATUS_NO_ACTIVE_SESSIONS, "Incorrect return value");
 
     //Prevent upcoming events between tests
     lora_helper.event_lock = true;
@@ -338,13 +338,13 @@ void lora_get_channel_plan_test()
     //Allow upcoming events
     lora_helper.event_lock = false;
 
-    lora_channels_t channels[16];
-    lora_channelplan_t plan;
+    loramac_channel_t channels[16];
+    lorawan_channelplan_t plan;
     plan.channels = channels;
     int16_t ret;
     uint8_t counter = 0;
 
-    lora_channels_t expected[16] = {
+    loramac_channel_t expected[16] = {
          { 0, 868100000, 0, { ( ( DR_5 << 4 ) | DR_0 ) }, 1 },
          { 1, 868300000, 0, { ( ( DR_5 << 4 ) | DR_0 ) }, 1 },
          { 2, 868500000, 0, { ( ( DR_5 << 4 ) | DR_0 ) }, 1 },
@@ -352,7 +352,7 @@ void lora_get_channel_plan_test()
 
     // get_channel_plan requires join to be done before calling it
     ret = lorawan.connect();
-    TEST_ASSERT_MESSAGE(ret == LORA_MAC_STATUS_OK || ret == LORA_MAC_STATUS_CONNECT_IN_PROGRESS, "Connect failed");
+    TEST_ASSERT_MESSAGE(ret == LORAWAN_STATUS_OK || ret == LORAWAN_STATUS_CONNECT_IN_PROGRESS, "Connect failed");
 
     // Wait for CONNECTED event
     while (1) {
@@ -377,7 +377,7 @@ void lora_get_channel_plan_test()
     }
 
     // Get plan from stack
-    if (lorawan.get_channel_plan(plan) != LORA_MAC_STATUS_OK) {
+    if (lorawan.get_channel_plan(plan) != LORAWAN_STATUS_OK) {
         TEST_ASSERT_MESSAGE(false, "get_channel_plan failed");
         return;
     }
@@ -390,17 +390,17 @@ void lora_get_channel_plan_test()
         TEST_ASSERT_MESSAGE(plan.channels[i].ch_param.frequency == expected[i].ch_param.frequency, "Frequency mismatch");
         TEST_ASSERT_MESSAGE(plan.channels[i].ch_param.rx1_frequency == expected[i].ch_param.rx1_frequency, "Rx1 frequency mismatch");
 
-        TEST_ASSERT_MESSAGE(plan.channels[i].ch_param.dr_range.lora_mac_fields_s.min == 
-                expected[i].ch_param.dr_range.lora_mac_fields_s.min, "Dr range min mismatch");
+        TEST_ASSERT_MESSAGE(plan.channels[i].ch_param.dr_range.fields.min ==
+                expected[i].ch_param.dr_range.fields.min, "Dr range min mismatch");
 
-        TEST_ASSERT_MESSAGE(plan.channels[i].ch_param.dr_range.lora_mac_fields_s.max == 
-                expected[i].ch_param.dr_range.lora_mac_fields_s.max, "Dr range max mismath");
+        TEST_ASSERT_MESSAGE(plan.channels[i].ch_param.dr_range.fields.max ==
+                expected[i].ch_param.dr_range.fields.max, "Dr range max mismath");
 
         TEST_ASSERT_MESSAGE(plan.channels[i].ch_param.band == expected[i].ch_param.band, "Band mismatch");
     }
 
     ret = lorawan.disconnect();
-    TEST_ASSERT_MESSAGE(ret == LORA_MAC_STATUS_OK, "Disconnect failed");
+    TEST_ASSERT_MESSAGE(ret == LORAWAN_STATUS_OK, "Disconnect failed");
 
     //Prevent upcoming events between tests
     lora_helper.event_lock = true;
@@ -419,14 +419,14 @@ void lora_remove_channel_test()
     //Allow upcoming events
     lora_helper.event_lock = false;
 
-    lora_channels_t channels[16];
-    lora_channelplan_t plan;
+    loramac_channel_t channels[16];
+    lorawan_channelplan_t plan;
     plan.channels = channels;
     plan.nb_channels = 3;
     int16_t ret;
     uint8_t counter = 0;
 
-    lora_channels_t expected[16] = {
+    loramac_channel_t expected[16] = {
         { 0, 868100000, 0, { ( ( DR_5 << 4 ) | DR_0 ) }, 1 },
         { 1, 868300000, 0, { ( ( DR_5 << 4 ) | DR_0 ) }, 1 },
         { 2, 868500000, 0, { ( ( DR_5 << 4 ) | DR_0 ) }, 1 },
@@ -454,7 +454,7 @@ void lora_remove_channel_test()
 
     // get_channel_plan requires join to be done before calling it
     ret = lorawan.connect();
-    TEST_ASSERT_MESSAGE(ret == LORA_MAC_STATUS_OK || ret == LORA_MAC_STATUS_CONNECT_IN_PROGRESS, "Connect failed");
+    TEST_ASSERT_MESSAGE(ret == LORAWAN_STATUS_OK || ret == LORAWAN_STATUS_CONNECT_IN_PROGRESS, "Connect failed");
 
     // Wait for CONNECTED event
     while (1) {
@@ -479,7 +479,7 @@ void lora_remove_channel_test()
     }
 
     // Set plan to stack
-    if (lorawan.set_channel_plan(plan) != LORA_MAC_STATUS_OK) {
+    if (lorawan.set_channel_plan(plan) != LORAWAN_STATUS_OK) {
         TEST_ASSERT_MESSAGE(false, "set_channel_plan failed");
         return;
     }
@@ -493,7 +493,7 @@ void lora_remove_channel_test()
         return;
     }
 
-    if (lorawan.get_channel_plan(plan) != LORA_MAC_STATUS_OK) {
+    if (lorawan.get_channel_plan(plan) != LORAWAN_STATUS_OK) {
         TEST_ASSERT_MESSAGE(false, "get_channel_plan failed");
         return;
     }
@@ -506,17 +506,17 @@ void lora_remove_channel_test()
         TEST_ASSERT_MESSAGE(plan.channels[i].ch_param.frequency == expected[i].ch_param.frequency, "Frequency mismatch");
         TEST_ASSERT_MESSAGE(plan.channels[i].ch_param.rx1_frequency == expected[i].ch_param.rx1_frequency, "Rx1 frequency mismatch");
 
-        TEST_ASSERT_MESSAGE(plan.channels[i].ch_param.dr_range.lora_mac_fields_s.min == 
-                expected[i].ch_param.dr_range.lora_mac_fields_s.min, "Dr range min mismatch");
+        TEST_ASSERT_MESSAGE(plan.channels[i].ch_param.dr_range.fields.min ==
+                expected[i].ch_param.dr_range.fields.min, "Dr range min mismatch");
 
-        TEST_ASSERT_MESSAGE(plan.channels[i].ch_param.dr_range.lora_mac_fields_s.max == 
-                expected[i].ch_param.dr_range.lora_mac_fields_s.max, "Dr range max mismath");
+        TEST_ASSERT_MESSAGE(plan.channels[i].ch_param.dr_range.fields.max ==
+                expected[i].ch_param.dr_range.fields.max, "Dr range max mismath");
 
         TEST_ASSERT_MESSAGE(plan.channels[i].ch_param.band == expected[i].ch_param.band, "Band mismatch");
     }
 
     ret = lorawan.disconnect();
-    TEST_ASSERT_MESSAGE(ret == LORA_MAC_STATUS_OK, "Disconnect failed");
+    TEST_ASSERT_MESSAGE(ret == LORAWAN_STATUS_OK, "Disconnect failed");
 
     //Prevent upcoming events between tests
     lora_helper.event_lock = true;
@@ -533,14 +533,14 @@ void lora_remove_channel_plan()
     //Allow upcoming events
     lora_helper.event_lock = false;
 
-    lora_channels_t channels[16];
-    lora_channelplan_t plan;
+    loramac_channel_t channels[16];
+    lorawan_channelplan_t plan;
     plan.channels = channels;
     plan.nb_channels = 3;
     int16_t ret;
     uint8_t counter = 0;
 
-    lora_channels_t expected[16] = {
+    loramac_channel_t expected[16] = {
         { 0, 868100000, 0, { ( ( DR_5 << 4 ) | DR_0 ) }, 1 },
         { 1, 868300000, 0, { ( ( DR_5 << 4 ) | DR_0 ) }, 1 },
         { 2, 868500000, 0, { ( ( DR_5 << 4 ) | DR_0 ) }, 1 },
@@ -566,7 +566,7 @@ void lora_remove_channel_plan()
 
     // get_channel_plan requires join to be done before calling it
     ret = lorawan.connect();
-    TEST_ASSERT_MESSAGE(ret == LORA_MAC_STATUS_OK || ret == LORA_MAC_STATUS_CONNECT_IN_PROGRESS, "Connect failed");
+    TEST_ASSERT_MESSAGE(ret == LORAWAN_STATUS_OK || ret == LORAWAN_STATUS_CONNECT_IN_PROGRESS, "Connect failed");
 
     // Wait for CONNECTED event
     while (1) {
@@ -591,7 +591,7 @@ void lora_remove_channel_plan()
     }
 
     // Set plan to stack
-    if (lorawan.set_channel_plan(plan) != LORA_MAC_STATUS_OK) {
+    if (lorawan.set_channel_plan(plan) != LORAWAN_STATUS_OK) {
         TEST_ASSERT_MESSAGE(false, "set_channel_plan failed");
         return;
     }
@@ -605,7 +605,7 @@ void lora_remove_channel_plan()
     plan.nb_channels = 0;
     memset(&channels, 0, sizeof(channels));
 
-    if (lorawan.get_channel_plan(plan) != LORA_MAC_STATUS_OK) {
+    if (lorawan.get_channel_plan(plan) != LORAWAN_STATUS_OK) {
         TEST_ASSERT_MESSAGE(false, "get_channel_plan failed");
         return;
     }
@@ -618,17 +618,17 @@ void lora_remove_channel_plan()
         TEST_ASSERT_MESSAGE(plan.channels[i].ch_param.frequency == expected[i].ch_param.frequency, "Frequency mismatch");
         TEST_ASSERT_MESSAGE(plan.channels[i].ch_param.rx1_frequency == expected[i].ch_param.rx1_frequency, "Rx1 frequency mismatch");
 
-        TEST_ASSERT_MESSAGE(plan.channels[i].ch_param.dr_range.lora_mac_fields_s.min == 
-                expected[i].ch_param.dr_range.lora_mac_fields_s.min, "Dr range min mismatch");
+        TEST_ASSERT_MESSAGE(plan.channels[i].ch_param.dr_range.fields.min ==
+                expected[i].ch_param.dr_range.fields.min, "Dr range min mismatch");
 
-        TEST_ASSERT_MESSAGE(plan.channels[i].ch_param.dr_range.lora_mac_fields_s.max == 
-                expected[i].ch_param.dr_range.lora_mac_fields_s.max, "Dr range max mismath");
+        TEST_ASSERT_MESSAGE(plan.channels[i].ch_param.dr_range.fields.max ==
+                expected[i].ch_param.dr_range.fields.max, "Dr range max mismath");
 
         TEST_ASSERT_MESSAGE(plan.channels[i].ch_param.band == expected[i].ch_param.band, "Band mismatch");
     }
 
     ret = lorawan.disconnect();
-    TEST_ASSERT_MESSAGE(ret == LORA_MAC_STATUS_OK, "Disconnect failed");
+    TEST_ASSERT_MESSAGE(ret == LORAWAN_STATUS_OK, "Disconnect failed");
 
     //Prevent upcoming events between tests
     lora_helper.event_lock = true;
@@ -647,14 +647,14 @@ void lora_set_all_channel_plan_test()
     //Allow upcoming events
     lora_helper.event_lock = false;
 
-    lora_channels_t channels[16];
-    lora_channelplan_t plan;
+    loramac_channel_t channels[16];
+    lorawan_channelplan_t plan;
     plan.channels = channels;
     plan.nb_channels = 13;
     int16_t ret;
     uint8_t counter = 0;
 
-    lora_channels_t expected[16] = {
+    loramac_channel_t expected[16] = {
         { 0, 868100000, 0, { ( ( DR_5 << 4 ) | DR_0 ) }, 1 },      //EU868_LC1,
         { 1, 868300000, 0, { ( ( DR_5 << 4 ) | DR_0 ) }, 1 },      //EU868_LC2
         { 2, 868500000, 0, { ( ( DR_5 << 4 ) | DR_0 ) }, 1 },      //EU868_LC3
@@ -677,96 +677,96 @@ void lora_set_all_channel_plan_test()
     plan.channels[0].ch_param.frequency = 867100000;
     plan.channels[0].ch_param.rx1_frequency = 0;
     plan.channels[0].ch_param.band = 0;
-    plan.channels[0].ch_param.dr_range.lora_mac_fields_s.max = DR_5;
-    plan.channels[0].ch_param.dr_range.lora_mac_fields_s.min = DR_0;
+    plan.channels[0].ch_param.dr_range.fields.max = DR_5;
+    plan.channels[0].ch_param.dr_range.fields.min = DR_0;
 
     plan.channels[1].id = 4;
     plan.channels[1].ch_param.frequency = 867300000;
     plan.channels[1].ch_param.rx1_frequency = 0;
     plan.channels[1].ch_param.band = 0;
-    plan.channels[1].ch_param.dr_range.lora_mac_fields_s.max = DR_5;
-    plan.channels[1].ch_param.dr_range.lora_mac_fields_s.min = DR_0;
+    plan.channels[1].ch_param.dr_range.fields.max = DR_5;
+    plan.channels[1].ch_param.dr_range.fields.min = DR_0;
 
     plan.channels[2].id = 5;
     plan.channels[2].ch_param.frequency = 867500000;
     plan.channels[2].ch_param.rx1_frequency = 0;
     plan.channels[2].ch_param.band = 0;
-    plan.channels[2].ch_param.dr_range.lora_mac_fields_s.max = DR_5;
-    plan.channels[2].ch_param.dr_range.lora_mac_fields_s.min = DR_0;
+    plan.channels[2].ch_param.dr_range.fields.max = DR_5;
+    plan.channels[2].ch_param.dr_range.fields.min = DR_0;
 
     plan.channels[3].id = 6;
     plan.channels[3].ch_param.frequency = 867700000;
     plan.channels[3].ch_param.rx1_frequency = 0;
     plan.channels[3].ch_param.band = 0;
-    plan.channels[3].ch_param.dr_range.lora_mac_fields_s.max = DR_5;
-    plan.channels[3].ch_param.dr_range.lora_mac_fields_s.min = DR_0;
+    plan.channels[3].ch_param.dr_range.fields.max = DR_5;
+    plan.channels[3].ch_param.dr_range.fields.min = DR_0;
 
     plan.channels[4].id = 7;
     plan.channels[4].ch_param.frequency = 867900000;
     plan.channels[4].ch_param.rx1_frequency = 0;
     plan.channels[4].ch_param.band = 0;
-    plan.channels[4].ch_param.dr_range.lora_mac_fields_s.max = DR_5;
-    plan.channels[4].ch_param.dr_range.lora_mac_fields_s.min = DR_0;
+    plan.channels[4].ch_param.dr_range.fields.max = DR_5;
+    plan.channels[4].ch_param.dr_range.fields.min = DR_0;
 
     plan.channels[5].id = 8;
     plan.channels[5].ch_param.frequency = 868800000;
     plan.channels[5].ch_param.rx1_frequency = 0;
     plan.channels[5].ch_param.band = 2;
-    plan.channels[5].ch_param.dr_range.lora_mac_fields_s.max = DR_7;
-    plan.channels[5].ch_param.dr_range.lora_mac_fields_s.min = DR_7;
+    plan.channels[5].ch_param.dr_range.fields.max = DR_7;
+    plan.channels[5].ch_param.dr_range.fields.min = DR_7;
 
     plan.channels[6].id = 9;
     plan.channels[6].ch_param.frequency = 868300000;
     plan.channels[6].ch_param.rx1_frequency = 0;
     plan.channels[6].ch_param.band = 1;
-    plan.channels[6].ch_param.dr_range.lora_mac_fields_s.max = DR_6;
-    plan.channels[6].ch_param.dr_range.lora_mac_fields_s.min = DR_6;
+    plan.channels[6].ch_param.dr_range.fields.max = DR_6;
+    plan.channels[6].ch_param.dr_range.fields.min = DR_6;
 
     plan.channels[7].id = 10;
     plan.channels[7].ch_param.frequency = 868200000;
     plan.channels[7].ch_param.rx1_frequency = 0;
     plan.channels[7].ch_param.band = 1;
-    plan.channels[7].ch_param.dr_range.lora_mac_fields_s.max = DR_5;
-    plan.channels[7].ch_param.dr_range.lora_mac_fields_s.min = DR_0;
+    plan.channels[7].ch_param.dr_range.fields.max = DR_5;
+    plan.channels[7].ch_param.dr_range.fields.min = DR_0;
 
     plan.channels[8].id = 11;
     plan.channels[8].ch_param.frequency = 869700000;
     plan.channels[8].ch_param.rx1_frequency = 0;
     plan.channels[8].ch_param.band = 4;
-    plan.channels[8].ch_param.dr_range.lora_mac_fields_s.max = DR_5;
-    plan.channels[8].ch_param.dr_range.lora_mac_fields_s.min = DR_0;
+    plan.channels[8].ch_param.dr_range.fields.max = DR_5;
+    plan.channels[8].ch_param.dr_range.fields.min = DR_0;
 
     plan.channels[9].id = 12;
     plan.channels[9].ch_param.frequency = 869400000;
     plan.channels[9].ch_param.rx1_frequency = 0;
     plan.channels[9].ch_param.band = 3;
-    plan.channels[9].ch_param.dr_range.lora_mac_fields_s.max = DR_5;
-    plan.channels[9].ch_param.dr_range.lora_mac_fields_s.min = DR_0;
+    plan.channels[9].ch_param.dr_range.fields.max = DR_5;
+    plan.channels[9].ch_param.dr_range.fields.min = DR_0;
 
     plan.channels[10].id = 13;
     plan.channels[10].ch_param.frequency = 868700000;
     plan.channels[10].ch_param.rx1_frequency = 0;
     plan.channels[10].ch_param.band = 2;
-    plan.channels[10].ch_param.dr_range.lora_mac_fields_s.max = DR_5;
-    plan.channels[10].ch_param.dr_range.lora_mac_fields_s.min = DR_0;
+    plan.channels[10].ch_param.dr_range.fields.max = DR_5;
+    plan.channels[10].ch_param.dr_range.fields.min = DR_0;
 
     plan.channels[11].id = 14;
     plan.channels[11].ch_param.frequency = 869200000;
     plan.channels[11].ch_param.rx1_frequency = 0;
     plan.channels[11].ch_param.band = 2;
-    plan.channels[11].ch_param.dr_range.lora_mac_fields_s.max = DR_5;
-    plan.channels[11].ch_param.dr_range.lora_mac_fields_s.min = DR_0;
+    plan.channels[11].ch_param.dr_range.fields.max = DR_5;
+    plan.channels[11].ch_param.dr_range.fields.min = DR_0;
 
     plan.channels[12].id = 15;
     plan.channels[12].ch_param.frequency = 868600000;
     plan.channels[12].ch_param.rx1_frequency = 0;
     plan.channels[12].ch_param.band = 1;
-    plan.channels[12].ch_param.dr_range.lora_mac_fields_s.max = DR_5;
-    plan.channels[12].ch_param.dr_range.lora_mac_fields_s.min = DR_0;
+    plan.channels[12].ch_param.dr_range.fields.max = DR_5;
+    plan.channels[12].ch_param.dr_range.fields.min = DR_0;
 
     // get_channel_plan requires join to be done before calling it
     ret = lorawan.connect();
-    TEST_ASSERT_MESSAGE(ret == LORA_MAC_STATUS_OK || ret == LORA_MAC_STATUS_CONNECT_IN_PROGRESS, "Connect failed");
+    TEST_ASSERT_MESSAGE(ret == LORAWAN_STATUS_OK || ret == LORAWAN_STATUS_CONNECT_IN_PROGRESS, "Connect failed");
 
     // Wait for CONNECTED event
     while (1) {
@@ -791,7 +791,7 @@ void lora_set_all_channel_plan_test()
     }
 
     // Set plan to stack
-    if (lorawan.set_channel_plan(plan) != LORA_MAC_STATUS_OK) {
+    if (lorawan.set_channel_plan(plan) != LORAWAN_STATUS_OK) {
         TEST_ASSERT_MESSAGE(false, "set_channel_plan failed");
         return;
     }
@@ -800,7 +800,7 @@ void lora_set_all_channel_plan_test()
     plan.nb_channels = 0;
     memset(&channels, 0, sizeof(channels));
 
-    if (lorawan.get_channel_plan(plan) != LORA_MAC_STATUS_OK) {
+    if (lorawan.get_channel_plan(plan) != LORAWAN_STATUS_OK) {
         TEST_ASSERT_MESSAGE(false, "get_channel_plan failed");
         return;
     }
@@ -813,17 +813,17 @@ void lora_set_all_channel_plan_test()
         TEST_ASSERT_MESSAGE(plan.channels[i].ch_param.frequency == expected[i].ch_param.frequency, "Frequency mismatch");
         TEST_ASSERT_MESSAGE(plan.channels[i].ch_param.rx1_frequency == expected[i].ch_param.rx1_frequency, "Rx1 frequency mismatch");
 
-        TEST_ASSERT_MESSAGE(plan.channels[i].ch_param.dr_range.lora_mac_fields_s.min == 
-                expected[i].ch_param.dr_range.lora_mac_fields_s.min, "Dr range min mismatch");
+        TEST_ASSERT_MESSAGE(plan.channels[i].ch_param.dr_range.fields.min ==
+                expected[i].ch_param.dr_range.fields.min, "Dr range min mismatch");
 
-        TEST_ASSERT_MESSAGE(plan.channels[i].ch_param.dr_range.lora_mac_fields_s.max == 
-                expected[i].ch_param.dr_range.lora_mac_fields_s.max, "Dr range max mismath");
+        TEST_ASSERT_MESSAGE(plan.channels[i].ch_param.dr_range.fields.max ==
+                expected[i].ch_param.dr_range.fields.max, "Dr range max mismath");
 
         TEST_ASSERT_MESSAGE(plan.channels[i].ch_param.band == expected[i].ch_param.band, "Band mismatch");
     }
 
     ret = lorawan.disconnect();
-    TEST_ASSERT_MESSAGE(ret == LORA_MAC_STATUS_OK, "Disconnect failed");
+    TEST_ASSERT_MESSAGE(ret == LORAWAN_STATUS_OK, "Disconnect failed");
 
     //Prevent upcoming events between tests
     lora_helper.event_lock = true;
@@ -842,14 +842,14 @@ void lora_set_6_channel_plan_test()
     //Allow upcoming events
     lora_helper.event_lock = false;
 
-    lora_channels_t channels[16];
-    lora_channelplan_t plan;
+    loramac_channel_t channels[16];
+    lorawan_channelplan_t plan;
     plan.channels = channels;
     plan.nb_channels = 3;
     int16_t ret;
     uint8_t counter = 0;
 
-    lora_channels_t expected[16] = {
+    loramac_channel_t expected[16] = {
         { 0, 868100000, 0, { ( ( DR_5 << 4 ) | DR_0 ) }, 1 },
         { 1, 868300000, 0, { ( ( DR_5 << 4 ) | DR_0 ) }, 1 },
         { 2, 868500000, 0, { ( ( DR_5 << 4 ) | DR_0 ) }, 1 },
@@ -878,7 +878,7 @@ void lora_set_6_channel_plan_test()
 
     // get_channel_plan requires join to be done before calling it
     ret = lorawan.connect();
-    TEST_ASSERT_MESSAGE(ret == LORA_MAC_STATUS_OK || ret == LORA_MAC_STATUS_CONNECT_IN_PROGRESS, "Connect failed");
+    TEST_ASSERT_MESSAGE(ret == LORAWAN_STATUS_OK || ret == LORAWAN_STATUS_CONNECT_IN_PROGRESS, "Connect failed");
 
     // Wait for CONNECTED event
     while (1) {
@@ -903,7 +903,7 @@ void lora_set_6_channel_plan_test()
     }
 
     // Set plan to stack
-    if (lorawan.set_channel_plan(plan) != LORA_MAC_STATUS_OK) {
+    if (lorawan.set_channel_plan(plan) != LORAWAN_STATUS_OK) {
         TEST_ASSERT_MESSAGE(false, "set_channel_plan failed");
         return;
     }
@@ -912,7 +912,7 @@ void lora_set_6_channel_plan_test()
     plan.nb_channels = 0;
     memset(&channels, 0, sizeof(channels));
 
-    if (lorawan.get_channel_plan(plan) != LORA_MAC_STATUS_OK) {
+    if (lorawan.get_channel_plan(plan) != LORAWAN_STATUS_OK) {
         TEST_ASSERT_MESSAGE(false, "get_channel_plan failed");
         return;
     }
@@ -925,17 +925,17 @@ void lora_set_6_channel_plan_test()
         TEST_ASSERT_MESSAGE(plan.channels[i].ch_param.frequency == expected[i].ch_param.frequency, "Frequency mismatch");
         TEST_ASSERT_MESSAGE(plan.channels[i].ch_param.rx1_frequency == expected[i].ch_param.rx1_frequency, "Rx1 frequency mismatch");
 
-        TEST_ASSERT_MESSAGE(plan.channels[i].ch_param.dr_range.lora_mac_fields_s.min == 
-                expected[i].ch_param.dr_range.lora_mac_fields_s.min, "Dr range min mismatch");
+        TEST_ASSERT_MESSAGE(plan.channels[i].ch_param.dr_range.fields.min ==
+                expected[i].ch_param.dr_range.fields.min, "Dr range min mismatch");
 
-        TEST_ASSERT_MESSAGE(plan.channels[i].ch_param.dr_range.lora_mac_fields_s.max == 
-                expected[i].ch_param.dr_range.lora_mac_fields_s.max, "Dr range max mismath");
+        TEST_ASSERT_MESSAGE(plan.channels[i].ch_param.dr_range.fields.max ==
+                expected[i].ch_param.dr_range.fields.max, "Dr range max mismath");
 
         TEST_ASSERT_MESSAGE(plan.channels[i].ch_param.band == expected[i].ch_param.band, "Band mismatch");
     }
 
     ret = lorawan.disconnect();
-    TEST_ASSERT_MESSAGE(ret == LORA_MAC_STATUS_OK, "Disconnect failed");
+    TEST_ASSERT_MESSAGE(ret == LORAWAN_STATUS_OK, "Disconnect failed");
 
     //Prevent upcoming events between tests
     lora_helper.event_lock = true;
@@ -954,8 +954,8 @@ void lora_channel_plan_extended()
     //Allow upcoming events
     lora_helper.event_lock = false;
 
-    lora_channels_t channels[16];
-    lora_channelplan_t plan;
+    loramac_channel_t channels[16];
+    lorawan_channelplan_t plan;
     plan.channels = channels;
     plan.nb_channels = 3;
     int16_t ret;
@@ -963,7 +963,7 @@ void lora_channel_plan_extended()
     uint8_t rx_data[64] = { 0 };
     uint8_t tx_data[] = "test_confirmed_message";
 
-    lora_channels_t expected[16] = {
+    loramac_channel_t expected[16] = {
         { 0, 868100000, 0, { ( ( DR_5 << 4 ) | DR_0 ) }, 1 },
         { 1, 868300000, 0, { ( ( DR_5 << 4 ) | DR_0 ) }, 1 },
         { 2, 868500000, 0, { ( ( DR_5 << 4 ) | DR_0 ) }, 1 },
@@ -974,7 +974,7 @@ void lora_channel_plan_extended()
 
     // get_channel_plan requires join to be done before calling it
     ret = lorawan.connect();
-    TEST_ASSERT_MESSAGE(ret == LORA_MAC_STATUS_OK || ret == LORA_MAC_STATUS_CONNECT_IN_PROGRESS, "Connect failed");
+    TEST_ASSERT_MESSAGE(ret == LORAWAN_STATUS_OK || ret == LORAWAN_STATUS_CONNECT_IN_PROGRESS, "Connect failed");
 
     // Wait for CONNECTED event
     while (1) {
@@ -1021,7 +1021,7 @@ void lora_channel_plan_extended()
     plan.channels[2].ch_param.rx1_frequency = 0;
 
     // Set plan to stack
-    if (lorawan.set_channel_plan(plan) != LORA_MAC_STATUS_OK) {
+    if (lorawan.set_channel_plan(plan) != LORAWAN_STATUS_OK) {
         TEST_ASSERT_MESSAGE(false, "set_channel_plan failed");
         return;
     }
@@ -1115,7 +1115,7 @@ void lora_channel_plan_extended()
         return;
     }
 
-    if (lorawan.get_channel_plan(plan) != LORA_MAC_STATUS_OK) {
+    if (lorawan.get_channel_plan(plan) != LORAWAN_STATUS_OK) {
         TEST_ASSERT_MESSAGE(false, "get_channel_plan failed");
         return;
     }
@@ -1128,17 +1128,17 @@ void lora_channel_plan_extended()
         TEST_ASSERT_MESSAGE(plan.channels[i].ch_param.frequency == expected[i].ch_param.frequency, "Frequency mismatch");
         TEST_ASSERT_MESSAGE(plan.channels[i].ch_param.rx1_frequency == expected[i].ch_param.rx1_frequency, "Rx1 frequency mismatch");
 
-        TEST_ASSERT_MESSAGE(plan.channels[i].ch_param.dr_range.lora_mac_fields_s.min == 
-                expected[i].ch_param.dr_range.lora_mac_fields_s.min, "Dr range min mismatch");
+        TEST_ASSERT_MESSAGE(plan.channels[i].ch_param.dr_range.fields.min ==
+                expected[i].ch_param.dr_range.fields.min, "Dr range min mismatch");
 
-        TEST_ASSERT_MESSAGE(plan.channels[i].ch_param.dr_range.lora_mac_fields_s.max == 
-                expected[i].ch_param.dr_range.lora_mac_fields_s.max, "Dr range max mismath");
+        TEST_ASSERT_MESSAGE(plan.channels[i].ch_param.dr_range.fields.max ==
+                expected[i].ch_param.dr_range.fields.max, "Dr range max mismath");
 
         TEST_ASSERT_MESSAGE(plan.channels[i].ch_param.band == expected[i].ch_param.band, "Band mismatch");
     }
 
     ret = lorawan.disconnect();
-    TEST_ASSERT_MESSAGE(ret == LORA_MAC_STATUS_OK, "Disconnect failed");
+    TEST_ASSERT_MESSAGE(ret == LORAWAN_STATUS_OK, "Disconnect failed");
 
     //Prevent upcoming events between tests
     lora_helper.event_lock = true;
@@ -1177,7 +1177,7 @@ utest::v1::status_t greentea_test_setup(const size_t number_of_cases) {
 // Do not print in this function.
 // As we are using a thread to dispatch events, this is being called
 // from dispatch thread context
-static void lora_event_handler(lora_events_t events)
+static void lora_event_handler(lorawan_events_t events)
 {
     if (lora_helper.event_lock) {
         return;
@@ -1192,14 +1192,14 @@ int main() {
     // start thread to handle events
     t.start(callback(&ev_queue, &EventQueue::dispatch_forever));
 
-    lora_mac_status_t ret;
+    lorawan_status_t ret;
 
     callbacks.events = mbed::callback(lora_event_handler);
 
     lorawan.add_app_callbacks(&callbacks);
 
     ret = lorawan.initialize(&ev_queue);
-    TEST_ASSERT_MESSAGE(ret == LORA_MAC_STATUS_OK, "Lora layer initialization failed");
+    TEST_ASSERT_MESSAGE(ret == LORAWAN_STATUS_OK, "Lora layer initialization failed");
 
     Specification specification(greentea_test_setup, cases, greentea_test_teardown_handler);
     Harness::run(specification);

--- a/TESTS/lorawan/receive_message_fill_buffer/main.cpp
+++ b/TESTS/lorawan/receive_message_fill_buffer/main.cpp
@@ -85,7 +85,7 @@ static Thread t(osPriorityNormal, TEST_DISPATCH_THREAD_SIZE);
                            NC, LORA_ANT_BOOST, LORA_TCXO);
 #endif
 
-void lora_event_handler(lora_events_t events);
+void lora_event_handler(lorawan_events_t events);
 
 class LoRaTestHelper
 {
@@ -131,7 +131,7 @@ void lora_receive_fill_buffer()
     // Connect to conduit
     ret = lorawan.connect();
 
-    if (ret != LORA_MAC_STATUS_OK && ret != LORA_MAC_STATUS_CONNECT_IN_PROGRESS) {
+    if (ret != LORAWAN_STATUS_OK && ret != LORAWAN_STATUS_CONNECT_IN_PROGRESS) {
         TEST_ASSERT_MESSAGE(false, "Connect failed");
         return;
     }
@@ -245,7 +245,7 @@ int main() {
     Harness::run(specification);
 }
 
-void lora_event_handler(lora_events_t events)
+void lora_event_handler(lorawan_events_t events)
 {
     if (lora_helper.event_lock) {
         return;

--- a/features/lorawan/LoRaWANInterface.cpp
+++ b/features/lorawan/LoRaWANInterface.cpp
@@ -42,16 +42,16 @@ LoRaWANInterface::~LoRaWANInterface()
 {
 }
 
-lora_mac_status_t LoRaWANInterface::initialize(EventQueue *queue)
+lorawan_status_t LoRaWANInterface::initialize(EventQueue *queue)
 {
     if(!queue) {
-        return LORA_MAC_STATUS_PARAMETER_INVALID;
+        return LORAWAN_STATUS_PARAMETER_INVALID;
     }
 
     return stk_obj().initialize_mac_layer(queue);
 }
 
-lora_mac_status_t LoRaWANInterface::connect()
+lorawan_status_t LoRaWANInterface::connect()
 {
     // connection attempt without parameters.
     // System tries to look for configuration in mbed_lib.json that can be
@@ -96,28 +96,28 @@ lora_mac_status_t LoRaWANInterface::connect()
     }
 }
 
-lora_mac_status_t LoRaWANInterface::connect(const lorawan_connect_t &connect)
+lorawan_status_t LoRaWANInterface::connect(const lorawan_connect_t &connect)
 {
-    lora_mac_status_t mac_status;
+    lorawan_status_t mac_status;
 
     if (connect.connect_type == LORAWAN_CONNECTION_OTAA) {
         mac_status = stk_obj().join_request_by_otaa(connect);
     } else if (connect.connect_type == LORAWAN_CONNECTION_ABP) {
         mac_status = stk_obj().activation_by_personalization(connect);
     } else {
-        return LORA_MAC_STATUS_PARAMETER_INVALID;
+        return LORAWAN_STATUS_PARAMETER_INVALID;
     }
 
     return mac_status;
 }
 
-lora_mac_status_t LoRaWANInterface::disconnect()
+lorawan_status_t LoRaWANInterface::disconnect()
 {
     stk_obj().shutdown();
-    return LORA_MAC_STATUS_OK;
+    return LORAWAN_STATUS_OK;
 }
 
-lora_mac_status_t LoRaWANInterface::add_link_check_request()
+lorawan_status_t LoRaWANInterface::add_link_check_request()
 {
     _link_check_requested = true;
     return stk_obj().set_link_check_request();
@@ -128,42 +128,42 @@ void LoRaWANInterface::remove_link_check_request()
     _link_check_requested = false;
 }
 
-lora_mac_status_t LoRaWANInterface::set_datarate(uint8_t data_rate)
+lorawan_status_t LoRaWANInterface::set_datarate(uint8_t data_rate)
 {
     return stk_obj().set_channel_data_rate(data_rate);
 }
 
-lora_mac_status_t LoRaWANInterface::set_confirmed_msg_retries(uint8_t count)
+lorawan_status_t LoRaWANInterface::set_confirmed_msg_retries(uint8_t count)
 {
     return stk_obj().set_confirmed_msg_retry(count);
 }
 
-lora_mac_status_t LoRaWANInterface::enable_adaptive_datarate()
+lorawan_status_t LoRaWANInterface::enable_adaptive_datarate()
 {
     return stk_obj().enable_adaptive_datarate(true);
 }
 
-lora_mac_status_t LoRaWANInterface::disable_adaptive_datarate()
+lorawan_status_t LoRaWANInterface::disable_adaptive_datarate()
 {
     return stk_obj().enable_adaptive_datarate(false);
 }
 
-lora_mac_status_t LoRaWANInterface::set_channel_plan(const lora_channelplan_t &channel_plan)
+lorawan_status_t LoRaWANInterface::set_channel_plan(const lorawan_channelplan_t &channel_plan)
 {
     return stk_obj().add_channels(channel_plan);
 }
 
-lora_mac_status_t LoRaWANInterface::get_channel_plan(lora_channelplan_t &channel_plan)
+lorawan_status_t LoRaWANInterface::get_channel_plan(lorawan_channelplan_t &channel_plan)
 {
     return stk_obj().get_enabled_channels(channel_plan);
 }
 
-lora_mac_status_t LoRaWANInterface::remove_channel(uint8_t id)
+lorawan_status_t LoRaWANInterface::remove_channel(uint8_t id)
 {
     return stk_obj().remove_a_channel(id);
 }
 
-lora_mac_status_t LoRaWANInterface::remove_channel_plan()
+lorawan_status_t LoRaWANInterface::remove_channel_plan()
 {
     return stk_obj().drop_channel_list();
 }
@@ -180,7 +180,7 @@ int16_t LoRaWANInterface::send(uint8_t port, const uint8_t* data,
     if (data) {
         return stk_obj().handle_tx(port, data, length, flags);
     } else {
-        return LORA_MAC_STATUS_PARAMETER_INVALID;
+        return LORAWAN_STATUS_PARAMETER_INVALID;
     }
 }
 
@@ -190,17 +190,17 @@ int16_t LoRaWANInterface::receive(uint8_t port, uint8_t* data, uint16_t length,
     if (data && length > 0) {
         return stk_obj().handle_rx(port, data, length, flags);
     } else {
-        return LORA_MAC_STATUS_PARAMETER_INVALID;
+        return LORAWAN_STATUS_PARAMETER_INVALID;
     }
 }
 
-lora_mac_status_t LoRaWANInterface::add_app_callbacks(lorawan_app_callbacks_t *callbacks)
+lorawan_status_t LoRaWANInterface::add_app_callbacks(lorawan_app_callbacks_t *callbacks)
   {
      if (!callbacks || !callbacks->events) {
          // Event Callback is mandatory
-         return LORA_MAC_STATUS_PARAMETER_INVALID;
+         return LORAWAN_STATUS_PARAMETER_INVALID;
      }
 
      stk_obj().set_lora_callbacks(callbacks);
-     return LORA_MAC_STATUS_OK;
+     return LORAWAN_STATUS_OK;
   }

--- a/features/lorawan/LoRaWANInterface.h
+++ b/features/lorawan/LoRaWANInterface.h
@@ -44,7 +44,7 @@ public:
      *
      * @return         0 on success, a negative error code on failure.
      */
-    virtual lora_mac_status_t initialize(events::EventQueue *ev_queue) ;
+    virtual lorawan_status_t initialize(events::EventQueue *ev_queue) ;
 
     /** Connect OTAA or ABP using Mbed-OS config system
      *
@@ -52,7 +52,7 @@ public:
      * You need to configure the connection properly via the Mbed OS configuration
      * system.
      *
-     * When connecting via OTAA, the return code for success (LORA_MAC_STATUS_CONNECT_IN_PROGRESS) is negative.
+     * When connecting via OTAA, the return code for success (LORAWAN_STATUS_CONNECT_IN_PROGRESS) is negative.
      * However, this is not a real error. It tells you that the connection is in progress and you will
      * be notified of the completion via an event. By default, after the Join Accept message
      * is received, base stations may provide the node with a CF-List that replaces
@@ -78,17 +78,17 @@ public:
      * is important, at least for ABP. That's why we try to restore frame counters from
      * session information after a disconnection.
      *
-     * @return         LORA_MAC_STATUS_OK or LORA_MAC_STATUS_CONNECT_IN_PROGRESS
+     * @return         LORAWAN_STATUS_OK or LORAWAN_STATUS_CONNECT_IN_PROGRESS
      *                 on success, or a negative error code on failure.
      */
-    virtual lora_mac_status_t connect();
+    virtual lorawan_status_t connect();
 
     /** Connect OTAA or ABP with parameters
      *
      * All connection parameters are chosen by the user and provided in the
      * data structure passed down.
      *
-     * When connecting via OTAA, the return code for success (LORA_MAC_STATUS_CONNECT_IN_PROGRESS) is negative.
+     * When connecting via OTAA, the return code for success (LORAWAN_STATUS_CONNECT_IN_PROGRESS) is negative.
      * However, this is not a real error. It tells you that connection is in progress and you will
      * be notified of completion via an event. By default, after Join Accept message
      * is received, base stations may provide the node with a CF-List which replaces
@@ -118,17 +118,17 @@ public:
      *
      * @param connect  Options for an end device connection to the gateway.
      *
-     * @return        LORA_MAC_STATUS_OK or LORA_MAC_STATUS_CONNECT_IN_PROGRESS,
+     * @return        LORAWAN_STATUS_OK or LORAWAN_STATUS_CONNECT_IN_PROGRESS,
      *                a negative error code on failure.
      */
-    virtual lora_mac_status_t connect(const lorawan_connect_t &connect);
+    virtual lorawan_status_t connect(const lorawan_connect_t &connect);
 
     /** Disconnect the current session.
      *
-     * @return         LORA_MAC_STATUS_OK on success, a negative error code on
+     * @return         LORAWAN_STATUS_OK on success, a negative error code on
      *                 failure.
      */
-    virtual lora_mac_status_t disconnect();
+    virtual lorawan_status_t disconnect();
 
     /** Validate the connectivity with the network.
      *
@@ -145,7 +145,7 @@ public:
      *
      * This API is usable only when the 'link_check_resp' callback is set by
      * the application. See add_lora_app_callbacks API. If the above mentioned
-     * callback is not set, a LORA_MAC_STATUS_PARAMETER_INVALID error is thrown.
+     * callback is not set, a LORAWAN_STATUS_PARAMETER_INVALID error is thrown.
      *
      * First parameter to callback function is the demodulation margin and
      * the second parameter is the number of gateways that successfully received
@@ -155,11 +155,11 @@ public:
      * transmission, until/unless application explicitly turns it off using
      * remove_link_check_request() API.
      *
-     * @return          LORA_MAC_STATUS_OK on successfully queuing a request, or
+     * @return          LORAWAN_STATUS_OK on successfully queuing a request, or
      *                  a negative error code on failure.
      *
      */
-    virtual lora_mac_status_t add_link_check_request();
+    virtual lorawan_status_t add_link_check_request();
 
     /** Removes link check request sticky MAC command.
      *
@@ -176,28 +176,28 @@ public:
      * @param data_rate   The intended data rate, for example DR_0 or DR_1.
      *                    Please note, that the macro DR_* can mean different
      *                    things in different regions.
-     * @return            LORA_MAC_STATUS_OK if everything goes well, otherwise
+     * @return            LORAWAN_STATUS_OK if everything goes well, otherwise
      *                    a negative error code.
      */
-    virtual lora_mac_status_t set_datarate(uint8_t data_rate);
+    virtual lorawan_status_t set_datarate(uint8_t data_rate);
 
     /** Enables adaptive data rate (ADR).
      *
      * The underlying LoRaPHY and LoRaMac layers handle the data rate automatically
      * for the user, based upon the radio conditions (network congestion).
      *
-     * @return          LORA_MAC_STATUS_OK or negative error code otherwise.
+     * @return          LORAWAN_STATUS_OK or negative error code otherwise.
      */
-    virtual lora_mac_status_t enable_adaptive_datarate();
+    virtual lorawan_status_t enable_adaptive_datarate();
 
     /** Disables adaptive data rate.
      *
      * When adaptive data rate (ADR) is disabled, you can either set a certain
      * data rate or the MAC layer selects a default value.
      *
-     * @return          LORA_MAC_STATUS_OK or negative error code otherwise.
+     * @return          LORAWAN_STATUS_OK or negative error code otherwise.
      */
-    virtual lora_mac_status_t disable_adaptive_datarate();
+    virtual lorawan_status_t disable_adaptive_datarate();
 
     /** Sets up the retry counter for confirmed messages.
      *
@@ -212,9 +212,9 @@ public:
      *
      * @param count     The number of retries for confirmed messages.
      *
-     * @return          LORA_MAC_STATUS_OK or a negative error code.
+     * @return          LORAWAN_STATUS_OK or a negative error code.
      */
-    virtual lora_mac_status_t set_confirmed_msg_retries(uint8_t count);
+    virtual lorawan_status_t set_confirmed_msg_retries(uint8_t count);
 
     /** Sets the channel plan.
      *
@@ -240,10 +240,10 @@ public:
      *
      * @param channel_plan      The channel plan to set.
      *
-     * @return                  LORA_MAC_STATUS_OK on success, a negative error
+     * @return                  LORAWAN_STATUS_OK on success, a negative error
      *                          code on failure.
      */
-    virtual lora_mac_status_t set_channel_plan(const lora_channelplan_t &channel_plan);
+    virtual lorawan_status_t set_channel_plan(const lorawan_channelplan_t &channel_plan);
 
     /** Gets the channel plans from the LoRa stack.
      *
@@ -254,20 +254,20 @@ public:
      *
      * @param  channel_plan     The current channel plan information.
      *
-     * @return                  LORA_MAC_STATUS_OK on success, a negative error
+     * @return                  LORAWAN_STATUS_OK on success, a negative error
      *                          code on failure.
      */
-    virtual lora_mac_status_t get_channel_plan(lora_channelplan_t &channel_plan);
+    virtual lorawan_status_t get_channel_plan(lorawan_channelplan_t &channel_plan);
 
     /** Removes an active channel plan.
      *
      * You cannot remove default channels (the channels the base stations are listening to).
      * When a plan is abolished, only the non-default channels are removed.
      *
-     * @return                  LORA_MAC_STATUS_OK on success, a negative error
+     * @return                  LORAWAN_STATUS_OK on success, a negative error
      *                          code on failure.
      */
-    virtual lora_mac_status_t remove_channel_plan();
+    virtual lorawan_status_t remove_channel_plan();
 
     /** Removes a single channel.
      *
@@ -275,10 +275,10 @@ public:
      *
      * @param    index          The channel index.
      *
-     * @return                  LORA_MAC_STATUS_OK on success, a negative error
+     * @return                  LORAWAN_STATUS_OK on success, a negative error
      *                          code on failure.
      */
-    virtual lora_mac_status_t remove_channel(uint8_t index);
+    virtual lorawan_status_t remove_channel(uint8_t index);
 
     /** Send message to gateway
      *
@@ -311,7 +311,7 @@ public:
      *
      *
      * @return                  The number of bytes sent, or
-     *                          LORA_MAC_STATUS_WOULD_BLOCK if another TX is
+     *                          LORAWAN_STATUS_WOULD_BLOCK if another TX is
      *                          ongoing, or a negative error code on failure.
      */
     virtual int16_t send(uint8_t port, const uint8_t* data, uint16_t length,
@@ -352,7 +352,7 @@ public:
      * @return                  It could be one of these:
      *                             i)   0 if there is nothing else to read.
      *                             ii)  Number of bytes written to user buffer.
-     *                             iii) LORA_MAC_STATUS_WOULD_BLOCK if there is
+     *                             iii) LORAWAN_STATUS_WOULD_BLOCK if there is
      *                                  nothing available to read at the moment.
      *                             iv)  A negative error code on failure.
      */
@@ -427,7 +427,7 @@ public:
        * @param callbacks         A pointer to the structure containing application
        *                          callbacks.
        */
-    virtual lora_mac_status_t add_app_callbacks(lorawan_app_callbacks_t *callbacks);
+    virtual lorawan_status_t add_app_callbacks(lorawan_app_callbacks_t *callbacks);
 
 private:
     bool _link_check_requested;

--- a/features/lorawan/LoRaWANStack.cpp
+++ b/features/lorawan/LoRaWANStack.cpp
@@ -44,13 +44,6 @@ SPDX-License-Identifier: BSD-3-Clause
 using namespace mbed;
 using namespace events;
 
-/**
- * Helper function prototypes
- */
-static Mcps_t interpret_mcps_confirm_type(const lora_mac_mcps_t& local);
-static Mib_t interpret_mib_req_confirm_type(const lora_mac_mib_t& mib_local);
-static lora_mac_event_info_status_t interpret_event_info_type(const LoRaMacEventInfoStatus_t& remote);
-
 #if defined(LORAWAN_COMPLIANCE_TEST)
     /**
      *
@@ -78,14 +71,14 @@ bool LoRaWANStack::is_port_valid(uint8_t port)
     }
 }
 
-lora_mac_status_t LoRaWANStack::set_application_port(uint8_t port)
+lorawan_status_t LoRaWANStack::set_application_port(uint8_t port)
 {
     if (is_port_valid(port)) {
         _app_port = port;
-        return LORA_MAC_STATUS_OK;
+        return LORAWAN_STATUS_OK;
     }
 
-    return LORA_MAC_STATUS_PORT_INVALID;
+    return LORAWAN_STATUS_PORT_INVALID;
 }
 
 /*****************************************************************************
@@ -138,17 +131,16 @@ radio_events_t *LoRaWANStack::bind_radio_driver(LoRaRadio& radio)
     _lora_phy.set_radio_instance(radio);
     return _mac_handlers;
 }
-lora_mac_status_t LoRaWANStack::initialize_mac_layer(EventQueue *queue)
+lorawan_status_t LoRaWANStack::initialize_mac_layer(EventQueue *queue)
 {
     if (DEVICE_STATE_NOT_INITIALIZED != _device_current_state)
     {
         tr_debug("Initialized already");
-        return LORA_MAC_STATUS_OK;
+        return LORAWAN_STATUS_OK;
     }
 
-    static LoRaMacPrimitives_t LoRaMacPrimitives;
-    static LoRaMacCallback_t LoRaMacCallbacks;
-    static lora_mac_mib_request_confirm_t mib_req;
+    static loramac_primitives_t LoRaMacPrimitives;
+    static loramac_mib_req_confirm_t mib_req;
 
 #if defined(LORAWAN_COMPLIANCE_TEST)
     static uint8_t compliance_test_buffer[MBED_CONF_LORA_TX_MAX_SIZE];
@@ -166,18 +158,18 @@ lora_mac_status_t LoRaWANStack::initialize_mac_layer(EventQueue *queue)
 
     _lora_time.TimerTimeCounterInit(queue);
 
-    LoRaMacPrimitives.MacMcpsConfirm = callback(this, &LoRaWANStack::mcps_confirm);
-    LoRaMacPrimitives.MacMcpsIndication = callback(this, &LoRaWANStack::mcps_indication);
-    LoRaMacPrimitives.MacMlmeConfirm = callback(this, &LoRaWANStack::mlme_confirm);
-    LoRaMacPrimitives.MacMlmeIndication = callback(this, &LoRaWANStack::mlme_indication);
-    _loramac.LoRaMacInitialization(&LoRaMacPrimitives, &LoRaMacCallbacks, &_lora_phy, queue);
+    LoRaMacPrimitives.mcps_confirm = callback(this, &LoRaWANStack::mcps_confirm_handler);
+    LoRaMacPrimitives.mcps_indication = callback(this, &LoRaWANStack::mcps_indication_handler);
+    LoRaMacPrimitives.mlme_confirm = callback(this, &LoRaWANStack::mlme_confirm_handler);
+    LoRaMacPrimitives.mlme_indication = callback(this, &LoRaWANStack::mlme_indication_handler);
+    _loramac.LoRaMacInitialization(&LoRaMacPrimitives, &_lora_phy, queue);
 
-    mib_req.type = LORA_MIB_ADR;
-    mib_req.param.adr_enable = MBED_CONF_LORA_ADR_ON;
+    mib_req.type = MIB_ADR;
+    mib_req.param.is_adr_enable = MBED_CONF_LORA_ADR_ON;
     mib_set_request(&mib_req);
 
-    mib_req.type = LORA_MIB_PUBLIC_NETWORK;
-    mib_req.param.enable_public_network = MBED_CONF_LORA_PUBLIC_NETWORK;
+    mib_req.type = MIB_PUBLIC_NETWORK;
+    mib_req.param.enable_public_nwk = MBED_CONF_LORA_PUBLIC_NETWORK;
     mib_set_request(&mib_req);
 
     // Reset counters to zero. Will change in future with 1.1 support.
@@ -234,9 +226,9 @@ void LoRaWANStack::prepare_special_tx_frame(uint8_t port)
  *
  * \return          returns the state of the LoRa MAC
  */
-lora_mac_status_t LoRaWANStack::send_compliance_test_frame_to_mac()
+lorawan_status_t LoRaWANStack::send_compliance_test_frame_to_mac()
 {
-    lora_mac_mcps_req_t mcps_req;
+    loramac_mcps_req_t mcps_req;
 
     GetPhyParams_t phy_params;
     PhyParam_t default_datarate;
@@ -246,32 +238,32 @@ lora_mac_status_t LoRaWANStack::send_compliance_test_frame_to_mac()
     prepare_special_tx_frame(_compliance_test.app_port);
 
     if (!_compliance_test.is_tx_confirmed) {
-        mcps_req.type = LORA_MCPS_UNCONFIRMED;
-        mcps_req.req.unconfirmed.f_port = _compliance_test.app_port;
+        mcps_req.type = MCPS_UNCONFIRMED;
+        mcps_req.req.unconfirmed.fport = _compliance_test.app_port;
         mcps_req.f_buffer = _tx_msg.f_buffer;
         mcps_req.f_buffer_size = _tx_msg.f_buffer_size;
-        mcps_req.req.unconfirmed.datarate = default_datarate.Value;
+        mcps_req.req.unconfirmed.data_rate = default_datarate.Value;
 
-        tr_info("Transmit unconfirmed compliance test frame %d bytes.", mcps_req.f_buffer_size);
+        tr_info("Transmit unconfirmed compliance test frame %d bytes.", mcps_req.req.unconfirmed.fbuffer_size);
 
         for (uint8_t i = 0; i < mcps_req.f_buffer_size; ++i) {
             tr_info("Byte %d, data is 0x%x", i+1, ((uint8_t*)mcps_req.f_buffer)[i]);
         }
     } else if (_compliance_test.is_tx_confirmed) {
-        mcps_req.type = LORA_MCPS_CONFIRMED;
-        mcps_req.req.confirmed.f_port = _compliance_test.app_port;
+        mcps_req.type = MCPS_CONFIRMED;
+        mcps_req.req.confirmed.fport = _compliance_test.app_port;
         mcps_req.f_buffer = _tx_msg.f_buffer;
         mcps_req.f_buffer_size = _tx_msg.f_buffer_size;
         mcps_req.req.confirmed.nb_trials = _num_retry;
-        mcps_req.req.confirmed.datarate = default_datarate.Value;
+        mcps_req.req.confirmed.data_rate = default_datarate.Value;
 
-        tr_info("Transmit confirmed compliance test frame %d bytes.", mcps_req.f_buffer_size);
+        tr_info("Transmit confirmed compliance test frame %d bytes.", mcps_req.req.confirmed.fbuffer_size);
 
         for (uint8_t i = 0; i < mcps_req.f_buffer_size; ++i) {
             tr_info("Byte %d, data is 0x%x", i+1, ((uint8_t*)mcps_req.f_buffer)[i]);
         }
     } else {
-        return LORA_MAC_STATUS_SERVICE_UNKNOWN;
+        return LORAWAN_STATUS_SERVICE_UNKNOWN;
     }
 
     return mcps_request_handler(&mcps_req);
@@ -280,25 +272,25 @@ lora_mac_status_t LoRaWANStack::send_compliance_test_frame_to_mac()
 
 uint16_t LoRaWANStack::check_possible_tx_size(uint16_t size)
 {
-    LoRaMacTxInfo_t txInfo;
-    if (_loramac.LoRaMacQueryTxPossible(size, &txInfo) == LORAMAC_STATUS_LENGTH_ERROR) {
+    loramac_tx_info_t tx_info;
+    if (_loramac.LoRaMacQueryTxPossible(size, &tx_info) == LORAWAN_STATUS_LENGTH_ERROR) {
         // Cannot transmit this much. Return how much data can be sent
         // at the moment
-        return txInfo.MaxPossiblePayload;
+        return tx_info.max_possible_payload_size;
     }
 
-    return txInfo.CurrentPayloadSize;
+    return tx_info.current_payload_size;
 }
 
 /** Hands over the frame to MAC layer
  *
  * \return          returns the state of the LoRa MAC
  */
-lora_mac_status_t LoRaWANStack::send_frame_to_mac()
+lorawan_status_t LoRaWANStack::send_frame_to_mac()
 {
-    lora_mac_mcps_req_t mcps_req;
-    lora_mac_status_t status;
-    lora_mac_mib_request_confirm_t mib_get_params;
+    loramac_mcps_req_t mcps_req;
+    lorawan_status_t status;
+    loramac_mib_req_confirm_t mib_get_params;
 
     GetPhyParams_t phy_params;
     PhyParam_t default_datarate;
@@ -307,48 +299,48 @@ lora_mac_status_t LoRaWANStack::send_frame_to_mac()
 
     mcps_req.type = _tx_msg.type;
 
-    if (LORA_MCPS_UNCONFIRMED == mcps_req.type) {
-        mcps_req.req.unconfirmed.f_port = _tx_msg.message_u.unconfirmed.f_port;
+    if (MCPS_UNCONFIRMED == mcps_req.type) {
+        mcps_req.req.unconfirmed.fport = _tx_msg.message_u.unconfirmed.fport;
         mcps_req.f_buffer = _tx_msg.f_buffer;
 
         mcps_req.f_buffer_size = _tx_msg.f_buffer_size;
 
-        mib_get_params.type = LORA_MIB_CHANNELS_DATARATE;
-        if(mib_get_request(&mib_get_params) != LORA_MAC_STATUS_OK) {
+        mib_get_params.type = MIB_CHANNELS_DATARATE;
+        if(mib_get_request(&mib_get_params) != LORAWAN_STATUS_OK) {
             tr_debug("Couldn't get MIB parameters: Using default data rate");
-            mcps_req.req.unconfirmed.datarate = default_datarate.Value;
+            mcps_req.req.unconfirmed.data_rate = default_datarate.Value;
         } else {
-            mcps_req.req.unconfirmed.datarate = mib_get_params.param.channels_datarate;
+            mcps_req.req.unconfirmed.data_rate = mib_get_params.param.channel_data_rate;
         }
 
-    } else if (LORA_MCPS_CONFIRMED == mcps_req.type) {
-        mcps_req.req.confirmed.f_port = _tx_msg.message_u.confirmed.f_port;
+    } else if (mcps_req.type == MCPS_CONFIRMED) {
+        mcps_req.req.confirmed.fport = _tx_msg.message_u.confirmed.fport;
         mcps_req.f_buffer = _tx_msg.f_buffer;
         mcps_req.f_buffer_size = _tx_msg.f_buffer_size;
         mcps_req.req.confirmed.nb_trials = _tx_msg.message_u.confirmed.nb_trials;
 
-        mib_get_params.type = LORA_MIB_CHANNELS_DATARATE;
-        if(mib_get_request(&mib_get_params) != LORA_MAC_STATUS_OK) {
+        mib_get_params.type = MIB_CHANNELS_DATARATE;
+        if(mib_get_request(&mib_get_params) != LORAWAN_STATUS_OK) {
             tr_debug("Couldn't get MIB parameters: Using default data rate");
-            mcps_req.req.confirmed.datarate = default_datarate.Value;
+            mcps_req.req.confirmed.data_rate = default_datarate.Value;
         } else {
-            mcps_req.req.confirmed.datarate = mib_get_params.param.channels_datarate;
+            mcps_req.req.confirmed.data_rate = mib_get_params.param.channel_data_rate;
         }
 
-    } else if (LORA_MCPS_PROPRIETARY == mcps_req.type) {
+    } else if ( mcps_req.type == MCPS_PROPRIETARY) {
         mcps_req.f_buffer = _tx_msg.f_buffer;
         mcps_req.f_buffer_size = _tx_msg.f_buffer_size;
 
-        mib_get_params.type = LORA_MIB_CHANNELS_DATARATE;
-        if(mib_get_request(&mib_get_params) != LORA_MAC_STATUS_OK) {
+        mib_get_params.type =MIB_CHANNELS_DATARATE;
+        if(mib_get_request(&mib_get_params) != LORAWAN_STATUS_OK) {
             tr_debug("Couldn't get MIB parameters: Using default data rate");
-            mcps_req.req.proprietary.datarate = default_datarate.Value;
+            mcps_req.req.proprietary.data_rate = default_datarate.Value;
         } else {
-            mcps_req.req.proprietary.datarate = mib_get_params.param.channels_datarate;
+            mcps_req.req.proprietary.data_rate = mib_get_params.param.channel_data_rate;
         }
 
     } else {
-        return LORA_MAC_STATUS_SERVICE_UNKNOWN;
+        return LORAWAN_STATUS_SERVICE_UNKNOWN;
     }
 
     status = mcps_request_handler(&mcps_req);
@@ -356,15 +348,15 @@ lora_mac_status_t LoRaWANStack::send_frame_to_mac()
     return status;
 }
 
-lora_mac_status_t LoRaWANStack::set_confirmed_msg_retry(uint8_t count)
+lorawan_status_t LoRaWANStack::set_confirmed_msg_retry(uint8_t count)
 {
     if (count >= MAX_CONFIRMED_MSG_RETRIES) {
-        return LORA_MAC_STATUS_PARAMETER_INVALID;
+        return LORAWAN_STATUS_PARAMETER_INVALID;
     }
 
     _num_retry = count;
 
-    return LORA_MAC_STATUS_OK;
+    return LORAWAN_STATUS_OK;
 }
 
 void LoRaWANStack::set_device_state(device_states_t new_state)
@@ -372,84 +364,14 @@ void LoRaWANStack::set_device_state(device_states_t new_state)
     _device_current_state = new_state;
 }
 
-/** Wrapper function to MCPS-Confirm event function
- *
- * \param mcps_confirm      Pointer to the confirm structure,
- *                          containing confirm attributes.
- */
-void LoRaWANStack::mcps_confirm(McpsConfirm_t *mcps_confirm)
-{
-    lora_mac_mcps_confirm_t lora_mcps_confirm;
-    lora_mcps_confirm.ack_received = mcps_confirm->AckReceived;
-    lora_mcps_confirm.nb_retries = mcps_confirm->NbRetries;
-    lora_mcps_confirm.datarate = mcps_confirm->Datarate;
-    lora_mcps_confirm.tx_power = mcps_confirm->TxPower;
-    lora_mcps_confirm.uplink_counter = mcps_confirm->UpLinkCounter;
-    lora_mcps_confirm.uplink_frequency = mcps_confirm->UpLinkFrequency;
-
-    // Interprets from Mcps_t to lora_mac_mcps_t
-    mcps_confirm->McpsRequest = interpret_mcps_confirm_type(lora_mcps_confirm.mcps_request);
-    // Interprets from LoRaMacEventInfoStatus_t to lora_mac_event_info_status_t
-    lora_mcps_confirm.status = interpret_event_info_type(mcps_confirm->Status);
-    lora_mcps_confirm.tx_time_on_air = mcps_confirm->TxTimeOnAir;
-
-    mcps_confirm_handler(&lora_mcps_confirm);
-}
-
-/** Wrapper function to MCPS-Indication event function
- *
- * \param mcps_indication   Pointer to the indication structure,
- *                          containing indication attributes.
- */
-void LoRaWANStack::mcps_indication(McpsIndication_t *mcps_indication)
-{
-    lora_mac_mcps_indication_t lora_mcps_indication;
-
-    lora_mcps_indication.ack_received = mcps_indication->AckReceived;
-    memcpy(lora_mcps_indication.buffer,  mcps_indication->Buffer, mcps_indication->BufferSize);
-    lora_mcps_indication.buffer_size = mcps_indication->BufferSize;
-    lora_mcps_indication.downlink_counter = mcps_indication->DownLinkCounter;
-    lora_mcps_indication.frame_pending = mcps_indication->FramePending;
-    lora_mcps_indication.mcps_indication = (lora_mac_mcps_t)mcps_indication->McpsIndication;
-    lora_mcps_indication.multicast = mcps_indication->Multicast;
-    lora_mcps_indication.port = mcps_indication->Port;
-    lora_mcps_indication.rssi = mcps_indication->Rssi;
-    lora_mcps_indication.rx_data = mcps_indication->RxData;
-    lora_mcps_indication.rx_datarate = mcps_indication->RxDatarate;
-    lora_mcps_indication.rx_slot = mcps_indication->RxSlot;
-    lora_mcps_indication.snr = mcps_indication->Snr;
-    lora_mcps_indication.status = (lora_mac_event_info_status_t)mcps_indication->Status;
-
-    mcps_indication_handler(&lora_mcps_indication);
-}
-
-/** Wrapper function to MLME-Confirm event function
- *
- * \param mlme_confirm      Pointer to the confirm structure,
- *                          containing confirm attributes.
- */
-void LoRaWANStack::mlme_confirm(MlmeConfirm_t *mlme_confirm)
-{
-    lora_mac_mlme_confirm_t lora_mlme_confirm;
-
-    lora_mlme_confirm.demod_margin = mlme_confirm->DemodMargin;
-    lora_mlme_confirm.mlme_request = (lora_mac_mlme_t)mlme_confirm->MlmeRequest;
-    lora_mlme_confirm.nb_gateways = mlme_confirm->NbGateways;
-    lora_mlme_confirm.nb_retries = mlme_confirm->NbRetries;
-    lora_mlme_confirm.status = (lora_mac_event_info_status_t)mlme_confirm->Status;
-    lora_mlme_confirm.tx_time_on_air = mlme_confirm->TxTimeOnAir;
-
-    mlme_confirm_handler(&lora_mlme_confirm);
-}
-
 /*!
  * \brief   MLME-Indication event function
  *
  * \param   [IN] mlmeIndication - Pointer to the indication structure.
  */
-void LoRaWANStack::mlme_indication( MlmeIndication_t *mlmeIndication )
+void LoRaWANStack::mlme_indication_handler(loramac_mlme_indication_t *mlmeIndication)
 {
-    switch( mlmeIndication->MlmeIndication )
+    switch( mlmeIndication->indication_type )
     {
         case MLME_SCHEDULE_UPLINK:
         {// The MAC signals that we shall provide an uplink as soon as possible
@@ -474,94 +396,96 @@ void LoRaWANStack::set_lora_callbacks(lorawan_app_callbacks_t *cbs)
         if (cbs->link_check_resp) {
             _callbacks.link_check_resp = cbs->link_check_resp;
         }
+
+        if (cbs->battery_level) {
+            _callbacks.battery_level = cbs->battery_level;
+        }
     }
 }
 
-lora_mac_status_t LoRaWANStack::add_channels(const lora_channelplan_t &channel_plan)
+lorawan_status_t LoRaWANStack::add_channels(const lorawan_channelplan_t &channel_plan)
 {
     // If device is not initialized, stop right away
     if (_device_current_state == DEVICE_STATE_NOT_INITIALIZED) {
         tr_error("Stack not initialized!");
-        return LORA_MAC_STATUS_NOT_INITIALIZED;
+        return LORAWAN_STATUS_NOT_INITIALIZED;
     }
 
-    LoRaMacStatus_t status = _loramac.AddChannelPlan(channel_plan);
-
-    return error_type_converter(status);
+    return _loramac.AddChannelPlan(channel_plan);
 }
 
-lora_mac_status_t LoRaWANStack::drop_channel_list()
+lorawan_status_t LoRaWANStack::drop_channel_list()
 {
     if (_device_current_state == DEVICE_STATE_NOT_INITIALIZED) {
         tr_error("Stack not initialized!");
-        return LORA_MAC_STATUS_NOT_INITIALIZED;
+        return LORAWAN_STATUS_NOT_INITIALIZED;
     }
 
-    return error_type_converter(_loramac.RemoveChannelPlan());
+    return _loramac.RemoveChannelPlan();
 }
 
-lora_mac_status_t LoRaWANStack::remove_a_channel(uint8_t channel_id)
+lorawan_status_t LoRaWANStack::remove_a_channel(uint8_t channel_id)
 {
     if (_device_current_state == DEVICE_STATE_NOT_INITIALIZED )
     {
         tr_error("Stack not initialized!");
-        return LORA_MAC_STATUS_NOT_INITIALIZED;
+        return LORAWAN_STATUS_NOT_INITIALIZED;
     }
 
-    return error_type_converter(_loramac.RemoveSingleChannel(channel_id));
+    return _loramac.RemoveSingleChannel(channel_id);
 }
 
-lora_mac_status_t LoRaWANStack::get_enabled_channels(lora_channelplan_t& channel_plan)
+lorawan_status_t LoRaWANStack::get_enabled_channels(lorawan_channelplan_t& channel_plan)
 {
     if (_device_current_state == DEVICE_STATE_JOINING
             || _device_current_state == DEVICE_STATE_NOT_INITIALIZED
             || _device_current_state == DEVICE_STATE_INIT)
     {
         tr_error("Cannot get channel plan until Joined!");
-        return LORA_MAC_STATUS_BUSY;
+        return LORAWAN_STATUS_BUSY;
     }
 
-  return error_type_converter(_loramac.GetChannelPlan(channel_plan));
+  return _loramac.GetChannelPlan(channel_plan);
 }
 
-lora_mac_status_t LoRaWANStack::enable_adaptive_datarate(bool adr_enabled)
+lorawan_status_t LoRaWANStack::enable_adaptive_datarate(bool adr_enabled)
 {
     if (DEVICE_STATE_NOT_INITIALIZED == _device_current_state)
     {
         tr_error("Stack not initialized!");
-        return LORA_MAC_STATUS_NOT_INITIALIZED;
+        return LORAWAN_STATUS_NOT_INITIALIZED;
     }
 
-    lora_mac_mib_request_confirm_t adr_mib_params;
+    loramac_mib_req_confirm_t adr_mib_params;
 
-    adr_mib_params.type = LORA_MIB_ADR;
-    adr_mib_params.param.adr_enable = adr_enabled;
+    adr_mib_params.type = MIB_ADR;
+    adr_mib_params.param.is_adr_enable = adr_enabled;
 
     return mib_set_request(&adr_mib_params);
 }
 
-lora_mac_status_t LoRaWANStack::set_channel_data_rate(uint8_t data_rate)
+lorawan_status_t LoRaWANStack::set_channel_data_rate(uint8_t data_rate)
 {
     if (DEVICE_STATE_NOT_INITIALIZED == _device_current_state)
     {
         tr_error("Stack not initialized!");
-        return LORA_MAC_STATUS_NOT_INITIALIZED;
+        return LORAWAN_STATUS_NOT_INITIALIZED;
     }
 
-    lora_mac_mib_request_confirm_t mib_params;
-    mib_params.type = LORA_MIB_ADR;
+    loramac_mib_req_confirm_t mib_params;
+    mib_params.type = MIB_ADR;
     if (mib_get_request(&mib_params) == true) {
         tr_error("Cannot set data rate. Please turn off ADR first.");
-        return LORA_MAC_STATUS_PARAMETER_INVALID;
+        return LORAWAN_STATUS_PARAMETER_INVALID;
     }
 
-    mib_params.type = LORA_MIB_CHANNELS_DATARATE;
-    mib_params.param.channels_datarate = data_rate;
+    mib_params.type = MIB_CHANNELS_DATARATE;
+    mib_params.param.channel_data_rate = data_rate;
 
     return mib_set_request(&mib_params);
 }
 
-void LoRaWANStack::commission_device(const lora_dev_commission_t &commission_data)
+void LoRaWANStack::commission_device(const lorawan_dev_commission_t &commission_data)
 {
     _lw_session.connection.connect_type = commission_data.connection.connect_type;
     _lw_session.downlink_counter = commission_data.downlink_counter;
@@ -590,14 +514,14 @@ void LoRaWANStack::commission_device(const lora_dev_commission_t &commission_dat
  *
  * Join OTAA
  */
-lora_mac_status_t LoRaWANStack::join_request_by_otaa(const lorawan_connect_t &params)
+lorawan_status_t LoRaWANStack::join_request_by_otaa(const lorawan_connect_t &params)
 {
-    lora_dev_commission_t commission;
+    lorawan_dev_commission_t commission;
 
     if (DEVICE_STATE_NOT_INITIALIZED == _device_current_state)
     {
         tr_error("Stack not initialized!");
-        return LORA_MAC_STATUS_NOT_INITIALIZED;
+        return LORAWAN_STATUS_NOT_INITIALIZED;
     }
 
     tr_debug("Initiating OTAA");
@@ -623,14 +547,14 @@ lora_mac_status_t LoRaWANStack::join_request_by_otaa(const lorawan_connect_t &pa
  *
  * Connect ABP
  */
-lora_mac_status_t LoRaWANStack::activation_by_personalization(const lorawan_connect_t &params)
+lorawan_status_t LoRaWANStack::activation_by_personalization(const lorawan_connect_t &params)
 {
-    lora_mac_status_t status;
-    lora_dev_commission_t commission;
+    lorawan_status_t status;
+    lorawan_dev_commission_t commission;
 
     if (DEVICE_STATE_NOT_INITIALIZED == _device_current_state) {
         tr_error("Stack not initialized!");
-        return LORA_MAC_STATUS_NOT_INITIALIZED;
+        return LORAWAN_STATUS_NOT_INITIALIZED;
     }
 
     tr_debug("Initiating ABP");
@@ -666,33 +590,33 @@ int16_t LoRaWANStack::handle_tx(uint8_t port, const uint8_t* data,
                                 uint16_t length, uint8_t flags)
 {
     if (!_lw_session.active) {
-        return LORA_MAC_STATUS_NO_ACTIVE_SESSIONS;
+        return LORAWAN_STATUS_NO_ACTIVE_SESSIONS;
     }
 
     if (_tx_msg.tx_ongoing) {
-        return LORA_MAC_STATUS_WOULD_BLOCK;
+        return LORAWAN_STATUS_WOULD_BLOCK;
     }
 
 #if defined(LORAWAN_COMPLIANCE_TEST)
     if (_compliance_test.running) {
-        return LORA_MAC_STATUS_COMPLIANCE_TEST_ON;
+        return LORAWAN_STATUS_COMPLIANCE_TEST_ON;
     }
 #endif
 
-    lora_mac_mib_request_confirm_t mib_req;
-    lora_mac_status_t status;
-    mib_req.type = LORA_MIB_NETWORK_JOINED;
+    loramac_mib_req_confirm_t mib_req;
+    lorawan_status_t status;
+    mib_req.type = MIB_NETWORK_JOINED;
     status = mib_get_request(&mib_req);
 
-    if (status == LORA_MAC_STATUS_OK) {
-        if (mib_req.param.is_network_joined == false) {
-            return LORA_MAC_STATUS_NO_NETWORK_JOINED;
+    if (status == LORAWAN_STATUS_OK) {
+        if (mib_req.param.is_nwk_joined == false) {
+            return LORAWAN_STATUS_NO_NETWORK_JOINED;
         }
     }
 
     status = set_application_port(port);
 
-    if (status != LORA_MAC_STATUS_OK) {
+    if (status != LORAWAN_STATUS_OK) {
         tr_error("Illegal application port definition.");
         return status;
     }
@@ -700,7 +624,7 @@ int16_t LoRaWANStack::handle_tx(uint8_t port, const uint8_t* data,
     if (flags == 0
             || (flags & MSG_FLAG_MASK) == (MSG_CONFIRMED_FLAG|MSG_UNCONFIRMED_FLAG)) {
         tr_error("CONFIRMED and UNCONFIRMED are mutually exclusive for send()");
-        return LORA_MAC_STATUS_PARAMETER_INVALID;
+        return LORAWAN_STATUS_PARAMETER_INVALID;
     }
 
     _tx_msg.port = port;
@@ -739,8 +663,8 @@ int16_t LoRaWANStack::handle_tx(uint8_t port, const uint8_t* data,
             || (flags & MSG_FLAG_MASK) == MSG_UNCONFIRMED_MULTICAST
             || (flags & MSG_FLAG_MASK) == MSG_UNCONFIRMED_PROPRIETARY) {
 
-         _tx_msg.type = LORA_MCPS_UNCONFIRMED;
-         _tx_msg.message_u.unconfirmed.f_port = _app_port;
+         _tx_msg.type = MCPS_UNCONFIRMED;
+         _tx_msg.message_u.unconfirmed.fport = _app_port;
     }
 
     // Handles all confirmed messages, including proprietary and multicast
@@ -748,8 +672,8 @@ int16_t LoRaWANStack::handle_tx(uint8_t port, const uint8_t* data,
             || (flags & MSG_FLAG_MASK) == MSG_CONFIRMED_MULTICAST
             || (flags & MSG_FLAG_MASK) == MSG_CONFIRMED_PROPRIETARY) {
 
-        _tx_msg.type = LORA_MCPS_CONFIRMED;
-        _tx_msg.message_u.confirmed.f_port = _app_port;
+        _tx_msg.type = MCPS_CONFIRMED;
+        _tx_msg.message_u.confirmed.fport = _app_port;
         _tx_msg.message_u.confirmed.nb_trials = _num_retry;
     }
 
@@ -766,35 +690,35 @@ int16_t LoRaWANStack::handle_rx(const uint8_t port, uint8_t* data,
                                 uint16_t length, uint8_t flags)
 {
     if (!_lw_session.active) {
-        return LORA_MAC_STATUS_NO_ACTIVE_SESSIONS;
+        return LORAWAN_STATUS_NO_ACTIVE_SESSIONS;
     }
 
     // No messages to read.
     if (!_rx_msg.receive_ready) {
-        return LORA_MAC_STATUS_WOULD_BLOCK;
+        return LORAWAN_STATUS_WOULD_BLOCK;
     }
 
 #if defined(LORAWAN_COMPLIANCE_TEST)
     if (_compliance_test.running) {
-        return LORA_MAC_STATUS_COMPLIANCE_TEST_ON;
+        return LORAWAN_STATUS_COMPLIANCE_TEST_ON;
     }
 #endif
 
     if (data == NULL) {
-        return LORA_MAC_STATUS_PARAMETER_INVALID;
+        return LORAWAN_STATUS_PARAMETER_INVALID;
     }
 
-    uint8_t *base_ptr = _rx_msg.rx_message.mcps_indication.buffer;
-    uint16_t base_size = _rx_msg.rx_message.mcps_indication.buffer_size;
+    uint8_t *base_ptr = _rx_msg.msg.mcps_indication.buffer;
+    uint16_t base_size = _rx_msg.msg.mcps_indication.buffer_size;
     bool read_complete = false;
 
-    if (_rx_msg.rx_message.mcps_indication.port != port) {
+    if (_rx_msg.msg.mcps_indication.port != port) {
         // Nothing yet received for this particular port
-        return LORA_MAC_STATUS_WOULD_BLOCK;
+        return LORAWAN_STATUS_WOULD_BLOCK;
     }
 
     // check if message received is a Confirmed message and user subscribed to it or not
-    if (_rx_msg.rx_message.mcps_indication.mcps_indication == LORA_MCPS_CONFIRMED
+    if (_rx_msg.msg.mcps_indication.type == MCPS_CONFIRMED
             && ((flags & MSG_FLAG_MASK) == MSG_CONFIRMED_FLAG
                     || (flags & MSG_FLAG_MASK) == MSG_CONFIRMED_MULTICAST
                     || (flags & MSG_FLAG_MASK) == MSG_CONFIRMED_PROPRIETARY)) {
@@ -803,7 +727,7 @@ int16_t LoRaWANStack::handle_rx(const uint8_t port, uint8_t* data,
     }
 
     // check if message received is a Unconfirmed message and user subscribed to it or not
-    if (_rx_msg.rx_message.mcps_indication.mcps_indication == LORA_MCPS_UNCONFIRMED
+    if (_rx_msg.msg.mcps_indication.type == MCPS_UNCONFIRMED
             && ((flags & MSG_FLAG_MASK) == MSG_UNCONFIRMED_FLAG
                     || (flags & MSG_FLAG_MASK) == MSG_UNCONFIRMED_MULTICAST
                     || (flags & MSG_FLAG_MASK) == MSG_UNCONFIRMED_PROPRIETARY)) {
@@ -812,10 +736,10 @@ int16_t LoRaWANStack::handle_rx(const uint8_t port, uint8_t* data,
 
     // check the length of received message whether we can fit into user
     // buffer completely or not
-    if (_rx_msg.rx_message.mcps_indication.buffer_size > length &&
+    if (_rx_msg.msg.mcps_indication.buffer_size > length &&
             _rx_msg.prev_read_size == 0) {
         // we can't fit into user buffer. Invoke counter measures
-        _rx_msg.pending_size = _rx_msg.rx_message.mcps_indication.buffer_size - length;
+        _rx_msg.pending_size = _rx_msg.msg.mcps_indication.buffer_size - length;
         base_size = length;
         _rx_msg.prev_read_size = base_size;
         memcpy(data, base_ptr, base_size);
@@ -837,47 +761,20 @@ int16_t LoRaWANStack::handle_rx(const uint8_t port, uint8_t* data,
     // anything pending. If not, memset the buffer to zero and indicate
     // that no read is in progress
     if (read_complete) {
-        memset(_rx_msg.rx_message.mcps_indication.buffer, 0, LORAMAC_PHY_MAXPAYLOAD);
+        memset(_rx_msg.msg.mcps_indication.buffer, 0, LORAMAC_PHY_MAXPAYLOAD);
         _rx_msg.receive_ready = false;
     }
 
     return base_size;
 }
 
-lora_mac_status_t LoRaWANStack::mlme_request_handler(lora_mac_mlme_req_t *mlme_request)
+lorawan_status_t LoRaWANStack::mlme_request_handler(loramac_mlme_req_t *mlme_request)
 {
-    MlmeReq_t request;
-
-    if (NULL == mlme_request) {
-        return LORA_MAC_STATUS_PARAMETER_INVALID;
+    if (mlme_request == NULL) {
+        return LORAWAN_STATUS_PARAMETER_INVALID;
     }
 
-    request.Type = (Mlme_t)mlme_request->type;
-
-    switch (mlme_request->type) {
-        case LORA_MLME_JOIN:
-            request.Req.Join.AppEui = mlme_request->req.join.app_eui;
-            request.Req.Join.AppKey = mlme_request->req.join.app_key;
-            request.Req.Join.DevEui = mlme_request->req.join.dev_eui;
-            request.Req.Join.NbTrials = mlme_request->req.join.nb_trials;
-            break;
-        // This is handled in semtech stack. Only type value is needed.
-        case LORA_MLME_LINK_CHECK:
-            break;
-        case LORA_MLME_TXCW:
-            /* no break */
-            /* Fall through */
-        case LORA_MLME_TXCW_1:
-            request.Req.TxCw.Frequency = mlme_request->req.tx_cw.frequency;
-            request.Req.TxCw.Power = mlme_request->req.tx_cw.power;
-            request.Req.TxCw.Timeout = mlme_request->req.tx_cw.timeout;
-            break;
-        default:
-            return LORA_MAC_STATUS_SERVICE_UNKNOWN;
-            break;
-    }
-
-    return error_type_converter(_loramac.LoRaMacMlmeRequest(&request));
+    return _loramac.LoRaMacMlmeRequest(mlme_request);
 }
 
 /** MLME-Confirm event function
@@ -885,15 +782,15 @@ lora_mac_status_t LoRaWANStack::mlme_request_handler(lora_mac_mlme_req_t *mlme_r
  * \param mlme_confirm      Pointer to the confirm structure,
  *                          containing confirm attributes.
  */
-void LoRaWANStack::mlme_confirm_handler(lora_mac_mlme_confirm_t *mlme_confirm)
+void LoRaWANStack::mlme_confirm_handler(loramac_mlme_confirm_t *mlme_confirm)
 {
     if (NULL == mlme_confirm) {
         return;
     }
 
-    switch (mlme_confirm->mlme_request) {
-        case LORA_MLME_JOIN:
-            if (mlme_confirm->status == LORA_EVENT_INFO_STATUS_OK) {
+    switch (mlme_confirm->req_type) {
+        case MLME_JOIN:
+            if (mlme_confirm->status == LORAMAC_EVENT_INFO_STATUS_OK) {
                 // Status is OK, node has joined the network
                 set_device_state(DEVICE_STATE_JOINED);
                 lora_state_machine();
@@ -907,8 +804,8 @@ void LoRaWANStack::mlme_confirm_handler(lora_mac_mlme_confirm_t *mlme_confirm)
                 }
             }
             break;
-        case LORA_MLME_LINK_CHECK:
-            if (mlme_confirm->status == LORA_EVENT_INFO_STATUS_OK) {
+        case MLME_LINK_CHECK:
+            if (mlme_confirm->status == LORAMAC_EVENT_INFO_STATUS_OK) {
                 // Check DemodMargin
                 // Check NbGateways
 #if defined(LORAWAN_COMPLIANCE_TEST)
@@ -921,8 +818,9 @@ void LoRaWANStack::mlme_confirm_handler(lora_mac_mlme_confirm_t *mlme_confirm)
                 {
                     // normal operation as oppose to compliance testing
                     if (_callbacks.link_check_resp) {
-                        _queue->call(_callbacks.link_check_resp, mlme_confirm->demod_margin,
-                                 mlme_confirm->nb_gateways);
+                        _queue->call(_callbacks.link_check_resp,
+                                     mlme_confirm->demod_margin,
+                                     mlme_confirm->nb_gateways);
                     }
                 }
             }
@@ -933,41 +831,13 @@ void LoRaWANStack::mlme_confirm_handler(lora_mac_mlme_confirm_t *mlme_confirm)
     }
 }
 
-lora_mac_status_t LoRaWANStack::mcps_request_handler(lora_mac_mcps_req_t *mcps_request)
+lorawan_status_t LoRaWANStack::mcps_request_handler(loramac_mcps_req_t *mcps_request)
 {
-    McpsReq_t request;
-
-    if (NULL == mcps_request) {
-        return LORA_MAC_STATUS_PARAMETER_INVALID;
+    if (mcps_request == NULL) {
+        return LORAWAN_STATUS_PARAMETER_INVALID;
     }
 
-    request.Type = (Mcps_t)mcps_request->type;
-
-    switch (mcps_request->type) {
-        case LORA_MCPS_UNCONFIRMED:
-            request.Req.Unconfirmed.Datarate = mcps_request->req.unconfirmed.datarate;
-            request.Req.Unconfirmed.fBuffer = mcps_request->f_buffer;
-            request.Req.Unconfirmed.fBufferSize = mcps_request->f_buffer_size;
-            request.Req.Unconfirmed.fPort = mcps_request->req.unconfirmed.f_port;
-            break;
-        case LORA_MCPS_CONFIRMED:
-            request.Req.Confirmed.Datarate = mcps_request->req.confirmed.datarate;
-            request.Req.Confirmed.fBuffer = mcps_request->f_buffer;
-            request.Req.Confirmed.fBufferSize = mcps_request->f_buffer_size;
-            request.Req.Confirmed.fPort = mcps_request->req.confirmed.f_port;
-            request.Req.Confirmed.NbTrials = mcps_request->req.confirmed.nb_trials;
-            break;
-        case LORA_MCPS_PROPRIETARY:
-            request.Req.Proprietary.Datarate = mcps_request->req.proprietary.datarate;
-            request.Req.Proprietary.fBuffer = mcps_request->f_buffer;
-            request.Req.Proprietary.fBufferSize = mcps_request->f_buffer_size;
-            break;
-        default:
-            return LORA_MAC_STATUS_SERVICE_UNKNOWN;
-            break;
-    }
-
-    return error_type_converter(_loramac.LoRaMacMcpsRequest(&request));
+    return _loramac.LoRaMacMcpsRequest(mcps_request);
 }
 
 /** MCPS-Confirm event function
@@ -975,14 +845,14 @@ lora_mac_status_t LoRaWANStack::mcps_request_handler(lora_mac_mcps_req_t *mcps_r
  * \param mcps_confirm      Pointer to the confirm structure,
  *                          containing confirm attributes.
  */
-void LoRaWANStack::mcps_confirm_handler(lora_mac_mcps_confirm_t *mcps_confirm)
+void LoRaWANStack::mcps_confirm_handler(loramac_mcps_confirm_t *mcps_confirm)
 {
     if (mcps_confirm == NULL) {
         tr_error("mcps_confirm: struct [in] is null.");
         return;
     }
 
-    if (mcps_confirm->status != LORA_EVENT_INFO_STATUS_OK) {
+    if (mcps_confirm->status != LORAMAC_EVENT_INFO_STATUS_OK) {
         // Couldn't schedule packet, ack not recieved in CONFIRMED case
         // or some other error happened. Discard buffer, unset the tx-ongoing
         // flag and let the application know
@@ -993,12 +863,12 @@ void LoRaWANStack::mcps_confirm_handler(lora_mac_mcps_confirm_t *mcps_confirm)
         tr_error("mcps_confirm_handler: Error code = %d", mcps_confirm->status);
 
         // If sending timed out, we have a special event for that
-        if (mcps_confirm->status == LORA_EVENT_INFO_STATUS_TX_TIMEOUT) {
+        if (mcps_confirm->status == LORAMAC_EVENT_INFO_STATUS_TX_TIMEOUT) {
             if (_callbacks.events) {
                 _queue->call(_callbacks.events, TX_TIMEOUT);
             }
             return;
-        } if (mcps_confirm->status == LORA_EVENT_INFO_STATUS_RX2_TIMEOUT) {
+        } if (mcps_confirm->status == LORAMAC_EVENT_INFO_STATUS_RX2_TIMEOUT) {
             tr_debug("Did not receive Ack");
         }
 
@@ -1011,7 +881,7 @@ void LoRaWANStack::mcps_confirm_handler(lora_mac_mcps_confirm_t *mcps_confirm)
 
     // If No errors encountered, let's proceed with the status.
     // CONFIRMED needs special handling because of acks
-    if (mcps_confirm->mcps_request == LORA_MCPS_CONFIRMED) {
+    if (mcps_confirm->req_type == MCPS_CONFIRMED) {
         // In confirmed case, we need to check if we have received the Ack or not.
         // This is actually just being paranoid about ack because LoRaMac.cpp doesn't
         // call this callback until an ack is received.
@@ -1023,7 +893,7 @@ void LoRaWANStack::mcps_confirm_handler(lora_mac_mcps_confirm_t *mcps_confirm)
     // This part is common to both CONFIRMED and UNCONFIRMED.
     // Tell the application about successful transmission and store
     // data rate plus frame counter.
-    _lw_session.uplink_counter = mcps_confirm->uplink_counter;
+    _lw_session.uplink_counter = mcps_confirm->ul_frame_counter;
     _tx_msg.tx_ongoing = false;
      if (_callbacks.events) {
          _queue->call(_callbacks.events, TX_DONE);
@@ -1035,28 +905,28 @@ void LoRaWANStack::mcps_confirm_handler(lora_mac_mcps_confirm_t *mcps_confirm)
  * \param mcps_indication   Pointer to the indication structure,
  *                          containing indication attributes.
  */
-void LoRaWANStack::mcps_indication_handler(lora_mac_mcps_indication_t *mcps_indication)
+void LoRaWANStack::mcps_indication_handler(loramac_mcps_indication_t *mcps_indication)
 {
     if (mcps_indication == NULL) {
         tr_error("mcps_indication: struct [in] is null.");
         return;
     }
 
-    if (mcps_indication->status != LORA_EVENT_INFO_STATUS_OK) {
+    if (mcps_indication->status != LORAMAC_EVENT_INFO_STATUS_OK) {
         if (_callbacks.events) {
             _queue->call(_callbacks.events, RX_ERROR);
         }
         return;
     }
 
-    switch (mcps_indication->mcps_indication) {
-        case LORA_MCPS_UNCONFIRMED:
+    switch (mcps_indication->type) {
+        case MCPS_UNCONFIRMED:
             break;
-        case LORA_MCPS_CONFIRMED:
+        case MCPS_CONFIRMED:
             break;
-        case LORA_MCPS_PROPRIETARY:
+        case MCPS_PROPRIETARY:
             break;
-        case LORA_MCPS_MULTICAST:
+        case MCPS_MULTICAST:
             break;
         default:
             break;
@@ -1080,7 +950,7 @@ void LoRaWANStack::mcps_indication_handler(lora_mac_mcps_indication_t *mcps_indi
     }
 #endif
 
-    if (mcps_indication->rx_data == true) {
+    if (mcps_indication->is_data_recvd == true) {
         switch (mcps_indication->port) {
         case 224:
 #if defined(LORAWAN_COMPLIANCE_TEST)
@@ -1092,11 +962,11 @@ void LoRaWANStack::mcps_indication_handler(lora_mac_mcps_indication_t *mcps_indi
             break;
         default:
             if (is_port_valid(mcps_indication->port) == true ||
-                    mcps_indication->mcps_indication == LORA_MCPS_PROPRIETARY) {
+                    mcps_indication->type == MCPS_PROPRIETARY) {
 
                 // Valid message arrived.
                 // Save message to buffer with session information.
-                if (_rx_msg.rx_message.mcps_indication.buffer_size > LORAMAC_PHY_MAXPAYLOAD) {
+                if (_rx_msg.msg.mcps_indication.buffer_size > LORAMAC_PHY_MAXPAYLOAD) {
                     // This may never happen as both radio and MAC are limited
                     // to the size 255 bytes
                     tr_debug("Cannot receive more than buffer capacity!");
@@ -1106,15 +976,15 @@ void LoRaWANStack::mcps_indication_handler(lora_mac_mcps_indication_t *mcps_indi
                     return;
                 } else {
                     _rx_msg.type = LORAMAC_RX_MCPS_INDICATION;
-                    _rx_msg.rx_message.mcps_indication.buffer_size = mcps_indication->buffer_size;
-                    _rx_msg.rx_message.mcps_indication.port = mcps_indication->port;
-                    // Copy message for user
-                    memcpy(_rx_msg.rx_message.mcps_indication.buffer,
-                           mcps_indication->buffer, mcps_indication->buffer_size);
+                    _rx_msg.msg.mcps_indication.buffer_size = mcps_indication->buffer_size;
+                    _rx_msg.msg.mcps_indication.port = mcps_indication->port;
+
+                    // no copy, just set the pointer for the user
+                    _rx_msg.msg.mcps_indication.buffer = mcps_indication->buffer;
                 }
 
                 // Notify application about received frame..
-                tr_debug("Received %d bytes", _rx_msg.rx_message.mcps_indication.buffer_size);
+                tr_debug("Received %d bytes", _rx_msg.msg.mcps_indication.buffer_size);
                 _rx_msg.receive_ready = true;
                 if (_callbacks.events) {
                     _queue->call(_callbacks.events, RX_DONE);
@@ -1124,7 +994,7 @@ void LoRaWANStack::mcps_indication_handler(lora_mac_mcps_indication_t *mcps_indi
                 // with CONFIRMED flag set. We always set a CONFIRMED flag so
                 // that we could retry a certain number of times if the uplink
                 // failed for some reason
-                if (mcps_indication->frame_pending) {
+                if (mcps_indication->fpending_status) {
                     handle_tx(mcps_indication->port, NULL, 0, MSG_CONFIRMED_FLAG);
                 }
             } else {
@@ -1141,7 +1011,7 @@ void LoRaWANStack::mcps_indication_handler(lora_mac_mcps_indication_t *mcps_indi
  * \param mcps_indication   Pointer to the indication structure,
  *                          containing indication attributes.
  */
-void LoRaWANStack::compliance_test_handler(lora_mac_mcps_indication_t *mcps_indication)
+void LoRaWANStack::compliance_test_handler(loramac_mcps_indication_t *mcps_indication)
 {
     if (_compliance_test.running == false) {
         // Check compliance test enable command (i)
@@ -1160,9 +1030,9 @@ void LoRaWANStack::compliance_test_handler(lora_mac_mcps_indication_t *mcps_indi
             _compliance_test.running = true;
             _compliance_test.state = 1;
 
-            lora_mac_mib_request_confirm_t mib_req;
-            mib_req.type = LORA_MIB_ADR;
-            mib_req.param.adr_enable = true;
+            loramac_mib_req_confirm_t mib_req;
+            mib_req.type = MIB_ADR;
+            mib_req.param.is_adr_enable = true;
             mib_set_request(&mib_req);
 
 #if MBED_CONF_LORA_PHY      == 0
@@ -1183,9 +1053,9 @@ void LoRaWANStack::compliance_test_handler(lora_mac_mcps_indication_t *mcps_indi
             _compliance_test.downlink_counter = 0;
             _compliance_test.running = false;
 
-            lora_mac_mib_request_confirm_t mib_req;
-            mib_req.type = LORA_MIB_ADR;
-            mib_req.param.adr_enable = MBED_CONF_LORA_ADR_ON;
+            loramac_mib_req_confirm_t mib_req;
+            mib_req.type = MIB_ADR;
+            mib_req.param.is_adr_enable = MBED_CONF_LORA_ADR_ON;
             mib_set_request(&mib_req);
 #if MBED_CONF_LORA_PHY      == 0
             _loramac.LoRaMacTestSetDutyCycleOn(MBED_CONF_LORA_DUTY_CYCLE_ON);
@@ -1221,13 +1091,13 @@ void LoRaWANStack::compliance_test_handler(lora_mac_mcps_indication_t *mcps_indi
             send_compliance_test_frame_to_mac();
             break;
         case 5: // (viii)
-            lora_mac_mlme_req_t mlme_req;
-            mlme_req.type = LORA_MLME_LINK_CHECK;
+            loramac_mlme_req_t mlme_req;
+            mlme_req.type = MLME_LINK_CHECK;
             mlme_request_handler(&mlme_req);
             break;
         case 6: // (ix)
-            lora_mac_mlme_req_t mlme_request;
-            lora_mac_mib_request_confirm_t mib_request;
+            loramac_mlme_req_t mlme_request;
+            loramac_mib_req_confirm_t mib_request;
 
             // Disable TestMode and revert back to normal operation
             _compliance_test.is_tx_confirmed = true;
@@ -1236,13 +1106,13 @@ void LoRaWANStack::compliance_test_handler(lora_mac_mcps_indication_t *mcps_indi
             _compliance_test.downlink_counter = 0;
             _compliance_test.running = false;
 
-            mib_request.type = LORA_MIB_ADR;
-            mib_request.param.adr_enable = MBED_CONF_LORA_ADR_ON;
+            mib_request.type = MIB_ADR;
+            mib_request.param.is_adr_enable = MBED_CONF_LORA_ADR_ON;
             mib_set_request(&mib_request);
 #if MBED_CONF_LORA_PHY      == 0
             _loramac.LoRaMacTestSetDutyCycleOn(MBED_CONF_LORA_DUTY_CYCLE_ON);
 #endif
-            mlme_request.type = LORA_MLME_JOIN;
+            mlme_request.type = MLME_JOIN;
             mlme_request.req.join.dev_eui = _lw_session.connection.connection_u.otaa.dev_eui;
             mlme_request.req.join.app_eui = _lw_session.connection.connection_u.otaa.app_eui;
             mlme_request.req.join.app_key = _lw_session.connection.connection_u.otaa.app_key;
@@ -1251,17 +1121,17 @@ void LoRaWANStack::compliance_test_handler(lora_mac_mcps_indication_t *mcps_indi
             break;
         case 7: // (x)
             if (mcps_indication->buffer_size == 3) {
-                lora_mac_mlme_req_t mlme_req;
-                mlme_req.type = LORA_MLME_TXCW;
-                mlme_req.req.tx_cw.timeout = (uint16_t)((mcps_indication->buffer[1] << 8) | mcps_indication->buffer[2]);
+                loramac_mlme_req_t mlme_req;
+                mlme_req.type = MLME_TXCW;
+                mlme_req.req.cw_tx_mode.timeout = (uint16_t)((mcps_indication->buffer[1] << 8) | mcps_indication->buffer[2]);
                 mlme_request_handler(&mlme_req);
             } else if (mcps_indication->buffer_size == 7) {
-                lora_mac_mlme_req_t mlme_req;
-                mlme_req.type = LORA_MLME_TXCW_1;
-                mlme_req.req.tx_cw.timeout = (uint16_t)((mcps_indication->buffer[1] << 8) | mcps_indication->buffer[2]);
-                mlme_req.req.tx_cw.frequency = (uint32_t)((mcps_indication->buffer[3] << 16) | (mcps_indication->buffer[4] << 8)
+                loramac_mlme_req_t mlme_req;
+                mlme_req.type = MLME_TXCW_1;
+                mlme_req.req.cw_tx_mode.timeout = (uint16_t)((mcps_indication->buffer[1] << 8) | mcps_indication->buffer[2]);
+                mlme_req.req.cw_tx_mode.frequency = (uint32_t)((mcps_indication->buffer[3] << 16) | (mcps_indication->buffer[4] << 8)
                         | mcps_indication->buffer[5]) * 100;
-                mlme_req.req.tx_cw.power = mcps_indication->buffer[6];
+                mlme_req.req.cw_tx_mode.power = mcps_indication->buffer[6];
                 mlme_request_handler(&mlme_req);
             }
             _compliance_test.state = 1;
@@ -1271,401 +1141,36 @@ void LoRaWANStack::compliance_test_handler(lora_mac_mcps_indication_t *mcps_indi
 }
 #endif
 
-lora_mac_status_t LoRaWANStack::mib_set_request(lora_mac_mib_request_confirm_t *mib_set_params)
+lorawan_status_t LoRaWANStack::mib_set_request(loramac_mib_req_confirm_t *mib_set_params)
 {
-    MibRequestConfirm_t stack_mib_set;
-    ChannelParams_t stack_channel_params;
-    MulticastParams_t *stack_multicast_params = NULL;
-    MulticastParams_t *head = NULL;
-    lora_mac_status_t status;
-
     if (NULL == mib_set_params) {
-        return LORA_MAC_STATUS_PARAMETER_INVALID;
+        return LORAWAN_STATUS_PARAMETER_INVALID;
     }
 
-    // Interpreting from lora_mac_mib_t to Mib_t
-    stack_mib_set.Type = interpret_mib_req_confirm_type(mib_set_params->type);
-
-    switch (mib_set_params->type) {
-        case LORA_MIB_DEVICE_CLASS:
-            stack_mib_set.Param.Class = (DeviceClass_t)mib_set_params->param.lora_class;
-            break;
-
-        case LORA_MIB_NETWORK_JOINED:
-            stack_mib_set.Param.IsNetworkJoined = mib_set_params->param.is_network_joined;
-            break;
-
-        case LORA_MIB_ADR:
-            stack_mib_set.Param.AdrEnable = mib_set_params->param.adr_enable;
-            break;
-
-        case LORA_MIB_NET_ID:
-            stack_mib_set.Param.NetID = mib_set_params->param.net_id;
-            break;
-
-        case LORA_MIB_DEV_ADDR:
-            stack_mib_set.Param.DevAddr = mib_set_params->param.dev_addr;
-            break;
-
-        case LORA_MIB_NWK_SKEY:
-            stack_mib_set.Param.NwkSKey = mib_set_params->param.nwk_skey;
-            break;
-
-        case LORA_MIB_APP_SKEY:
-            stack_mib_set.Param.AppSKey = mib_set_params->param.app_skey;
-            break;
-
-        case LORA_MIB_PUBLIC_NETWORK:
-            stack_mib_set.Param.EnablePublicNetwork = mib_set_params->param.enable_public_network;
-            break;
-
-        case LORA_MIB_REPEATER_SUPPORT:
-            stack_mib_set.Param.EnableRepeaterSupport = mib_set_params->param.enable_repeater_support;
-            break;
-
-        case LORA_MIB_CHANNELS:
-            stack_channel_params.Frequency = mib_set_params->param.channel_list->frequency;
-            stack_channel_params.DrRange.Value = mib_set_params->param.channel_list->dr_range.value;
-            stack_channel_params.DrRange.Fields.Min = mib_set_params->param.channel_list->dr_range.lora_mac_fields_s.min;
-            stack_channel_params.DrRange.Fields.Max = mib_set_params->param.channel_list->dr_range.lora_mac_fields_s.max;
-            stack_channel_params.Band = mib_set_params->param.channel_list->band;
-            stack_channel_params.Rx1Frequency = mib_set_params->param.channel_list->rx1_frequency;
-            stack_mib_set.Param.ChannelList = &stack_channel_params;
-            break;
-
-        case LORA_MIB_RX2_CHANNEL:
-            stack_mib_set.Param.Rx2Channel.Frequency = mib_set_params->param.rx2_channel.frequency;
-            stack_mib_set.Param.Rx2Channel.Datarate = mib_set_params->param.rx2_channel.datarate;
-            break;
-
-        case LORA_MIB_RX2_DEFAULT_CHANNEL:
-            stack_mib_set.Param.Rx2DefaultChannel.Frequency = mib_set_params->param.rx2_default_channel.frequency;
-            stack_mib_set.Param.Rx2DefaultChannel.Datarate = mib_set_params->param.rx2_default_channel.datarate;
-            break;
-
-        case LORA_MIB_CHANNELS_MASK:
-            stack_mib_set.Param.ChannelsMask = mib_set_params->param.channels_mask;
-           break;
-
-        case LORA_MIB_CHANNELS_DEFAULT_MASK:
-            stack_mib_set.Param.ChannelsDefaultMask = mib_set_params->param.channels_default_mask;
-            break;
-
-        case LORA_MIB_CHANNELS_NB_REP:
-            stack_mib_set.Param.ChannelNbRep = mib_set_params->param.channel_nb_rep;
-            break;
-
-        case LORA_MIB_MAX_RX_WINDOW_DURATION:
-            stack_mib_set.Param.MaxRxWindow = mib_set_params->param.max_rx_window;
-            break;
-
-        case LORA_MIB_RECEIVE_DELAY_1:
-            stack_mib_set.Param.ReceiveDelay1 = mib_set_params->param.receive_delay1;
-            break;
-
-        case LORA_MIB_RECEIVE_DELAY_2:
-            stack_mib_set.Param.ReceiveDelay2 = mib_set_params->param.receive_delay2;
-            break;
-
-        case LORA_MIB_JOIN_ACCEPT_DELAY_1:
-            stack_mib_set.Param.JoinAcceptDelay1 = mib_set_params->param.join_accept_delay1;
-            break;
-
-        case LORA_MIB_JOIN_ACCEPT_DELAY_2:
-            stack_mib_set.Param.JoinAcceptDelay2 = mib_set_params->param.join_accept_delay2;
-            break;
-
-        case LORA_MIB_CHANNELS_DEFAULT_DATARATE:
-            stack_mib_set.Param.ChannelsDefaultDatarate = mib_set_params->param.channels_default_datarate;
-            break;
-
-        case LORA_MIB_CHANNELS_DATARATE:
-            stack_mib_set.Param.ChannelsDatarate = mib_set_params->param.channels_datarate;
-            break;
-
-        case LORA_MIB_CHANNELS_TX_POWER:
-            stack_mib_set.Param.ChannelsTxPower = mib_set_params->param.channels_tx_power;
-            break;
-
-        case LORA_MIB_CHANNELS_DEFAULT_TX_POWER:
-            stack_mib_set.Param.ChannelsDefaultTxPower = mib_set_params->param.channels_default_tx_power;
-            break;
-
-        case LORA_MIB_UPLINK_COUNTER:
-            stack_mib_set.Param.UpLinkCounter = mib_set_params->param.uplink_counter;
-            break;
-
-        case LORA_MIB_DOWNLINK_COUNTER:
-            stack_mib_set.Param.DownLinkCounter = mib_set_params->param.downlink_counter;
-            break;
-
-        case LORA_MIB_MULTICAST_CHANNEL:
-            /*
-             * Parse multicast list (C++ linked list)
-             */
-            while (mib_set_params->param.multicast_list != NULL) {
-                if (stack_multicast_params == NULL) {
-                    stack_multicast_params = new MulticastParams_t;
-                    head = stack_multicast_params;
-                } else {
-                    while (stack_multicast_params != NULL) {
-                        stack_multicast_params = stack_multicast_params->Next;
-                    }
-
-                    stack_multicast_params = new MulticastParams_t;
-                }
-
-                stack_multicast_params->Address = mib_set_params->param.multicast_list->address;
-                for (int i = 0; i < 16; i++) {
-                    stack_multicast_params->NwkSKey[i] = mib_set_params->param.multicast_list->nwk_skey[i];
-                    stack_multicast_params->AppSKey[i] = mib_set_params->param.multicast_list->app_skey[i];
-                }
-
-                stack_multicast_params->DownLinkCounter = mib_set_params->param.multicast_list->downlink_counter;
-            }
-
-            stack_mib_set.Param.MulticastList = head;
-            break;
-
-        case LORA_MIB_SYSTEM_MAX_RX_ERROR:
-            stack_mib_set.Param.SystemMaxRxError = mib_set_params->param.system_max_rx_error;
-            break;
-
-        case LORA_MIB_MIN_RX_SYMBOLS:
-            stack_mib_set.Param.MinRxSymbols = mib_set_params->param.min_rx_symbols;
-            break;
-
-        default:
-            return LORA_MAC_STATUS_SERVICE_UNKNOWN;
-            break;
-    }
-
-    /*
-     * Set MIB data to LoRa stack
-     */
-    status = error_type_converter(_loramac.LoRaMacMibSetRequestConfirm(&stack_mib_set));
-    /*
-     * Release memory if reserved by multicast list
-     */
-    if (NULL != head) {
-        while (NULL != head) {
-            delete head;
-            head = NULL;
-            head = stack_mib_set.Param.MulticastList->Next;
-        }
-        stack_mib_set.Param.MulticastList = NULL;
-    }
-
-    return status;
+    return _loramac.LoRaMacMibSetRequestConfirm(mib_set_params);
 }
 
-lora_mac_status_t LoRaWANStack::mib_get_request(lora_mac_mib_request_confirm_t *mib_get_params)
+lorawan_status_t LoRaWANStack::mib_get_request(loramac_mib_req_confirm_t *mib_get_params)
 {
-    MibRequestConfirm_t stack_mib_get;
-    MulticastParams_t *origin_multicast_list = NULL;
-    lora_mac_multicast_params_t *new_multicast_list = NULL;
-    lora_mac_status_t mac_status = LORA_MAC_STATUS_OK;
-
     if(NULL == mib_get_params) {
-        return LORA_MAC_STATUS_PARAMETER_INVALID;
+        return LORAWAN_STATUS_PARAMETER_INVALID;
     }
 
-    // Interprets from lora_mac_mib_t to Mib_t
-    stack_mib_get.Type = interpret_mib_req_confirm_type(mib_get_params->type);
-    mac_status = error_type_converter(_loramac.LoRaMacMibGetRequestConfirm(&stack_mib_get));
+    return _loramac.LoRaMacMibGetRequestConfirm(mib_get_params);
 
-    if (LORA_MAC_STATUS_OK != mac_status) {
-        return LORA_MAC_STATUS_SERVICE_UNKNOWN;
-    }
 
-    switch(mib_get_params->type) {
-        case LORA_MIB_DEVICE_CLASS:
-            mib_get_params->param.lora_class = (lora_mac_device_class_t)stack_mib_get.Param.Class;
-            break;
-        case LORA_MIB_NETWORK_JOINED:
-            mib_get_params->param.is_network_joined = stack_mib_get.Param.IsNetworkJoined;
-            break;
-        case LORA_MIB_ADR:
-            mib_get_params->param.adr_enable = stack_mib_get.Param.AdrEnable;
-            break;
-        case LORA_MIB_NET_ID:
-            mib_get_params->param.net_id = stack_mib_get.Param.NetID;
-            break;
-        case LORA_MIB_DEV_ADDR:
-            mib_get_params->param.dev_addr = stack_mib_get.Param.DevAddr;
-            break;
-        case LORA_MIB_NWK_SKEY:
-            mib_get_params->param.nwk_skey = stack_mib_get.Param.NwkSKey;
-            break;
-        case LORA_MIB_APP_SKEY:
-            mib_get_params->param.app_skey = stack_mib_get.Param.AppSKey;
-            break;
-        case LORA_MIB_PUBLIC_NETWORK:
-            mib_get_params->param.enable_public_network = stack_mib_get.Param.EnablePublicNetwork;
-            break;
-        case LORA_MIB_REPEATER_SUPPORT:
-            mib_get_params->param.enable_repeater_support = stack_mib_get.Param.EnableRepeaterSupport;
-            break;
-        case LORA_MIB_CHANNELS:
-            mib_get_params->param.channel_list = (lora_mac_channel_params_t *) stack_mib_get.Param.ChannelList;
-            break;
-        case LORA_MIB_RX2_CHANNEL:
-            mib_get_params->param.rx2_channel.datarate = stack_mib_get.Param.Rx2Channel.Datarate;
-            mib_get_params->param.rx2_channel.frequency = stack_mib_get.Param.Rx2Channel.Frequency;
-            break;
-        case LORA_MIB_RX2_DEFAULT_CHANNEL:
-            mib_get_params->param.rx2_default_channel.datarate = stack_mib_get.Param.Rx2DefaultChannel.Datarate;
-            mib_get_params->param.rx2_default_channel.frequency = stack_mib_get.Param.Rx2DefaultChannel.Frequency;
-            break;
-        case LORA_MIB_CHANNELS_DEFAULT_MASK:
-            mib_get_params->param.channels_default_mask = stack_mib_get.Param.ChannelsDefaultMask;
-            break;
-        case LORA_MIB_CHANNELS_MASK:
-            mib_get_params->param.channels_mask = stack_mib_get.Param.ChannelsMask;
-            break;
-        case LORA_MIB_CHANNELS_NB_REP:
-            mib_get_params->param.channel_nb_rep = stack_mib_get.Param.ChannelNbRep;
-            break;
-        case LORA_MIB_MAX_RX_WINDOW_DURATION:
-            mib_get_params->param.max_rx_window = stack_mib_get.Param.MaxRxWindow;
-            break;
-        case LORA_MIB_RECEIVE_DELAY_1:
-            mib_get_params->param.receive_delay1 = stack_mib_get.Param.ReceiveDelay1;
-            break;
-        case LORA_MIB_RECEIVE_DELAY_2:
-            mib_get_params->param.receive_delay2 = stack_mib_get.Param.ReceiveDelay2;
-            break;
-        case LORA_MIB_JOIN_ACCEPT_DELAY_1:
-            mib_get_params->param.join_accept_delay1 = stack_mib_get.Param.JoinAcceptDelay1;
-            break;
-        case LORA_MIB_JOIN_ACCEPT_DELAY_2:
-            mib_get_params->param.join_accept_delay2 = stack_mib_get.Param.JoinAcceptDelay2;
-            break;
-        case LORA_MIB_CHANNELS_DEFAULT_DATARATE:
-            mib_get_params->param.channels_default_datarate = stack_mib_get.Param.ChannelsDefaultDatarate;
-            break;
-        case LORA_MIB_CHANNELS_DATARATE:
-            mib_get_params->param.channels_datarate = stack_mib_get.Param.ChannelsDatarate;
-            break;
-        case LORA_MIB_CHANNELS_DEFAULT_TX_POWER:
-            mib_get_params->param.channels_default_tx_power = stack_mib_get.Param.ChannelsDefaultTxPower;
-            break;
-        case LORA_MIB_CHANNELS_TX_POWER:
-            mib_get_params->param.channels_tx_power = stack_mib_get.Param.ChannelsTxPower;
-            break;
-        case LORA_MIB_UPLINK_COUNTER:
-            mib_get_params->param.uplink_counter = stack_mib_get.Param.UpLinkCounter;
-            break;
-        case LORA_MIB_DOWNLINK_COUNTER:
-            mib_get_params->param.downlink_counter = stack_mib_get.Param.DownLinkCounter;
-            break;
-        case LORA_MIB_MULTICAST_CHANNEL:
-            /*
-             * Parse multicast list (C++ linked list)
-             */
-            origin_multicast_list = stack_mib_get.Param.MulticastList;
-
-            while (NULL != origin_multicast_list) {
-                if (NULL == new_multicast_list) {
-                    new_multicast_list = new lora_mac_multicast_params_t;
-                    new_multicast_list->next = NULL;
-
-                    mib_get_params->param.multicast_list = new_multicast_list;
-                } else {
-                    while (NULL != new_multicast_list) {
-                        new_multicast_list = new_multicast_list->next;
-                    }
-                    new_multicast_list = new lora_mac_multicast_params_t;
-                    new_multicast_list->next = NULL;
-                }
-
-                new_multicast_list->address = origin_multicast_list->Address;
-                for (int i = 0; i < 16; ++i) {
-                    new_multicast_list->nwk_skey[i] = origin_multicast_list->NwkSKey[i];
-                    new_multicast_list->app_skey[i] = origin_multicast_list->AppSKey[i];
-                }
-                new_multicast_list->downlink_counter = origin_multicast_list->DownLinkCounter;
-
-                origin_multicast_list = origin_multicast_list->Next;
-            }
-            break;
-        case LORA_MIB_SYSTEM_MAX_RX_ERROR:
-            mib_get_params->param.system_max_rx_error = stack_mib_get.Param.SystemMaxRxError;
-            break;
-        case LORA_MIB_MIN_RX_SYMBOLS:
-            mib_get_params->param.min_rx_symbols = stack_mib_get.Param.MinRxSymbols;
-            break;
-        default:
-            return LORA_MAC_STATUS_SERVICE_UNKNOWN;
-            break;
-    }
-
-    return mac_status;
 }
 
-lora_mac_status_t LoRaWANStack::error_type_converter(LoRaMacStatus_t type)
-{
-    switch (type) {
-        case LORAMAC_STATUS_OK:
-            return LORA_MAC_STATUS_OK;
-            break;
-
-        case LORAMAC_STATUS_BUSY:
-            return LORA_MAC_STATUS_BUSY;
-            break;
-
-        case LORAMAC_STATUS_SERVICE_UNKNOWN:
-            return LORA_MAC_STATUS_SERVICE_UNKNOWN;
-            break;
-
-        case LORAMAC_STATUS_PARAMETER_INVALID:
-            return LORA_MAC_STATUS_PARAMETER_INVALID;
-            break;
-
-        case LORAMAC_STATUS_FREQUENCY_INVALID:
-            return LORA_MAC_STATUS_FREQUENCY_INVALID;
-            break;
-
-        case LORAMAC_STATUS_DATARATE_INVALID:
-            return LORA_MAC_STATUS_DATARATE_INVALID;
-            break;
-
-        case LORAMAC_STATUS_FREQ_AND_DR_INVALID:
-            return LORA_MAC_STATUS_FREQ_AND_DR_INVALID;
-            break;
-
-        case LORAMAC_STATUS_NO_NETWORK_JOINED:
-            return LORA_MAC_STATUS_NO_NETWORK_JOINED;
-            break;
-
-        case LORAMAC_STATUS_LENGTH_ERROR:
-            return LORA_MAC_STATUS_LENGTH_ERROR;
-            break;
-
-        case LORAMAC_STATUS_DEVICE_OFF:
-            return LORA_MAC_STATUS_DEVICE_OFF;
-            break;
-
-        case LORAMAC_STATUS_CRYPTO_FAIL:
-            return LORA_MAC_STATUS_CRYPTO_FAIL;
-            break;
-
-        default:
-            return LORA_MAC_STATUS_SERVICE_UNKNOWN;
-            break;
-    }
-}
-
-lora_mac_status_t LoRaWANStack::set_link_check_request()
+lorawan_status_t LoRaWANStack::set_link_check_request()
 {
     if (!_callbacks.link_check_resp) {
         tr_error("Must assign a callback function for link check request. ");
-        return LORA_MAC_STATUS_PARAMETER_INVALID;
+        return LORAWAN_STATUS_PARAMETER_INVALID;
     }
 
-    lora_mac_mlme_req_t mlme_req;
+    loramac_mlme_req_t mlme_req;
 
-    mlme_req.type = LORA_MLME_LINK_CHECK;
+    mlme_req.type = MLME_LINK_CHECK;
     return mlme_request_handler(&mlme_req);
 }
 
@@ -1675,10 +1180,10 @@ void LoRaWANStack::shutdown()
     lora_state_machine();
 }
 
-lora_mac_status_t LoRaWANStack::lora_state_machine()
+lorawan_status_t LoRaWANStack::lora_state_machine()
 {
-    lora_mac_mib_request_confirm_t mib_req;
-    lora_mac_status_t status = LORA_MAC_STATUS_DEVICE_OFF;
+    loramac_mib_req_confirm_t mib_req;
+    lorawan_status_t status = LORAWAN_STATUS_DEVICE_OFF;
 
     switch (_device_current_state) {
         case DEVICE_STATE_SHUTDOWN:
@@ -1692,8 +1197,8 @@ lora_mac_status_t LoRaWANStack::lora_state_machine()
 #if defined(LORAWAN_COMPLIANCE_TEST)
             _loramac.LoRaMacStopTxTimer();
 #endif
-            mib_req.type = LORA_MIB_NETWORK_JOINED;
-            mib_req.param.is_network_joined = false;
+            mib_req.type = MIB_NETWORK_JOINED;
+            mib_req.param.is_nwk_joined = false;
             mib_set_request(&mib_req);
 
             // reset buffers to original state
@@ -1701,10 +1206,10 @@ lora_mac_status_t LoRaWANStack::lora_state_machine()
             _tx_msg.pending_size = 0;
             _tx_msg.f_buffer_size = 0;
             _tx_msg.tx_ongoing = false;
-            memset(_rx_msg.rx_message.mcps_indication.buffer, 0, LORAMAC_PHY_MAXPAYLOAD);
+            _rx_msg.msg.mcps_indication.buffer = NULL;
             _rx_msg.receive_ready = false;
             _rx_msg.prev_read_size = 0;
-            _rx_msg.rx_message.mcps_indication.buffer_size = 0;
+            _rx_msg.msg.mcps_indication.buffer_size = 0;
 
             // disable the session
             _lw_session.active = false;
@@ -1713,14 +1218,14 @@ lora_mac_status_t LoRaWANStack::lora_state_machine()
             if (_callbacks.events) {
                 _queue->call(_callbacks.events, DISCONNECTED);
             }
-            status = LORA_MAC_STATUS_DEVICE_OFF;
+            status = LORAWAN_STATUS_DEVICE_OFF;
             break;
         case DEVICE_STATE_NOT_INITIALIZED:
             // Device is disconnected.
-            status = LORA_MAC_STATUS_DEVICE_OFF;
+            status = LORAWAN_STATUS_DEVICE_OFF;
             break;
         case DEVICE_STATE_INIT:
-            status = LORA_MAC_STATUS_OK;
+            status = LORAWAN_STATUS_OK;
             break;
         case DEVICE_STATE_JOINING:
             if (_lw_session.connection.connect_type == LORAWAN_CONNECTION_OTAA) {
@@ -1728,8 +1233,8 @@ lora_mac_status_t LoRaWANStack::lora_state_machine()
                  * OTAA join
                  */
                 tr_debug("Send Join-request..");
-                lora_mac_mlme_req_t mlme_req;
-                mlme_req.type = LORA_MLME_JOIN;
+                loramac_mlme_req_t mlme_req;
+                mlme_req.type = MLME_JOIN;
 
                 mlme_req.req.join.dev_eui = _lw_session.connection.connection_u.otaa.dev_eui;
                 mlme_req.req.join.app_eui = _lw_session.connection.connection_u.otaa.app_eui;
@@ -1738,14 +1243,14 @@ lora_mac_status_t LoRaWANStack::lora_state_machine()
 
                 // Send join request to server.
                 status = mlme_request_handler(&mlme_req);
-                if (status != LORA_MAC_STATUS_OK) {
+                if (status != LORAWAN_STATUS_OK) {
                     return status;
                 }
                 // Otherwise request was successful and OTAA connect is in
                 //progress
-                return LORA_MAC_STATUS_CONNECT_IN_PROGRESS;
+                return LORAWAN_STATUS_CONNECT_IN_PROGRESS;
             } else {
-                status = LORA_MAC_STATUS_PARAMETER_INVALID;
+                status = LORAWAN_STATUS_PARAMETER_INVALID;
                 break;
             }
             break;
@@ -1762,30 +1267,30 @@ lora_mac_status_t LoRaWANStack::lora_state_machine()
             /*
              * ABP connection
              */
-            mib_req.type = LORA_MIB_NET_ID;
+            mib_req.type = MIB_NET_ID;
             mib_req.param.net_id = _lw_session.connection.connection_u.abp.nwk_id;
             mib_set_request(&mib_req);
 
-            mib_req.type = LORA_MIB_DEV_ADDR;
+            mib_req.type = MIB_DEV_ADDR;
             mib_req.param.dev_addr = _lw_session.connection.connection_u.abp.dev_addr;
             mib_set_request(&mib_req);
 
-            mib_req.type = LORA_MIB_NWK_SKEY;
+            mib_req.type = MIB_NWK_SKEY;
             mib_req.param.nwk_skey = _lw_session.connection.connection_u.abp.nwk_skey;
             mib_set_request(&mib_req);
 
-            mib_req.type = LORA_MIB_APP_SKEY;
+            mib_req.type = MIB_APP_SKEY;
             mib_req.param.app_skey = _lw_session.connection.connection_u.abp.app_skey;
             mib_set_request(&mib_req);
 
-            mib_req.type = LORA_MIB_NETWORK_JOINED;
-            mib_req.param.is_network_joined = true;
+            mib_req.type = MIB_NETWORK_JOINED;
+            mib_req.param.is_nwk_joined = true;
             mib_set_request(&mib_req);
             tr_debug("ABP Connection OK!");
             // tell the application we are okay
             // if users provide wrong keys, it's their responsibility
             // there is no way to test ABP authentication success
-            status = LORA_MAC_STATUS_OK;
+            status = LORAWAN_STATUS_OK;
             // Session is now active
             _lw_session.active = true;
             if (_callbacks.events) {
@@ -1795,16 +1300,16 @@ lora_mac_status_t LoRaWANStack::lora_state_machine()
         case DEVICE_STATE_SEND:
             // If a transmission is ongoing, don't interrupt
             if (_tx_msg.tx_ongoing) {
-                status = LORA_MAC_STATUS_OK;
+                status = LORAWAN_STATUS_OK;
             } else {
                 _tx_msg.tx_ongoing = true;
                 status = send_frame_to_mac();
 
                 switch (status) {
-                    case LORA_MAC_STATUS_OK:
+                    case LORAWAN_STATUS_OK:
                         tr_debug("Frame scheduled to TX..");
                         break;
-                    case LORA_MAC_STATUS_CRYPTO_FAIL:
+                    case LORAWAN_STATUS_CRYPTO_FAIL:
                         tr_error("Crypto failed. Clearing TX buffers");
                         if (_callbacks.events) {
                             _queue->call(_callbacks.events, TX_CRYPTO_ERROR);
@@ -1823,7 +1328,7 @@ lora_mac_status_t LoRaWANStack::lora_state_machine()
             break;
         case DEVICE_STATE_IDLE:
             //Do nothing
-            status = LORA_MAC_STATUS_IDLE;
+            status = LORAWAN_STATUS_IDLE;
             break;
 #if defined(LORAWAN_COMPLIANCE_TEST)
         case DEVICE_STATE_COMPLIANCE_TEST:
@@ -1835,141 +1340,13 @@ lora_mac_status_t LoRaWANStack::lora_state_machine()
             if (_compliance_test.running == true) {
                 send_compliance_test_frame_to_mac();
             }
-            status = LORA_MAC_STATUS_COMPLIANCE_TEST_ON;
+            status = LORAWAN_STATUS_COMPLIANCE_TEST_ON;
             break;
 #endif
         default:
-            status = LORA_MAC_STATUS_SERVICE_UNKNOWN;
+            status = LORAWAN_STATUS_SERVICE_UNKNOWN;
             break;
     }
 
     return status;
 }
-
-static Mcps_t interpret_mcps_confirm_type(const lora_mac_mcps_t& local)
-{
-    switch (local) {
-        case LORA_MCPS_UNCONFIRMED:
-            return MCPS_UNCONFIRMED;
-        case LORA_MCPS_CONFIRMED:
-            return MCPS_CONFIRMED;
-        case LORA_MCPS_MULTICAST:
-            return MCPS_MULTICAST;
-        case LORA_MCPS_PROPRIETARY:
-            return MCPS_PROPRIETARY;
-        default:
-            MBED_ASSERT("Unknown Mcps_t");
-    }
-
-    // Never reaches here
-    return MCPS_UNCONFIRMED;
-}
-
-static lora_mac_event_info_status_t interpret_event_info_type(const LoRaMacEventInfoStatus_t& remote)
-{
-    switch (remote) {
-        case LORAMAC_EVENT_INFO_STATUS_OK:
-            return LORA_EVENT_INFO_STATUS_OK;
-        case LORAMAC_EVENT_INFO_STATUS_ERROR:
-            return LORA_EVENT_INFO_STATUS_ERROR;
-        case LORAMAC_EVENT_INFO_STATUS_TX_TIMEOUT:
-            return LORA_EVENT_INFO_STATUS_TX_TIMEOUT;
-        case LORAMAC_EVENT_INFO_STATUS_RX1_TIMEOUT:
-            return LORA_EVENT_INFO_STATUS_RX1_TIMEOUT;
-        case LORAMAC_EVENT_INFO_STATUS_RX2_TIMEOUT:
-            return LORA_EVENT_INFO_STATUS_RX2_TIMEOUT;
-        case LORAMAC_EVENT_INFO_STATUS_RX1_ERROR:
-            return LORA_EVENT_INFO_STATUS_RX1_ERROR;
-        case LORAMAC_EVENT_INFO_STATUS_RX2_ERROR:
-            return LORA_EVENT_INFO_STATUS_RX2_ERROR;
-        case LORAMAC_EVENT_INFO_STATUS_JOIN_FAIL:
-            return LORA_EVENT_INFO_STATUS_JOIN_FAIL;
-        case LORAMAC_EVENT_INFO_STATUS_DOWNLINK_REPEATED:
-            return LORA_EVENT_INFO_STATUS_DOWNLINK_REPEATED;
-        case LORAMAC_EVENT_INFO_STATUS_TX_DR_PAYLOAD_SIZE_ERROR:
-            return LORA_EVENT_INFO_STATUS_TX_DR_PAYLOAD_SIZE_ERROR;
-        case LORAMAC_EVENT_INFO_STATUS_DOWNLINK_TOO_MANY_FRAMES_LOSS:
-            return LORA_EVENT_INFO_STATUS_DOWNLINK_TOO_MANY_FRAMES_LOSS;
-        case LORAMAC_EVENT_INFO_STATUS_ADDRESS_FAIL:
-            return LORA_EVENT_INFO_STATUS_ADDRESS_FAIL;
-        case LORAMAC_EVENT_INFO_STATUS_MIC_FAIL:
-            return LORA_EVENT_INFO_STATUS_MIC_FAIL;
-        case LORAMAC_EVENT_INFO_STATUS_CRYPTO_FAIL:
-            return LORA_EVENT_INFO_STATUS_CRYPTO_FAIL;
-        default:
-            MBED_ASSERT("Unknown LoRaMacEventInfoStatus_t");
-    }
-
-    // Never reaches here actually
-    return LORA_EVENT_INFO_STATUS_OK;
-}
-
-static Mib_t interpret_mib_req_confirm_type(const lora_mac_mib_t& local)
-{
-    switch (local) {
-        case LORA_MIB_DEVICE_CLASS:
-            return MIB_DEVICE_CLASS;
-        case LORA_MIB_NETWORK_JOINED:
-            return MIB_NETWORK_JOINED;
-        case LORA_MIB_ADR:
-            return MIB_ADR;
-        case LORA_MIB_NET_ID:
-            return MIB_NET_ID;
-        case LORA_MIB_DEV_ADDR:
-            return MIB_DEV_ADDR;
-        case LORA_MIB_NWK_SKEY:
-            return MIB_NWK_SKEY;
-        case LORA_MIB_APP_SKEY:
-            return MIB_APP_SKEY;
-        case LORA_MIB_PUBLIC_NETWORK:
-            return MIB_PUBLIC_NETWORK;
-        case LORA_MIB_REPEATER_SUPPORT:
-            return MIB_REPEATER_SUPPORT;
-        case LORA_MIB_CHANNELS:
-            return MIB_CHANNELS;
-        case LORA_MIB_RX2_CHANNEL:
-            return MIB_RX2_CHANNEL;
-        case LORA_MIB_RX2_DEFAULT_CHANNEL:
-            return MIB_RX2_DEFAULT_CHANNEL;
-        case LORA_MIB_CHANNELS_MASK:
-            return MIB_CHANNELS_MASK;
-        case LORA_MIB_CHANNELS_DEFAULT_MASK:
-            return MIB_CHANNELS_DEFAULT_MASK;
-        case LORA_MIB_CHANNELS_NB_REP:
-            return MIB_CHANNELS_NB_REP;
-        case LORA_MIB_MAX_RX_WINDOW_DURATION:
-            return MIB_MAX_RX_WINDOW_DURATION;
-        case LORA_MIB_RECEIVE_DELAY_1:
-            return MIB_RECEIVE_DELAY_1;
-        case LORA_MIB_RECEIVE_DELAY_2:
-            return MIB_RECEIVE_DELAY_2;
-        case LORA_MIB_JOIN_ACCEPT_DELAY_1:
-            return MIB_JOIN_ACCEPT_DELAY_1;
-        case LORA_MIB_JOIN_ACCEPT_DELAY_2:
-            return MIB_JOIN_ACCEPT_DELAY_2;
-        case LORA_MIB_CHANNELS_DEFAULT_DATARATE:
-            return MIB_CHANNELS_DEFAULT_DATARATE;
-        case LORA_MIB_CHANNELS_DATARATE:
-            return MIB_CHANNELS_DATARATE;
-        case LORA_MIB_CHANNELS_TX_POWER:
-            return MIB_CHANNELS_TX_POWER;
-        case LORA_MIB_CHANNELS_DEFAULT_TX_POWER:
-            return MIB_CHANNELS_DEFAULT_TX_POWER;
-        case LORA_MIB_UPLINK_COUNTER:
-            return MIB_UPLINK_COUNTER;
-        case LORA_MIB_DOWNLINK_COUNTER:
-            return MIB_DOWNLINK_COUNTER;
-        case LORA_MIB_MULTICAST_CHANNEL:
-            return MIB_MULTICAST_CHANNEL;
-        case LORA_MIB_SYSTEM_MAX_RX_ERROR:
-            return MIB_SYSTEM_MAX_RX_ERROR;
-        case LORA_MIB_MIN_RX_SYMBOLS:
-            return MIB_MIN_RX_SYMBOLS;
-        default:
-            MBED_ASSERT("Cannot Interpret Mib_t");
-    }
-
-    // Never actually reaches here
-    return MIB_DEVICE_CLASS;
-}
-

--- a/features/lorawan/LoRaWANStack.h
+++ b/features/lorawan/LoRaWANStack.h
@@ -97,9 +97,9 @@ public:
 
     /** End device initialization.
      * @param queue            A pointer to an EventQueue passed from the application.
-     * @return                 LORA_MAC_STATUS_OK on success, a negative error code on failure.
+     * @return                 LORAWAN_STATUS_OK on success, a negative error code on failure.
      */
-    lora_mac_status_t initialize_mac_layer(events::EventQueue *queue);
+    lorawan_status_t initialize_mac_layer(events::EventQueue *queue);
 
     /** Sets all callbacks for the application.
      *
@@ -126,35 +126,35 @@ public:
      *
      * @param  channel_plan     A list of channels or a single channel.
      *
-     * @return                  LORA_MAC_STATUS_OK on success, a negative error
+     * @return                  LORAWAN_STATUS_OK on success, a negative error
      *                          code on failure.
      */
-    lora_mac_status_t add_channels(const lora_channelplan_t &channel_plan);
+    lorawan_status_t add_channels(const lorawan_channelplan_t &channel_plan);
 
     /** Removes a channel from the list.
      *
      * @param channel_id        Index of the channel being removed
      *
-     * @return                  LORA_MAC_STATUS_OK on success, a negative error
+     * @return                  LORAWAN_STATUS_OK on success, a negative error
      *                          code on failure.
      */
-    lora_mac_status_t remove_a_channel(uint8_t channel_id);
+    lorawan_status_t remove_a_channel(uint8_t channel_id);
 
     /** Removes a previously set channel plan.
      *
-     * @return                  LORA_MAC_STATUS_OK on success, a negative error
+     * @return                  LORAWAN_STATUS_OK on success, a negative error
      *                          code on failure.
      */
-    lora_mac_status_t drop_channel_list();
+    lorawan_status_t drop_channel_list();
 
     /** Gets a list of currently enabled channels .
      *
      * @param channel_plan      The channel plan structure to store final result.
      *
-     * @return                  LORA_MAC_STATUS_OK on success, a negative error
+     * @return                  LORAWAN_STATUS_OK on success, a negative error
      *                          code on failure.
      */
-    lora_mac_status_t get_enabled_channels(lora_channelplan_t &channel_plan);
+    lorawan_status_t get_enabled_channels(lorawan_channelplan_t &channel_plan);
 
     /** Sets up a retry counter for confirmed messages.
      *
@@ -164,9 +164,9 @@ public:
      *
      * @param count             The number of retries for confirmed messages.
      *
-     * @return                  LORA_MAC_STATUS_OK or a negative error code.
+     * @return                  LORAWAN_STATUS_OK or a negative error code.
      */
-    lora_mac_status_t set_confirmed_msg_retry(uint8_t count);
+    lorawan_status_t set_confirmed_msg_retry(uint8_t count);
 
     /** Sets up the data rate.
      *
@@ -177,26 +177,26 @@ public:
      *                    Note that the macro DR_* can mean different
      *                    things in different regions.
      *
-     * @return            LORA_MAC_STATUS_OK if everything goes well, otherwise
+     * @return            LORAWAN_STATUS_OK if everything goes well, otherwise
      *                    a negative error code.
      */
-    lora_mac_status_t set_channel_data_rate(uint8_t data_rate);
+    lorawan_status_t set_channel_data_rate(uint8_t data_rate);
 
     /** Enables ADR.
      *
      * @param adr_enabled       0 ADR disabled, 1 ADR enabled.
      *
-     * @return                  LORA_MAC_STATUS_OK on success, a negative error
+     * @return                  LORAWAN_STATUS_OK on success, a negative error
      *                          code on failure.
      */
-    lora_mac_status_t enable_adaptive_datarate(bool adr_enabled);
+    lorawan_status_t enable_adaptive_datarate(bool adr_enabled);
 
     /** Commissions a LoRa device.
      *
      * @param commission_data   A structure representing all the commission
      *                          information.
      */
-    void commission_device(const lora_dev_commission_t &commission_data);
+    void commission_device(const lorawan_dev_commission_t &commission_data);
 
     /** End device OTAA join.
      *
@@ -205,11 +205,11 @@ public:
      *
      * @param  params           The `lorawan_connect_t` type structure.
      *
-     * @return                  LORA_MAC_STATUS_OK or
-     *                          LORA_MAC_STATUS_CONNECT_IN_PROGRESS on success,
+     * @return                  LORAWAN_STATUS_OK or
+     *                          LORAWAN_STATUS_CONNECT_IN_PROGRESS on success,
      *                          or a negative error code on failure.
      */
-    lora_mac_status_t join_request_by_otaa(const lorawan_connect_t &params);
+    lorawan_status_t join_request_by_otaa(const lorawan_connect_t &params);
 
     /** End device ABP join.
      *
@@ -218,11 +218,11 @@ public:
      *
      * @param  params           The `lorawan_connect_t` type structure.
      *
-     * @return                  LORA_MAC_STATUS_OK or
-     *                          LORA_MAC_STATUS_CONNECT_IN_PROGRESS on success,
+     * @return                  LORAWAN_STATUS_OK or
+     *                          LORAWAN_STATUS_CONNECT_IN_PROGRESS on success,
      *                          or a negative error code on failure.
      */
-    lora_mac_status_t activation_by_personalization(const lorawan_connect_t &params);
+    lorawan_status_t activation_by_personalization(const lorawan_connect_t &params);
 
     /** Send message to gateway
      *
@@ -255,7 +255,7 @@ public:
      *
      *
      * @return                  The number of bytes sent, or
-     *                          LORA_MAC_STATUS_WOULD_BLOCK if another TX is
+     *                          LORAWAN_STATUS_WOULD_BLOCK if another TX is
      *                          ongoing, or a negative error code on failure.
      */
     int16_t handle_tx(uint8_t port, const uint8_t* data,
@@ -296,7 +296,7 @@ public:
      * @return                  It could be one of these:
      *                             i)   0 if there is nothing else to read.
      *                             ii)  Number of bytes written to user buffer.
-     *                             iii) LORA_MAC_STATUS_WOULD_BLOCK if there is
+     *                             iii) LORAWAN_STATUS_WOULD_BLOCK if there is
      *                                  nothing available to read at the moment.
      *                             iv)  A negative error code on failure.
      */
@@ -311,13 +311,13 @@ public:
      * from the Network Server, an event is generated.
      *
      * A callback function for the link check response must be set prior to using
-     * this API, otherwise a LORA_MAC_STATUS_PARAMETER_INVALID error is thrown.
+     * this API, otherwise a LORAWAN_STATUS_PARAMETER_INVALID error is thrown.
      *
-     * @return          LORA_MAC_STATUS_OK on successfully queuing a request, or
+     * @return          LORAWAN_STATUS_OK on successfully queuing a request, or
      *                  a negative error code on failure.
      *
      */
-    lora_mac_status_t set_link_check_request();
+    lorawan_status_t set_link_check_request();
 
     /** Shuts down the LoRaWAN protocol.
      *
@@ -338,7 +338,7 @@ private:
      * State machine for stack controller layer.
      * Needs to be wriggled for every state change
      */
-    lora_mac_status_t lora_state_machine();
+    lorawan_status_t lora_state_machine();
 
     /**
      * Sets the current state of the device.
@@ -351,56 +351,35 @@ private:
     /**
      * Hands over the packet to Mac layer by posting an MCPS request.
      */
-    lora_mac_status_t send_frame_to_mac();
-
-    /**
-     * Callback function for MCPS confirm. Mac layer calls this function once
-     * an MCPS confirmation is received. This method translates Mac layer data
-     * structure into stack layer data structure.
-     */
-    void mcps_confirm(McpsConfirm_t *mcps_confirm);
-
-    /**
-     * Callback function for MCPS indication. Mac layer calls this function once
-     * an MCPS indication is received. This method translates Mac layer data
-     * structure into stack layer data structure.
-     */
-    void mcps_indication(McpsIndication_t *mcps_indication);
-
-    /**
-     * Callback function for MLME confirm. Mac layer calls this function once
-     * an MLME confirmation is received. This method translates Mac layer data
-     * structure into stack layer data structure.
-     */
-    void mlme_confirm(MlmeConfirm_t *mlme_confirm);
+    lorawan_status_t send_frame_to_mac();
 
     /**
      * Callback function for MLME indication. Mac layer calls this function once
      * an MLME indication is received. This method translates Mac layer data
      * structure into stack layer data structure.
      */
-    void mlme_indication( MlmeIndication_t *mlmeIndication );
+    void mlme_indication_handler(loramac_mlme_indication_t *mlmeIndication);
 
     /**
      * Handles an MLME request coming from the upper layers and delegates
      * it to the Mac layer, for example, a Join request goes as an MLME request
      * to the Mac layer.
      */
-    lora_mac_status_t mlme_request_handler(lora_mac_mlme_req_t *mlme_request);
+    lorawan_status_t mlme_request_handler(loramac_mlme_req_t *mlme_request);
 
     /**
      * Handles an MLME confirmation coming from the Mac layer and uses it to
      * update the state for example, a Join Accept triggers an MLME confirmation,
      * that eventually comes here and we take necessary steps accordingly.
      */
-    void mlme_confirm_handler(lora_mac_mlme_confirm_t *mlme_confirm);
+    void mlme_confirm_handler(loramac_mlme_confirm_t *mlme_confirm);
 
     /**
      * Handles an MCPS request while attempting to hand over a packet from
      * upper layers to Mac layer. For example in response to send_frame_to_mac(),
      * an MCPS request is generated.
      */
-    lora_mac_status_t mcps_request_handler(lora_mac_mcps_req_t *mcps_request);
+    lorawan_status_t mcps_request_handler(loramac_mcps_req_t *mcps_request);
 
     /**
      * Handles an MCPS confirmation coming from the Mac layer in response to an
@@ -408,7 +387,7 @@ private:
      * e.g., letting the application know that ack was not received in case of
      * a CONFIRMED message or scheduling error etc.
      */
-    void mcps_confirm_handler(lora_mac_mcps_confirm_t *mcps_confirm);
+    void mcps_confirm_handler(loramac_mcps_confirm_t *mcps_confirm);
 
     /**
      * Handles an MCPS indication coming from the Mac layer, e.g., once we
@@ -416,22 +395,22 @@ private:
      * and consequently this handler posts an event to the application that
      * there is something available to read.
      */
-    void mcps_indication_handler(lora_mac_mcps_indication_t *mcps_indication);
+    void mcps_indication_handler(loramac_mcps_indication_t *mcps_indication);
 
     /**
      * Sets a MIB request, i.e., update a particular parameter etc.
      */
-    lora_mac_status_t mib_set_request(lora_mac_mib_request_confirm_t *mib_set_params);
+    lorawan_status_t mib_set_request(loramac_mib_req_confirm_t *mib_set_params);
 
     /**
      * Requests the MIB to inquire about a particular parameter.
      */
-    lora_mac_status_t mib_get_request(lora_mac_mib_request_confirm_t *mib_get_params);
+    lorawan_status_t mib_get_request(loramac_mib_req_confirm_t *mib_get_params);
 
     /**
      * Sets up user application port
      */
-    lora_mac_status_t set_application_port(uint8_t port);
+    lorawan_status_t set_application_port(uint8_t port);
 
     /**
      * Helper function to figure out if the user defined data size is possible
@@ -452,18 +431,13 @@ private:
     /**
      * Used only for compliance testing
      */
-    void compliance_test_handler(lora_mac_mcps_indication_t *mcps_indication);
+    void compliance_test_handler(loramac_mcps_indication_t *mcps_indication);
 
     /**
      * Used only for compliance testing
      */
-    lora_mac_status_t send_compliance_test_frame_to_mac();
+    lorawan_status_t send_compliance_test_frame_to_mac();
 #endif
-
-    /**
-     * converts error codes from Mac layer to controller layer
-     */
-    lora_mac_status_t error_type_converter(LoRaMacStatus_t type);
 
     LoRaWANTimeHandler _lora_time;
     LoRaMac _loramac;
@@ -477,8 +451,8 @@ private:
     lorawan_app_callbacks_t _callbacks;
     radio_events_t *_mac_handlers;
     lorawan_session_t _lw_session;
-    lora_mac_tx_message_t _tx_msg;
-    lora_mac_rx_message_t _rx_msg;
+    loramac_tx_message_t _tx_msg;
+    loramac_rx_message_t _rx_msg;
     uint8_t _app_port;
     uint8_t _num_retry;
     events::EventQueue *_queue;

--- a/features/lorawan/lorastack/mac/LoRaMac.cpp
+++ b/features/lorawan/lorastack/mac/LoRaMac.cpp
@@ -87,38 +87,38 @@ LoRaMac::LoRaMac(LoRaWANTimeHandler &lora_time)
 {
     lora_phy = NULL;
     //radio_events_t RadioEvents;
-    _params.keys.LoRaMacDevEui = NULL;
-    _params.keys.LoRaMacAppEui = NULL;
-    _params.keys.LoRaMacAppKey = NULL;
+    _params.keys.dev_eui = NULL;
+    _params.keys.app_eui = NULL;
+    _params.keys.app_key = NULL;
 
-    memset(_params.keys.LoRaMacNwkSKey, 0, sizeof(_params.keys.LoRaMacNwkSKey));
-    memset(_params.keys.LoRaMacAppSKey, 0, sizeof(_params.keys.LoRaMacAppSKey));
+    memset(_params.keys.nwk_skey, 0, sizeof(_params.keys.nwk_skey));
+    memset(_params.keys.app_skey, 0, sizeof(_params.keys.app_skey));
 
-    _params.LoRaMacDevNonce = 0;
-    _params.LoRaMacNetID = 0;
-    _params.LoRaMacDevAddr = 0;
-    _params.LoRaMacBufferPktLen = 0;
-    _params.LoRaMacTxPayloadLen = 0;
-    _params.UpLinkCounter = 0;
-    _params.DownLinkCounter = 0;
-    _params.IsUpLinkCounterFixed = false;
-    _params.IsRxWindowsEnabled = true;
-    _params.IsLoRaMacNetworkJoined = false;
-    _params.AdrAckCounter = 0;
-    _params.NodeAckRequested = false;
-    _params.SrvAckRequested = false;
-    _params.ChannelsNbRepCounter = 0;
-    _params.timers.LoRaMacInitializationTime = 0;
-    _params.LoRaMacState = LORAMAC_IDLE;
-    _params.AckTimeoutRetries = 1;
-    _params.AckTimeoutRetriesCounter = 1;
-    _params.AckTimeoutRetry = false;
-    _params.timers.TxTimeOnAir = 0;
+    _params.dev_nonce = 0;
+    _params.net_id = 0;
+    _params.dev_addr = 0;
+    _params.buffer_pkt_len = 0;
+    _params.payload_length = 0;
+    _params.ul_frame_counter = 0;
+    _params.dl_frame_counter = 0;
+    _params.is_ul_frame_counter_fixed = false;
+    _params.is_rx_window_enabled = true;
+    _params.is_nwk_joined = false;
+    _params.adr_ack_counter = 0;
+    _params.is_node_ack_requested = false;
+    _params.is_srv_ack_requested = false;
+    _params.ul_nb_rep_counter = 0;
+    _params.timers.mac_init_time = 0;
+    _params.mac_state = LORAMAC_IDLE;
+    _params.max_ack_timeout_retries = 1;
+    _params.ack_timeout_retry_counter = 1;
+    _params.is_ack_retry_timeout_expired = false;
+    _params.timers.tx_toa = 0;
 
-    _params.MulticastChannels = NULL;
+    _params.multicast_channels = NULL;
 
-    _params.sys_params.AdrCtrlOn = false;
-    _params.sys_params.MaxDCycle = 0;
+    _params.sys_params.adr_on = false;
+    _params.sys_params.max_duty_cycle = 0;
 }
 
 LoRaMac::~LoRaMac()
@@ -199,10 +199,10 @@ void LoRaMac::OnRadioTxDone( void )
     GetPhyParams_t getPhy;
     PhyParam_t phyParam;
     SetBandTxDoneParams_t txDone;
-    TimerTime_t curTime = _lora_time.TimerGetCurrentTime( );
-    MlmeConfirm_t mlme_confirm = mlme.get_confirmation();
+    lorawan_time_t curTime = _lora_time.TimerGetCurrentTime( );
+    loramac_mlme_confirm_t mlme_confirm = mlme.get_confirmation();
 
-    if( _params.LoRaMacDeviceClass != CLASS_C )
+    if( _params.dev_class != CLASS_C )
     {
         lora_phy->put_radio_to_sleep();
     }
@@ -212,83 +212,83 @@ void LoRaMac::OnRadioTxDone( void )
     }
 
     // Setup timers
-    if( _params.IsRxWindowsEnabled == true )
+    if( _params.is_rx_window_enabled == true )
     {
-        _lora_time.TimerSetValue( &_params.timers.RxWindowTimer1, _params.RxWindow1Delay );
-        _lora_time.TimerStart( &_params.timers.RxWindowTimer1 );
-        if( _params.LoRaMacDeviceClass != CLASS_C )
+        _lora_time.TimerSetValue( &_params.timers.rx_window1_timer, _params.rx_window1_delay );
+        _lora_time.TimerStart( &_params.timers.rx_window1_timer );
+        if( _params.dev_class != CLASS_C )
         {
-            _lora_time.TimerSetValue( &_params.timers.RxWindowTimer2, _params.RxWindow2Delay );
-            _lora_time.TimerStart( &_params.timers.RxWindowTimer2 );
+            _lora_time.TimerSetValue( &_params.timers.rx_window2_timer, _params.rx_window2_delay );
+            _lora_time.TimerStart( &_params.timers.rx_window2_timer );
         }
-        if( ( _params.LoRaMacDeviceClass == CLASS_C ) || ( _params.NodeAckRequested == true ) )
+        if( ( _params.dev_class == CLASS_C ) || ( _params.is_node_ack_requested == true ) )
         {
             getPhy.Attribute = PHY_ACK_TIMEOUT;
             phyParam = lora_phy->get_phy_params(&getPhy);
-            _lora_time.TimerSetValue( &_params.timers.AckTimeoutTimer, _params.RxWindow2Delay + phyParam.Value );
-            _lora_time.TimerStart( &_params.timers.AckTimeoutTimer );
+            _lora_time.TimerSetValue( &_params.timers.ack_timeout_timer, _params.rx_window2_delay + phyParam.Value );
+            _lora_time.TimerStart( &_params.timers.ack_timeout_timer );
         }
     }
     else
     {
-        mcps.get_confirmation().Status = LORAMAC_EVENT_INFO_STATUS_OK;
-        mlme_confirm.Status = LORAMAC_EVENT_INFO_STATUS_RX2_TIMEOUT;
+        mcps.get_confirmation().status = LORAMAC_EVENT_INFO_STATUS_OK;
+        mlme_confirm.status = LORAMAC_EVENT_INFO_STATUS_RX2_TIMEOUT;
 
-        if( _params.LoRaMacFlags.Value == 0 )
+        if( _params.flags.value == 0 )
         {
-            _params.LoRaMacFlags.Bits.McpsReq = 1;
+            _params.flags.bits.mcps_req = 1;
         }
-        _params.LoRaMacFlags.Bits.MacDone = 1;
+        _params.flags.bits.mac_done = 1;
     }
 
     // Verify if the last uplink was a join request
-    if( ( _params.LoRaMacFlags.Bits.MlmeReq == 1 ) && ( mlme_confirm.MlmeRequest == MLME_JOIN ) )
+    if( ( _params.flags.bits.mlme_req == 1 ) && ( mlme_confirm.req_type == MLME_JOIN ) )
     {
-        _params.LastTxIsJoinRequest = true;
+        _params.is_last_tx_join_request = true;
     }
     else
     {
-        _params.LastTxIsJoinRequest = false;
+        _params.is_last_tx_join_request = false;
     }
 
     // Store last Tx channel
-    _params.LastTxChannel = _params.Channel;
+    _params.last_channel_idx = _params.channel;
     // Update last tx done time for the current channel
-    txDone.Channel = _params.Channel;
-    txDone.Joined = _params.IsLoRaMacNetworkJoined;
+    txDone.Channel = _params.channel;
+    txDone.Joined = _params.is_nwk_joined;
     txDone.LastTxDoneTime = curTime;
     lora_phy->set_band_tx_done(&txDone);
     // Update Aggregated last tx done time
-    _params.timers.AggregatedLastTxDoneTime = curTime;
+    _params.timers.aggregated_last_tx_time = curTime;
 
-    if( _params.NodeAckRequested == false )
+    if( _params.is_node_ack_requested == false )
     {
-        mcps.get_confirmation().Status = LORAMAC_EVENT_INFO_STATUS_OK;
-        _params.ChannelsNbRepCounter++;
+        mcps.get_confirmation().status = LORAMAC_EVENT_INFO_STATUS_OK;
+        _params.ul_nb_rep_counter++;
     }
 }
 
 void LoRaMac::PrepareRxDoneAbort( void )
 {
-    _params.LoRaMacState |= LORAMAC_RX_ABORT;
+    _params.mac_state |= LORAMAC_RX_ABORT;
 
-    if( _params.NodeAckRequested )
+    if( _params.is_node_ack_requested )
     {
         handle_ack_timeout();
     }
 
-    _params.LoRaMacFlags.Bits.McpsInd = 1;
-    _params.LoRaMacFlags.Bits.MacDone = 1;
+    _params.flags.bits.mcps_ind = 1;
+    _params.flags.bits.mac_done = 1;
 
     // Trig OnMacCheckTimerEvent call as soon as possible
-    _lora_time.TimerSetValue( &_params.timers.MacStateCheckTimer, 1 );
-    _lora_time.TimerStart( &_params.timers.MacStateCheckTimer );
+    _lora_time.TimerSetValue( &_params.timers.mac_state_check_timer, 1 );
+    _lora_time.TimerStart( &_params.timers.mac_state_check_timer );
 }
 
 void LoRaMac::OnRadioRxDone( uint8_t *payload, uint16_t size, int16_t rssi, int8_t snr )
 {
-    LoRaMacHeader_t macHdr;
-    LoRaMacFrameCtrl_t fCtrl;
+    loramac_mhdr_t macHdr;
+    loramac_frame_ctrl_t fCtrl;
     ApplyCFListParams_t applyCFList;
     GetPhyParams_t getPhy;
     PhyParam_t phyParam;
@@ -307,131 +307,129 @@ void LoRaMac::OnRadioRxDone( uint8_t *payload, uint16_t size, int16_t rssi, int8
     uint16_t sequenceCounterDiff = 0;
     uint32_t downLinkCounter = 0;
 
-    MulticastParams_t *curMulticastParams = NULL;
-    uint8_t *nwkSKey = _params.keys.LoRaMacNwkSKey;
-    uint8_t *appSKey = _params.keys.LoRaMacAppSKey;
+    multicast_params_t *curMulticastParams = NULL;
+    uint8_t *nwkSKey = _params.keys.nwk_skey;
+    uint8_t *appSKey = _params.keys.app_skey;
 
     uint8_t multicast = 0;
 
     bool isMicOk = false;
 
-    mcps.get_confirmation().AckReceived = false;
-    mcps.get_indication().Rssi = rssi;
-    mcps.get_indication().Snr = snr;
-    mcps.get_indication().RxSlot = _params.RxSlot;
-    mcps.get_indication().Port = 0;
-    mcps.get_indication().Multicast = 0;
-    mcps.get_indication().FramePending = 0;
-    mcps.get_indication().Buffer = NULL;
-    mcps.get_indication().BufferSize = 0;
-    mcps.get_indication().RxData = false;
-    mcps.get_indication().AckReceived = false;
-    mcps.get_indication().DownLinkCounter = 0;
-    mcps.get_indication().McpsIndication = MCPS_UNCONFIRMED;
+    mcps.get_confirmation().ack_received = false;
+    mcps.get_indication().rssi = rssi;
+    mcps.get_indication().snr = snr;
+    mcps.get_indication().rx_slot = _params.rx_slot;
+    mcps.get_indication().port = 0;
+    mcps.get_indication().multicast = 0;
+    mcps.get_indication().fpending_status = 0;
+    mcps.get_indication().buffer = NULL;
+    mcps.get_indication().buffer_size = 0;
+    mcps.get_indication().is_data_recvd = false;
+    mcps.get_indication().is_ack_recvd = false;
+    mcps.get_indication().dl_frame_counter = 0;
+    mcps.get_indication().type = MCPS_UNCONFIRMED;
 
     lora_phy->put_radio_to_sleep();
 
-    _lora_time.TimerStop( &_params.timers.RxWindowTimer2 );
+    _lora_time.TimerStop( &_params.timers.rx_window2_timer );
 
-    macHdr.Value = payload[pktHeaderLen++];
+    macHdr.value = payload[pktHeaderLen++];
 
-    switch( macHdr.Bits.MType )
+    switch( macHdr.bits.mtype )
     {
         case FRAME_TYPE_JOIN_ACCEPT:
-            if( _params.IsLoRaMacNetworkJoined == true )
+            if( _params.is_nwk_joined == true )
             {
-                mcps.get_indication().Status = LORAMAC_EVENT_INFO_STATUS_ERROR;
+                mcps.get_indication().status = LORAMAC_EVENT_INFO_STATUS_ERROR;
                 PrepareRxDoneAbort( );
                 return;
             }
 
             if (0 != LoRaMacJoinDecrypt( payload + 1, size - 1,
-                                         _params.keys.LoRaMacAppKey,
-                                         _params.LoRaMacRxPayload + 1 )) {
-                mcps.get_indication().Status = LORAMAC_EVENT_INFO_STATUS_CRYPTO_FAIL;
+                                         _params.keys.app_key,
+                                         _params.payload + 1 )) {
+                mcps.get_indication().status = LORAMAC_EVENT_INFO_STATUS_CRYPTO_FAIL;
                 return;
             }
 
-            _params.LoRaMacRxPayload[0] = macHdr.Value;
+            _params.payload[0] = macHdr.value;
 
-            if (0 != LoRaMacJoinComputeMic( _params.LoRaMacRxPayload,
-                                            size - LORAMAC_MFR_LEN,
-                                            _params.keys.LoRaMacAppKey,
-                                            &mic )) {
-                mcps.get_indication().Status = LORAMAC_EVENT_INFO_STATUS_CRYPTO_FAIL;
+            if (0 != LoRaMacJoinComputeMic( _params.payload, size - LORAMAC_MFR_LEN,
+                                            _params.keys.app_key, &mic )) {
+                mcps.get_indication().status = LORAMAC_EVENT_INFO_STATUS_CRYPTO_FAIL;
                 return;
             }
 
-            micRx |= ( uint32_t ) _params.LoRaMacRxPayload[size - LORAMAC_MFR_LEN];
-            micRx |= ( ( uint32_t ) _params.LoRaMacRxPayload[size - LORAMAC_MFR_LEN + 1] << 8 );
-            micRx |= ( ( uint32_t ) _params.LoRaMacRxPayload[size - LORAMAC_MFR_LEN + 2] << 16 );
-            micRx |= ( ( uint32_t ) _params.LoRaMacRxPayload[size - LORAMAC_MFR_LEN + 3] << 24 );
+            micRx |= ( uint32_t ) _params.payload[size - LORAMAC_MFR_LEN];
+            micRx |= ( ( uint32_t ) _params.payload[size - LORAMAC_MFR_LEN + 1] << 8 );
+            micRx |= ( ( uint32_t ) _params.payload[size - LORAMAC_MFR_LEN + 2] << 16 );
+            micRx |= ( ( uint32_t ) _params.payload[size - LORAMAC_MFR_LEN + 3] << 24 );
 
             if( micRx == mic )
             {
-                if (0 != LoRaMacJoinComputeSKeys( _params.keys.LoRaMacAppKey,
-                                                  _params.LoRaMacRxPayload + 1,
-                                                  _params.LoRaMacDevNonce,
-                                                  _params.keys.LoRaMacNwkSKey,
-                                                  _params.keys.LoRaMacAppSKey )) {
-                    mcps.get_indication().Status = LORAMAC_EVENT_INFO_STATUS_CRYPTO_FAIL;
+                if (0 != LoRaMacJoinComputeSKeys( _params.keys.app_key,
+                                                  _params.payload + 1,
+                                                  _params.dev_nonce,
+                                                  _params.keys.nwk_skey,
+                                                  _params.keys.app_skey )) {
+                    mcps.get_indication().status = LORAMAC_EVENT_INFO_STATUS_CRYPTO_FAIL;
                     return;
                 }
 
-                _params.LoRaMacNetID = ( uint32_t ) _params.LoRaMacRxPayload[4];
-                _params.LoRaMacNetID |= ( ( uint32_t ) _params.LoRaMacRxPayload[5] << 8 );
-                _params.LoRaMacNetID |= ( ( uint32_t ) _params.LoRaMacRxPayload[6] << 16 );
+                _params.net_id = ( uint32_t ) _params.payload[4];
+                _params.net_id |= ( ( uint32_t ) _params.payload[5] << 8 );
+                _params.net_id |= ( ( uint32_t ) _params.payload[6] << 16 );
 
-                _params.LoRaMacDevAddr = ( uint32_t ) _params.LoRaMacRxPayload[7];
-                _params.LoRaMacDevAddr |= ( ( uint32_t ) _params.LoRaMacRxPayload[8] << 8 );
-                _params.LoRaMacDevAddr |= ( ( uint32_t ) _params.LoRaMacRxPayload[9] << 16 );
-                _params.LoRaMacDevAddr |= ( ( uint32_t ) _params.LoRaMacRxPayload[10] << 24 );
+                _params.dev_addr = ( uint32_t ) _params.payload[7];
+                _params.dev_addr |= ( ( uint32_t ) _params.payload[8] << 8 );
+                _params.dev_addr |= ( ( uint32_t ) _params.payload[9] << 16 );
+                _params.dev_addr |= ( ( uint32_t ) _params.payload[10] << 24 );
 
                 // DLSettings
-                _params.sys_params.Rx1DrOffset = ( _params.LoRaMacRxPayload[11] >> 4 ) & 0x07;
-                _params.sys_params.Rx2Channel.Datarate = _params.LoRaMacRxPayload[11] & 0x0F;
+                _params.sys_params.rx1_dr_offset = ( _params.payload[11] >> 4 ) & 0x07;
+                _params.sys_params.rx2_channel.datarate = _params.payload[11] & 0x0F;
 
                 // RxDelay
-                _params.sys_params.ReceiveDelay1 = ( _params.LoRaMacRxPayload[12] & 0x0F );
-                if( _params.sys_params.ReceiveDelay1 == 0 )
+                _params.sys_params.recv_delay1 = ( _params.payload[12] & 0x0F );
+                if( _params.sys_params.recv_delay1 == 0 )
                 {
-                    _params.sys_params.ReceiveDelay1 = 1;
+                    _params.sys_params.recv_delay1 = 1;
                 }
-                _params.sys_params.ReceiveDelay1 *= 1000;
-                _params.sys_params.ReceiveDelay2 = _params.sys_params.ReceiveDelay1 + 1000;
+                _params.sys_params.recv_delay1 *= 1000;
+                _params.sys_params.recv_delay2 = _params.sys_params.recv_delay1 + 1000;
 
                 // Apply CF list
-                applyCFList.Payload = &_params.LoRaMacRxPayload[13];
+                applyCFList.Payload = &_params.payload[13];
                 // Size of the regular payload is 12. Plus 1 byte MHDR and 4 bytes MIC
                 applyCFList.Size = size - 17;
 
                 lora_phy->apply_cf_list(&applyCFList);
 
-                mlme.get_confirmation().Status = LORAMAC_EVENT_INFO_STATUS_OK;
-                _params.IsLoRaMacNetworkJoined = true;
+                mlme.get_confirmation().status = LORAMAC_EVENT_INFO_STATUS_OK;
+                _params.is_nwk_joined = true;
             }
             else
             {
-                mlme.get_confirmation().Status = LORAMAC_EVENT_INFO_STATUS_JOIN_FAIL;
+                mlme.get_confirmation().status = LORAMAC_EVENT_INFO_STATUS_JOIN_FAIL;
             }
             break;
         case FRAME_TYPE_DATA_CONFIRMED_DOWN:
         case FRAME_TYPE_DATA_UNCONFIRMED_DOWN:
             {
                 // Check if the received payload size is valid
-                getPhy.UplinkDwellTime = _params.sys_params.DownlinkDwellTime;
-                getPhy.Datarate = mcps.get_indication().RxDatarate;
+                getPhy.UplinkDwellTime = _params.sys_params.downlink_dwell_time;
+                getPhy.Datarate = mcps.get_indication().rx_datarate;
                 getPhy.Attribute = PHY_MAX_PAYLOAD;
 
                 // Get the maximum payload length
-                if( _params.RepeaterSupport == true )
+                if( _params.is_repeater_supported == true )
                 {
                     getPhy.Attribute = PHY_MAX_PAYLOAD_REPEATER;
                 }
                 phyParam = lora_phy->get_phy_params(&getPhy);
                 if( MAX( 0, ( int16_t )( ( int16_t )size - ( int16_t )LORA_MAC_FRMPAYLOAD_OVERHEAD ) ) > (int32_t)phyParam.Value )
                 {
-                    mcps.get_indication().Status = LORAMAC_EVENT_INFO_STATUS_ERROR;
+                    mcps.get_indication().status = LORAMAC_EVENT_INFO_STATUS_ERROR;
                     PrepareRxDoneAbort( );
                     return;
                 }
@@ -441,17 +439,17 @@ void LoRaMac::OnRadioRxDone( uint8_t *payload, uint16_t size, int16_t rssi, int8
                 address |= ( (uint32_t)payload[pktHeaderLen++] << 16 );
                 address |= ( (uint32_t)payload[pktHeaderLen++] << 24 );
 
-                if( address != _params.LoRaMacDevAddr )
+                if( address != _params.dev_addr )
                 {
-                    curMulticastParams = _params.MulticastChannels;
+                    curMulticastParams = _params.multicast_channels;
                     while( curMulticastParams != NULL )
                     {
-                        if( address == curMulticastParams->Address )
+                        if( address == curMulticastParams->address )
                         {
                             multicast = 1;
-                            nwkSKey = curMulticastParams->NwkSKey;
-                            appSKey = curMulticastParams->AppSKey;
-                            downLinkCounter = curMulticastParams->DownLinkCounter;
+                            nwkSKey = curMulticastParams->nwk_skey;
+                            appSKey = curMulticastParams->app_skey;
+                            downLinkCounter = curMulticastParams->dl_frame_counter;
                             break;
                         }
                         curMulticastParams = curMulticastParams->Next;
@@ -459,7 +457,7 @@ void LoRaMac::OnRadioRxDone( uint8_t *payload, uint16_t size, int16_t rssi, int8
                     if( multicast == 0 )
                     {
                         // We are not the destination of this frame.
-                        mcps.get_indication().Status = LORAMAC_EVENT_INFO_STATUS_ADDRESS_FAIL;
+                        mcps.get_indication().status = LORAMAC_EVENT_INFO_STATUS_ADDRESS_FAIL;
                         PrepareRxDoneAbort( );
                         return;
                     }
@@ -467,17 +465,17 @@ void LoRaMac::OnRadioRxDone( uint8_t *payload, uint16_t size, int16_t rssi, int8
                 else
                 {
                     multicast = 0;
-                    nwkSKey = _params.keys.LoRaMacNwkSKey;
-                    appSKey = _params.keys.LoRaMacAppSKey;
-                    downLinkCounter = _params.DownLinkCounter;
+                    nwkSKey = _params.keys.nwk_skey;
+                    appSKey = _params.keys.app_skey;
+                    downLinkCounter = _params.dl_frame_counter;
                 }
 
-                fCtrl.Value = payload[pktHeaderLen++];
+                fCtrl.value = payload[pktHeaderLen++];
 
                 sequenceCounter = ( uint16_t )payload[pktHeaderLen++];
                 sequenceCounter |= ( uint16_t )payload[pktHeaderLen++] << 8;
 
-                appPayloadStartIndex = 8 + fCtrl.Bits.FOptsLen;
+                appPayloadStartIndex = 8 + fCtrl.bits.fopts_len;
 
                 micRx |= ( uint32_t )payload[size - LORAMAC_MFR_LEN];
                 micRx |= ( ( uint32_t )payload[size - LORAMAC_MFR_LEN + 1] << 8 );
@@ -513,50 +511,50 @@ void LoRaMac::OnRadioRxDone( uint8_t *payload, uint16_t size, int16_t rssi, int8
                 phyParam = lora_phy->get_phy_params( &getPhy );
                 if( sequenceCounterDiff >= phyParam.Value )
                 {
-                    mcps.get_indication().Status = LORAMAC_EVENT_INFO_STATUS_DOWNLINK_TOO_MANY_FRAMES_LOSS;
-                    mcps.get_indication().DownLinkCounter = downLinkCounter;
+                    mcps.get_indication().status = LORAMAC_EVENT_INFO_STATUS_DOWNLINK_TOO_MANY_FRAMES_LOSS;
+                    mcps.get_indication().dl_frame_counter = downLinkCounter;
                     PrepareRxDoneAbort( );
                     return;
                 }
 
                 if( isMicOk == true )
                 {
-                    mcps.get_indication().Status = LORAMAC_EVENT_INFO_STATUS_OK;
-                    mcps.get_indication().Multicast = multicast;
-                    mcps.get_indication().FramePending = fCtrl.Bits.FPending;
-                    mcps.get_indication().Buffer = NULL;
-                    mcps.get_indication().BufferSize = 0;
-                    mcps.get_indication().DownLinkCounter = downLinkCounter;
+                    mcps.get_indication().status = LORAMAC_EVENT_INFO_STATUS_OK;
+                    mcps.get_indication().multicast = multicast;
+                    mcps.get_indication().fpending_status = fCtrl.bits.fpending;
+                    mcps.get_indication().buffer = NULL;
+                    mcps.get_indication().buffer_size = 0;
+                    mcps.get_indication().dl_frame_counter = downLinkCounter;
 
-                    mcps.get_confirmation().Status = LORAMAC_EVENT_INFO_STATUS_OK;
+                    mcps.get_confirmation().status = LORAMAC_EVENT_INFO_STATUS_OK;
 
-                    _params.AdrAckCounter = 0;
+                    _params.adr_ack_counter = 0;
                     mac_commands.ClearRepeatBuffer();
 
                     // Update 32 bits downlink counter
                     if( multicast == 1 )
                     {
-                        mcps.get_indication().McpsIndication = MCPS_MULTICAST;
+                        mcps.get_indication().type = MCPS_MULTICAST;
 
-                        if( ( curMulticastParams->DownLinkCounter == downLinkCounter ) &&
-                            ( curMulticastParams->DownLinkCounter != 0 ) )
+                        if( ( curMulticastParams->dl_frame_counter == downLinkCounter ) &&
+                            ( curMulticastParams->dl_frame_counter != 0 ) )
                         {
-                            mcps.get_indication().Status = LORAMAC_EVENT_INFO_STATUS_DOWNLINK_REPEATED;
-                            mcps.get_indication().DownLinkCounter = downLinkCounter;
+                            mcps.get_indication().status = LORAMAC_EVENT_INFO_STATUS_DOWNLINK_REPEATED;
+                            mcps.get_indication().dl_frame_counter = downLinkCounter;
                             PrepareRxDoneAbort( );
                             return;
                         }
-                        curMulticastParams->DownLinkCounter = downLinkCounter;
+                        curMulticastParams->dl_frame_counter = downLinkCounter;
                     }
                     else
                     {
-                        if( macHdr.Bits.MType == FRAME_TYPE_DATA_CONFIRMED_DOWN )
+                        if( macHdr.bits.mtype == FRAME_TYPE_DATA_CONFIRMED_DOWN )
                         {
-                            _params.SrvAckRequested = true;
-                            mcps.get_indication().McpsIndication = MCPS_CONFIRMED;
+                            _params.is_srv_ack_requested = true;
+                            mcps.get_indication().type = MCPS_CONFIRMED;
 
-                            if( ( _params.DownLinkCounter == downLinkCounter ) &&
-                                ( _params.DownLinkCounter != 0 ) )
+                            if( ( _params.dl_frame_counter == downLinkCounter ) &&
+                                ( _params.dl_frame_counter != 0 ) )
                             {
                                 // Duplicated confirmed downlink. Skip indication.
                                 // In this case, the MAC layer shall accept the MAC commands
@@ -568,28 +566,28 @@ void LoRaMac::OnRadioRxDone( uint8_t *payload, uint16_t size, int16_t rssi, int8
                         }
                         else
                         {
-                            _params.SrvAckRequested = false;
-                            mcps.get_indication().McpsIndication = MCPS_UNCONFIRMED;
+                            _params.is_srv_ack_requested = false;
+                            mcps.get_indication().type = MCPS_UNCONFIRMED;
 
-                            if( ( _params.DownLinkCounter == downLinkCounter ) &&
-                                ( _params.DownLinkCounter != 0 ) )
+                            if( ( _params.dl_frame_counter == downLinkCounter ) &&
+                                ( _params.dl_frame_counter != 0 ) )
                             {
-                                mcps.get_indication().Status = LORAMAC_EVENT_INFO_STATUS_DOWNLINK_REPEATED;
-                                mcps.get_indication().DownLinkCounter = downLinkCounter;
+                                mcps.get_indication().status = LORAMAC_EVENT_INFO_STATUS_DOWNLINK_REPEATED;
+                                mcps.get_indication().dl_frame_counter = downLinkCounter;
                                 PrepareRxDoneAbort( );
                                 return;
                             }
                         }
-                        _params.DownLinkCounter = downLinkCounter;
+                        _params.dl_frame_counter = downLinkCounter;
                     }
 
                     // This must be done before parsing the payload and the MAC commands.
                     // We need to reset the MacCommandsBufferIndex here, since we need
                     // to take retransmissions and repetitions into account. Error cases
                     // will be handled in function OnMacStateCheckTimerEvent.
-                    if( mcps.get_confirmation().McpsRequest == MCPS_CONFIRMED )
+                    if( mcps.get_confirmation().req_type == MCPS_CONFIRMED )
                     {
-                        if( fCtrl.Bits.Ack == 1 )
+                        if( fCtrl.bits.ack == 1 )
                         {// Reset MacCommandsBufferIndex when we have received an ACK.
                             mac_commands.ClearCommandBuffer();
                         }
@@ -605,12 +603,12 @@ void LoRaMac::OnRadioRxDone( uint8_t *payload, uint16_t size, int16_t rssi, int8
                         port = payload[appPayloadStartIndex++];
                         frameLen = ( size - 4 ) - appPayloadStartIndex;
 
-                        mcps.get_indication().Port = port;
+                        mcps.get_indication().port = port;
 
                         if( port == 0 )
                         {
                             // Only allow frames which do not have fOpts
-                            if( fCtrl.Bits.FOptsLen == 0 )
+                            if( fCtrl.bits.fopts_len == 0 )
                             {
                                 if (0 != LoRaMacPayloadDecrypt( payload + appPayloadStartIndex,
                                                                 frameLen,
@@ -618,13 +616,13 @@ void LoRaMac::OnRadioRxDone( uint8_t *payload, uint16_t size, int16_t rssi, int8
                                                                 address,
                                                                 DOWN_LINK,
                                                                 downLinkCounter,
-                                                                _params.LoRaMacRxPayload )) {
-                                    mcps.get_indication().Status =  LORAMAC_EVENT_INFO_STATUS_CRYPTO_FAIL;
+                                                                _params.payload )) {
+                                    mcps.get_indication().status =  LORAMAC_EVENT_INFO_STATUS_CRYPTO_FAIL;
                                 }
 
                                 // Decode frame payload MAC commands
-                                mac_commands.ProcessMacCommands( _params.LoRaMacRxPayload, 0, frameLen, snr,
-                                                                 mlme.get_confirmation(), LoRaMacCallbacks,
+                                mac_commands.ProcessMacCommands( _params.payload, 0, frameLen, snr,
+                                                                 mlme.get_confirmation(),
                                                                  _params.sys_params, *lora_phy );
                             }
                             else
@@ -634,11 +632,11 @@ void LoRaMac::OnRadioRxDone( uint8_t *payload, uint16_t size, int16_t rssi, int8
                         }
                         else
                         {
-                            if( fCtrl.Bits.FOptsLen > 0 )
+                            if( fCtrl.bits.fopts_len > 0 )
                             {
                                 // Decode Options field MAC commands. Omit the fPort.
                                 mac_commands.ProcessMacCommands( payload, 8, appPayloadStartIndex - 1, snr,
-                                                                 mlme.get_confirmation(), LoRaMacCallbacks,
+                                                                 mlme.get_confirmation(),
                                                                  _params.sys_params, *lora_phy );
                             }
 
@@ -648,25 +646,25 @@ void LoRaMac::OnRadioRxDone( uint8_t *payload, uint16_t size, int16_t rssi, int8
                                                             address,
                                                             DOWN_LINK,
                                                             downLinkCounter,
-                                                            _params.LoRaMacRxPayload )) {
-                                mcps.get_indication().Status =  LORAMAC_EVENT_INFO_STATUS_CRYPTO_FAIL;
+                                                            _params.payload )) {
+                                mcps.get_indication().status =  LORAMAC_EVENT_INFO_STATUS_CRYPTO_FAIL;
                             }
 
                             if( skipIndication == false )
                             {
-                                mcps.get_indication().Buffer = _params.LoRaMacRxPayload;
-                                mcps.get_indication().BufferSize = frameLen;
-                                mcps.get_indication().RxData = true;
+                                mcps.get_indication().buffer = _params.payload;
+                                mcps.get_indication().buffer_size = frameLen;
+                                mcps.get_indication().is_data_recvd = true;
                             }
                         }
                     }
                     else
                     {
-                        if( fCtrl.Bits.FOptsLen > 0 )
+                        if( fCtrl.bits.fopts_len > 0 )
                         {
                             // Decode Options field MAC commands
                             mac_commands.ProcessMacCommands( payload, 8, appPayloadStartIndex, snr,
-                                                             mlme.get_confirmation(), LoRaMacCallbacks,
+                                                             mlme.get_confirmation(),
                                                              _params.sys_params, *lora_phy );
                         }
                     }
@@ -674,35 +672,35 @@ void LoRaMac::OnRadioRxDone( uint8_t *payload, uint16_t size, int16_t rssi, int8
                     if( skipIndication == false )
                     {
                         // Check if the frame is an acknowledgement
-                        if( fCtrl.Bits.Ack == 1 )
+                        if( fCtrl.bits.ack == 1 )
                         {
-                            mcps.get_confirmation().AckReceived = true;
-                            mcps.get_indication().AckReceived = true;
+                            mcps.get_confirmation().ack_received = true;
+                            mcps.get_indication().is_ack_recvd = true;
 
                             // Stop the AckTimeout timer as no more retransmissions
                             // are needed.
-                            _lora_time.TimerStop( &_params.timers.AckTimeoutTimer );
+                            _lora_time.TimerStop( &_params.timers.ack_timeout_timer );
                         }
                         else
                         {
-                            mcps.get_confirmation().AckReceived = false;
+                            mcps.get_confirmation().ack_received = false;
 
-                            if( _params.AckTimeoutRetriesCounter > _params.AckTimeoutRetries )
+                            if( _params.ack_timeout_retry_counter > _params.max_ack_timeout_retries )
                             {
                                 // Stop the AckTimeout timer as no more retransmissions
                                 // are needed.
-                                _lora_time.TimerStop( &_params.timers.AckTimeoutTimer );
+                                _lora_time.TimerStop( &_params.timers.ack_timeout_timer );
                             }
                         }
                     }
                     // Provide always an indication, skip the callback to the user application,
                     // in case of a confirmed downlink retransmission.
-                    _params.LoRaMacFlags.Bits.McpsInd = 1;
-                    _params.LoRaMacFlags.Bits.McpsIndSkip = skipIndication;
+                    _params.flags.bits.mcps_ind = 1;
+                    _params.flags.bits.mcps_ind_skip = skipIndication;
                 }
                 else
                 {
-                    mcps.get_indication().Status = LORAMAC_EVENT_INFO_STATUS_MIC_FAIL;
+                    mcps.get_indication().status = LORAMAC_EVENT_INFO_STATUS_MIC_FAIL;
 
                     PrepareRxDoneAbort( );
                     return;
@@ -711,31 +709,31 @@ void LoRaMac::OnRadioRxDone( uint8_t *payload, uint16_t size, int16_t rssi, int8
             break;
         case FRAME_TYPE_PROPRIETARY:
             {
-                memcpy( _params.LoRaMacRxPayload, &payload[pktHeaderLen], size );
+                memcpy( _params.payload, &payload[pktHeaderLen], size );
 
-                mcps.get_indication().McpsIndication = MCPS_PROPRIETARY;
-                mcps.get_indication().Status = LORAMAC_EVENT_INFO_STATUS_OK;
-                mcps.get_indication().Buffer = _params.LoRaMacRxPayload;
-                mcps.get_indication().BufferSize = size - pktHeaderLen;
+                mcps.get_indication().type = MCPS_PROPRIETARY;
+                mcps.get_indication().status = LORAMAC_EVENT_INFO_STATUS_OK;
+                mcps.get_indication().buffer = _params.payload;
+                mcps.get_indication().buffer_size = size - pktHeaderLen;
 
-                _params.LoRaMacFlags.Bits.McpsInd = 1;
+                _params.flags.bits.mcps_ind = 1;
                 break;
             }
         default:
-            mcps.get_indication().Status = LORAMAC_EVENT_INFO_STATUS_ERROR;
+            mcps.get_indication().status = LORAMAC_EVENT_INFO_STATUS_ERROR;
             PrepareRxDoneAbort( );
             break;
     }
-    _params.LoRaMacFlags.Bits.MacDone = 1;
+    _params.flags.bits.mac_done = 1;
 
     // Trig OnMacCheckTimerEvent call as soon as possible
-    _lora_time.TimerSetValue( &_params.timers.MacStateCheckTimer, 1 );
-    _lora_time.TimerStart( &_params.timers.MacStateCheckTimer );
+    _lora_time.TimerSetValue( &_params.timers.mac_state_check_timer, 1 );
+    _lora_time.TimerStart( &_params.timers.mac_state_check_timer );
 }
 
 void LoRaMac::OnRadioTxTimeout( void )
 {
-    if( _params.LoRaMacDeviceClass != CLASS_C )
+    if( _params.dev_class != CLASS_C )
     {
         lora_phy->put_radio_to_sleep();
     }
@@ -744,16 +742,16 @@ void LoRaMac::OnRadioTxTimeout( void )
         OpenContinuousRx2Window( );
     }
 
-    mcps.get_confirmation().Status = LORAMAC_EVENT_INFO_STATUS_TX_TIMEOUT;
+    mcps.get_confirmation().status = LORAMAC_EVENT_INFO_STATUS_TX_TIMEOUT;
 
-    mlme.get_confirmation().Status = LORAMAC_EVENT_INFO_STATUS_TX_TIMEOUT;
+    mlme.get_confirmation().status = LORAMAC_EVENT_INFO_STATUS_TX_TIMEOUT;
 
-    _params.LoRaMacFlags.Bits.MacDone = 1;
+    _params.flags.bits.mac_done = 1;
 }
 
 void LoRaMac::OnRadioRxError( void )
 {
-    if( _params.LoRaMacDeviceClass != CLASS_C )
+    if( _params.dev_class != CLASS_C )
     {
         lora_phy->put_radio_to_sleep();
     }
@@ -762,37 +760,37 @@ void LoRaMac::OnRadioRxError( void )
         OpenContinuousRx2Window( );
     }
 
-    if( _params.RxSlot == RX_SLOT_WIN_1 )
+    if( _params.rx_slot == RX_SLOT_WIN_1 )
     {
-        if( _params.NodeAckRequested == true )
+        if( _params.is_node_ack_requested == true )
         {
-            mcps.get_confirmation().Status = LORAMAC_EVENT_INFO_STATUS_RX1_ERROR;
+            mcps.get_confirmation().status = LORAMAC_EVENT_INFO_STATUS_RX1_ERROR;
         }
 
-        mlme.get_confirmation().Status = LORAMAC_EVENT_INFO_STATUS_RX1_ERROR;
+        mlme.get_confirmation().status = LORAMAC_EVENT_INFO_STATUS_RX1_ERROR;
 
-        if( _lora_time.TimerGetElapsedTime( _params.timers.AggregatedLastTxDoneTime ) >= _params.RxWindow2Delay )
+        if( _lora_time.TimerGetElapsedTime( _params.timers.aggregated_last_tx_time ) >= _params.rx_window2_delay )
         {
-            _lora_time.TimerStop( &_params.timers.RxWindowTimer2 );
-            _params.LoRaMacFlags.Bits.MacDone = 1;
+            _lora_time.TimerStop( &_params.timers.rx_window2_timer );
+            _params.flags.bits.mac_done = 1;
         }
     }
     else
     {
-        if( _params.NodeAckRequested == true )
+        if( _params.is_node_ack_requested == true )
         {
-            mcps.get_confirmation().Status = LORAMAC_EVENT_INFO_STATUS_RX2_ERROR;
+            mcps.get_confirmation().status = LORAMAC_EVENT_INFO_STATUS_RX2_ERROR;
         }
 
-        mlme.get_confirmation().Status = LORAMAC_EVENT_INFO_STATUS_RX2_ERROR;
+        mlme.get_confirmation().status = LORAMAC_EVENT_INFO_STATUS_RX2_ERROR;
 
-        _params.LoRaMacFlags.Bits.MacDone = 1;
+        _params.flags.bits.mac_done = 1;
     }
 }
 
 void LoRaMac::OnRadioRxTimeout( void )
 {
-    if( _params.LoRaMacDeviceClass != CLASS_C )
+    if( _params.dev_class != CLASS_C )
     {
         lora_phy->put_radio_to_sleep();
     }
@@ -801,32 +799,32 @@ void LoRaMac::OnRadioRxTimeout( void )
         OpenContinuousRx2Window( );
     }
 
-    if( _params.RxSlot == RX_SLOT_WIN_1 )
+    if( _params.rx_slot == RX_SLOT_WIN_1 )
     {
-        if( _params.NodeAckRequested == true )
+        if( _params.is_node_ack_requested == true )
         {
-            mcps.get_confirmation().Status = LORAMAC_EVENT_INFO_STATUS_RX1_TIMEOUT;
+            mcps.get_confirmation().status = LORAMAC_EVENT_INFO_STATUS_RX1_TIMEOUT;
         }
-        mlme.get_confirmation().Status = LORAMAC_EVENT_INFO_STATUS_RX1_TIMEOUT;
+        mlme.get_confirmation().status = LORAMAC_EVENT_INFO_STATUS_RX1_TIMEOUT;
 
-        if( _lora_time.TimerGetElapsedTime( _params.timers.AggregatedLastTxDoneTime ) >= _params.RxWindow2Delay )
+        if( _lora_time.TimerGetElapsedTime( _params.timers.aggregated_last_tx_time ) >= _params.rx_window2_delay )
         {
-            _lora_time.TimerStop( &_params.timers.RxWindowTimer2 );
-            _params.LoRaMacFlags.Bits.MacDone = 1;
+            _lora_time.TimerStop( &_params.timers.rx_window2_timer );
+            _params.flags.bits.mac_done = 1;
         }
     }
     else
     {
-        if( _params.NodeAckRequested == true )
+        if( _params.is_node_ack_requested == true )
         {
-            mcps.get_confirmation().Status = LORAMAC_EVENT_INFO_STATUS_RX2_TIMEOUT;
+            mcps.get_confirmation().status = LORAMAC_EVENT_INFO_STATUS_RX2_TIMEOUT;
         }
 
-        mlme.get_confirmation().Status = LORAMAC_EVENT_INFO_STATUS_RX2_TIMEOUT;
+        mlme.get_confirmation().status = LORAMAC_EVENT_INFO_STATUS_RX2_TIMEOUT;
 
-        if( _params.LoRaMacDeviceClass != CLASS_C )
+        if( _params.dev_class != CLASS_C )
         {
-            _params.LoRaMacFlags.Bits.MacDone = 1;
+            _params.flags.bits.mac_done = 1;
         }
     }
 }
@@ -840,54 +838,54 @@ void LoRaMac::OnMacStateCheckTimerEvent( void )
     PhyParam_t phyParam;
     bool txTimeout = false;
 
-    _lora_time.TimerStop( &_params.timers.MacStateCheckTimer );
+    _lora_time.TimerStop( &_params.timers.mac_state_check_timer );
 
-    if( _params.LoRaMacFlags.Bits.MacDone == 1 )
+    if( _params.flags.bits.mac_done == 1 )
     {
-        if( ( _params.LoRaMacState & LORAMAC_RX_ABORT ) == LORAMAC_RX_ABORT )
+        if( ( _params.mac_state & LORAMAC_RX_ABORT ) == LORAMAC_RX_ABORT )
         {
-            _params.LoRaMacState &= ~LORAMAC_RX_ABORT;
-            _params.LoRaMacState &= ~LORAMAC_TX_RUNNING;
+            _params.mac_state &= ~LORAMAC_RX_ABORT;
+            _params.mac_state &= ~LORAMAC_TX_RUNNING;
         }
 
-        if( ( _params.LoRaMacFlags.Bits.MlmeReq == 1 ) || ( ( _params.LoRaMacFlags.Bits.McpsReq == 1 ) ) )
+        if( ( _params.flags.bits.mlme_req == 1 ) || ( ( _params.flags.bits.mcps_req == 1 ) ) )
         {
-            if( ( mcps.get_confirmation().Status == LORAMAC_EVENT_INFO_STATUS_TX_TIMEOUT ) ||
-                ( mlme.get_confirmation().Status == LORAMAC_EVENT_INFO_STATUS_TX_TIMEOUT ) )
+            if( ( mcps.get_confirmation().status == LORAMAC_EVENT_INFO_STATUS_TX_TIMEOUT ) ||
+                ( mlme.get_confirmation().status == LORAMAC_EVENT_INFO_STATUS_TX_TIMEOUT ) )
             {
                 // Stop transmit cycle due to tx timeout.
-                _params.LoRaMacState &= ~LORAMAC_TX_RUNNING;
+                _params.mac_state &= ~LORAMAC_TX_RUNNING;
                 mac_commands.ClearCommandBuffer();
-                mcps.get_confirmation().NbRetries = _params.AckTimeoutRetriesCounter;
-                mcps.get_confirmation().AckReceived = false;
-                mcps.get_confirmation().TxTimeOnAir = 0;
+                mcps.get_confirmation().nb_retries = _params.ack_timeout_retry_counter;
+                mcps.get_confirmation().ack_received = false;
+                mcps.get_confirmation().tx_toa = 0;
                 txTimeout = true;
             }
         }
 
-        if( ( _params.NodeAckRequested == false ) && ( txTimeout == false ) )
+        if( ( _params.is_node_ack_requested == false ) && ( txTimeout == false ) )
         {
-            if( ( _params.LoRaMacFlags.Bits.MlmeReq == 1 ) || ( ( _params.LoRaMacFlags.Bits.McpsReq == 1 ) ) )
+            if( ( _params.flags.bits.mlme_req == 1 ) || ( ( _params.flags.bits.mcps_req == 1 ) ) )
             {
-                if( ( _params.LoRaMacFlags.Bits.MlmeReq == 1 ) && ( mlme.get_confirmation().MlmeRequest == MLME_JOIN ) )
+                if( ( _params.flags.bits.mlme_req == 1 ) && ( mlme.get_confirmation().req_type == MLME_JOIN ) )
                 {// Procedure for the join request
-                    mlme.get_confirmation().NbRetries = _params.JoinRequestTrials;
+                    mlme.get_confirmation().nb_retries = _params.join_request_trial_counter;
 
-                    if( mlme.get_confirmation().Status == LORAMAC_EVENT_INFO_STATUS_OK )
+                    if( mlme.get_confirmation().status == LORAMAC_EVENT_INFO_STATUS_OK )
                     {// Node joined successfully
-                        _params.UpLinkCounter = 0;
-                        _params.ChannelsNbRepCounter = 0;
-                        _params.LoRaMacState &= ~LORAMAC_TX_RUNNING;
+                        _params.ul_frame_counter = 0;
+                        _params.ul_nb_rep_counter = 0;
+                        _params.mac_state &= ~LORAMAC_TX_RUNNING;
                     }
                     else
                     {
-                        if( _params.JoinRequestTrials >= _params.MaxJoinRequestTrials )
+                        if( _params.join_request_trial_counter >= _params.max_join_request_trials )
                         {
-                            _params.LoRaMacState &= ~LORAMAC_TX_RUNNING;
+                            _params.mac_state &= ~LORAMAC_TX_RUNNING;
                         }
                         else
                         {
-                            _params.LoRaMacFlags.Bits.MacDone = 0;
+                            _params.flags.bits.mac_done = 0;
                             // Sends the same frame again
                             handle_delayed_tx_timer_event();
                         }
@@ -895,27 +893,27 @@ void LoRaMac::OnMacStateCheckTimerEvent( void )
                 }
                 else
                 {// Procedure for all other frames
-                    if( ( _params.ChannelsNbRepCounter >= _params.sys_params.ChannelsNbRep ) || ( _params.LoRaMacFlags.Bits.McpsInd == 1 ) )
+                    if( ( _params.ul_nb_rep_counter >= _params.sys_params.retry_num ) || ( _params.flags.bits.mcps_ind == 1 ) )
                     {
-                        if( _params.LoRaMacFlags.Bits.McpsInd == 0 )
+                        if( _params.flags.bits.mcps_ind == 0 )
                         {   // Maximum repetitions without downlink. Reset MacCommandsBufferIndex. Increase ADR Ack counter.
                             // Only process the case when the MAC did not receive a downlink.
                             mac_commands.ClearCommandBuffer();
-                            _params.AdrAckCounter++;
+                            _params.adr_ack_counter++;
                         }
 
-                        _params.ChannelsNbRepCounter = 0;
+                        _params.ul_nb_rep_counter = 0;
 
-                        if( _params.IsUpLinkCounterFixed == false )
+                        if( _params.is_ul_frame_counter_fixed == false )
                         {
-                            _params.UpLinkCounter++;
+                            _params.ul_frame_counter++;
                         }
 
-                        _params.LoRaMacState &= ~LORAMAC_TX_RUNNING;
+                        _params.mac_state &= ~LORAMAC_TX_RUNNING;
                     }
                     else
                     {
-                        _params.LoRaMacFlags.Bits.MacDone = 0;
+                        _params.flags.bits.mac_done = 0;
                         // Sends the same frame again
                         handle_delayed_tx_timer_event();
                     }
@@ -923,58 +921,58 @@ void LoRaMac::OnMacStateCheckTimerEvent( void )
             }
         }
 
-        if( _params.LoRaMacFlags.Bits.McpsInd == 1 )
+        if( _params.flags.bits.mcps_ind == 1 )
         {// Procedure if we received a frame
-            if( ( mcps.get_confirmation().AckReceived == true ) ||
-                ( _params.AckTimeoutRetriesCounter > _params.AckTimeoutRetries ) )
+            if( ( mcps.get_confirmation().ack_received == true ) ||
+                ( _params.ack_timeout_retry_counter > _params.max_ack_timeout_retries ) )
             {
-                _params.AckTimeoutRetry = false;
-                _params.NodeAckRequested = false;
-                if( _params.IsUpLinkCounterFixed == false )
+                _params.is_ack_retry_timeout_expired = false;
+                _params.is_node_ack_requested = false;
+                if( _params.is_ul_frame_counter_fixed == false )
                 {
-                    _params.UpLinkCounter++;
+                    _params.ul_frame_counter++;
                 }
-                mcps.get_confirmation().NbRetries = _params.AckTimeoutRetriesCounter;
+                mcps.get_confirmation().nb_retries = _params.ack_timeout_retry_counter;
 
-                _params.LoRaMacState &= ~LORAMAC_TX_RUNNING;
+                _params.mac_state &= ~LORAMAC_TX_RUNNING;
             }
         }
 
-        if( ( _params.AckTimeoutRetry == true ) && ( ( _params.LoRaMacState & LORAMAC_TX_DELAYED ) == 0 ) )
+        if( ( _params.is_ack_retry_timeout_expired == true ) && ( ( _params.mac_state & LORAMAC_TX_DELAYED ) == 0 ) )
         {// Retransmissions procedure for confirmed uplinks
-            _params.AckTimeoutRetry = false;
-            if( ( _params.AckTimeoutRetriesCounter < _params.AckTimeoutRetries ) &&
-                ( _params.AckTimeoutRetriesCounter <= MAX_ACK_RETRIES ) )
+            _params.is_ack_retry_timeout_expired = false;
+            if( ( _params.ack_timeout_retry_counter < _params.max_ack_timeout_retries ) &&
+                ( _params.ack_timeout_retry_counter <= MAX_ACK_RETRIES ) )
             {
-                _params.AckTimeoutRetriesCounter++;
+                _params.ack_timeout_retry_counter++;
 
-                if( ( _params.AckTimeoutRetriesCounter % 2 ) == 1 )
+                if( ( _params.ack_timeout_retry_counter % 2 ) == 1 )
                 {
                     getPhy.Attribute = PHY_NEXT_LOWER_TX_DR;
-                    getPhy.UplinkDwellTime = _params.sys_params.UplinkDwellTime;
-                    getPhy.Datarate = _params.sys_params.ChannelsDatarate;
+                    getPhy.UplinkDwellTime = _params.sys_params.uplink_dwell_time;
+                    getPhy.Datarate = _params.sys_params.channel_data_rate;
                     phyParam = lora_phy->get_phy_params( &getPhy );
-                    _params.sys_params.ChannelsDatarate = phyParam.Value;
+                    _params.sys_params.channel_data_rate = phyParam.Value;
                 }
                 // Try to send the frame again
-                if( ScheduleTx( ) == LORAMAC_STATUS_OK )
+                if( ScheduleTx( ) == LORAWAN_STATUS_OK )
                 {
-                    _params.LoRaMacFlags.Bits.MacDone = 0;
+                    _params.flags.bits.mac_done = 0;
                 }
                 else
                 {
                     // The DR is not applicable for the payload size
-                    mcps.get_confirmation().Status = LORAMAC_EVENT_INFO_STATUS_TX_DR_PAYLOAD_SIZE_ERROR;
+                    mcps.get_confirmation().status = LORAMAC_EVENT_INFO_STATUS_TX_DR_PAYLOAD_SIZE_ERROR;
 
                     mac_commands.ClearCommandBuffer();
-                    _params.LoRaMacState &= ~LORAMAC_TX_RUNNING;
-                    _params.NodeAckRequested = false;
-                    mcps.get_confirmation().AckReceived = false;
-                    mcps.get_confirmation().NbRetries = _params.AckTimeoutRetriesCounter;
-                    mcps.get_confirmation().Datarate = _params.sys_params.ChannelsDatarate;
-                    if( _params.IsUpLinkCounterFixed == false )
+                    _params.mac_state &= ~LORAMAC_TX_RUNNING;
+                    _params.is_node_ack_requested = false;
+                    mcps.get_confirmation().ack_received = false;
+                    mcps.get_confirmation().nb_retries = _params.ack_timeout_retry_counter;
+                    mcps.get_confirmation().data_rate = _params.sys_params.channel_data_rate;
+                    if( _params.is_ul_frame_counter_fixed == false )
                     {
-                        _params.UpLinkCounter++;
+                        _params.ul_frame_counter++;
                     }
                 }
             }
@@ -982,36 +980,36 @@ void LoRaMac::OnMacStateCheckTimerEvent( void )
             {
                 lora_phy->load_defaults(INIT_TYPE_RESTORE);
 
-                _params.LoRaMacState &= ~LORAMAC_TX_RUNNING;
+                _params.mac_state &= ~LORAMAC_TX_RUNNING;
 
                 mac_commands.ClearCommandBuffer();
-                _params.NodeAckRequested = false;
-                mcps.get_confirmation().AckReceived = false;
-                mcps.get_confirmation().NbRetries = _params.AckTimeoutRetriesCounter;
-                if( _params.IsUpLinkCounterFixed == false )
+                _params.is_node_ack_requested = false;
+                mcps.get_confirmation().ack_received = false;
+                mcps.get_confirmation().nb_retries = _params.ack_timeout_retry_counter;
+                if( _params.is_ul_frame_counter_fixed == false )
                 {
-                    _params.UpLinkCounter++;
+                    _params.ul_frame_counter++;
                 }
             }
         }
     }
     // Handle reception for Class B and Class C
-    if( ( _params.LoRaMacState & LORAMAC_RX ) == LORAMAC_RX )
+    if( ( _params.mac_state & LORAMAC_RX ) == LORAMAC_RX )
     {
-        _params.LoRaMacState &= ~LORAMAC_RX;
+        _params.mac_state &= ~LORAMAC_RX;
     }
-    if( _params.LoRaMacState == LORAMAC_IDLE )
+    if( _params.mac_state == LORAMAC_IDLE )
     {
-        if( _params.LoRaMacFlags.Bits.McpsReq == 1 )
+        if( _params.flags.bits.mcps_req == 1 )
         {
-            _params.LoRaMacFlags.Bits.McpsReq = 0;
-            LoRaMacPrimitives->MacMcpsConfirm( &mcps.get_confirmation() );
+            _params.flags.bits.mcps_req = 0;
+            LoRaMacPrimitives->mcps_confirm( &mcps.get_confirmation() );
         }
 
-        if( _params.LoRaMacFlags.Bits.MlmeReq == 1 )
+        if( _params.flags.bits.mlme_req == 1 )
         {
-            _params.LoRaMacFlags.Bits.MlmeReq = 0;
-            LoRaMacPrimitives->MacMlmeConfirm(&mlme.get_confirmation());
+            _params.flags.bits.mlme_req = 0;
+            LoRaMacPrimitives->mlme_confirm(&mlme.get_confirmation());
         }
 
         // Verify if sticky MAC commands are pending or not
@@ -1021,60 +1019,60 @@ void LoRaMac::OnMacStateCheckTimerEvent( void )
         }
 
         // Procedure done. Reset variables.
-        _params.LoRaMacFlags.Bits.MacDone = 0;
+        _params.flags.bits.mac_done = 0;
     }
     else
     {
         // Operation not finished restart timer
-        _lora_time.TimerSetValue( &_params.timers.MacStateCheckTimer,
+        _lora_time.TimerSetValue( &_params.timers.mac_state_check_timer,
                                   MAC_STATE_CHECK_TIMEOUT );
-        _lora_time.TimerStart( &_params.timers.MacStateCheckTimer );
+        _lora_time.TimerStart( &_params.timers.mac_state_check_timer );
     }
 
     // Handle MCPS indication
-    if( _params.LoRaMacFlags.Bits.McpsInd == 1 )
+    if( _params.flags.bits.mcps_ind == 1 )
     {
-        _params.LoRaMacFlags.Bits.McpsInd = 0;
-        if( _params.LoRaMacDeviceClass == CLASS_C )
+        _params.flags.bits.mcps_ind = 0;
+        if( _params.dev_class== CLASS_C )
         {// Activate RX2 window for Class C
             OpenContinuousRx2Window( );
         }
-        if( _params.LoRaMacFlags.Bits.McpsIndSkip == 0 )
+        if( _params.flags.bits.mcps_ind_skip == 0 )
         {
-            LoRaMacPrimitives->MacMcpsIndication( &mcps.get_indication() );
+            LoRaMacPrimitives->mcps_indication( &mcps.get_indication() );
         }
-        _params.LoRaMacFlags.Bits.McpsIndSkip = 0;
+        _params.flags.bits.mcps_ind_skip = 0;
     }
 
     // Handle MLME indication
-    if( _params.LoRaMacFlags.Bits.MlmeInd == 1 )
+    if( _params.flags.bits.mlme_ind == 1 )
     {
-        _params.LoRaMacFlags.Bits.MlmeInd = 0;
-        LoRaMacPrimitives->MacMlmeIndication(&mlme.get_indication());
+        _params.flags.bits.mlme_ind = 0;
+        LoRaMacPrimitives->mlme_indication(&mlme.get_indication());
     }
 }
 
 void LoRaMac::OnTxDelayedTimerEvent( void )
 {
-    LoRaMacHeader_t macHdr;
-    LoRaMacFrameCtrl_t fCtrl;
+    loramac_mhdr_t macHdr;
+    loramac_frame_ctrl_t fCtrl;
     AlternateDrParams_t altDr;
 
-    _lora_time.TimerStop( &_params.timers.TxDelayedTimer );
-    _params.LoRaMacState &= ~LORAMAC_TX_DELAYED;
+    _lora_time.TimerStop( &_params.timers.tx_delayed_timer );
+    _params.mac_state &= ~LORAMAC_TX_DELAYED;
 
-    if( ( _params.LoRaMacFlags.Bits.MlmeReq == 1 ) && ( mlme.get_confirmation().MlmeRequest == MLME_JOIN ) )
+    if( ( _params.flags.bits.mlme_req == 1 ) && ( mlme.get_confirmation().req_type == MLME_JOIN ) )
     {
         ResetMacParameters( );
 
-        altDr.NbTrials = _params.JoinRequestTrials + 1;
-        _params.sys_params.ChannelsDatarate = lora_phy->get_alternate_DR(&altDr);
+        altDr.NbTrials = _params.join_request_trial_counter + 1;
+        _params.sys_params.channel_data_rate = lora_phy->get_alternate_DR(&altDr);
 
-        macHdr.Value = 0;
-        macHdr.Bits.MType = FRAME_TYPE_JOIN_REQ;
+        macHdr.value = 0;
+        macHdr.bits.mtype = FRAME_TYPE_JOIN_REQ;
 
-        fCtrl.Value = 0;
-        fCtrl.Bits.Adr = _params.sys_params.AdrCtrlOn;
+        fCtrl.value = 0;
+        fCtrl.bits.adr = _params.sys_params.adr_on;
 
         /* In case of join request retransmissions, the stack must prepare
          * the frame again, because the network server keeps track of the random
@@ -1087,64 +1085,64 @@ void LoRaMac::OnTxDelayedTimerEvent( void )
 
 void LoRaMac::OnRxWindow1TimerEvent( void )
 {
-    _lora_time.TimerStop( &_params.timers.RxWindowTimer1 );
-    _params.RxSlot = RX_SLOT_WIN_1;
+    _lora_time.TimerStop( &_params.timers.rx_window1_timer );
+    _params.rx_slot= RX_SLOT_WIN_1;
 
-    _params.RxWindow1Config.Channel = _params.Channel;
-    _params.RxWindow1Config.DrOffset = _params.sys_params.Rx1DrOffset;
-    _params.RxWindow1Config.DownlinkDwellTime = _params.sys_params.DownlinkDwellTime;
-    _params.RxWindow1Config.RepeaterSupport = _params.RepeaterSupport;
-    _params.RxWindow1Config.RxContinuous = false;
-    _params.RxWindow1Config.RxSlot = _params.RxSlot;
+    _params.rx_window1_config.channel = _params.channel;
+    _params.rx_window1_config.dr_offset = _params.sys_params.rx1_dr_offset;
+    _params.rx_window1_config.dl_dwell_time = _params.sys_params.downlink_dwell_time;
+    _params.rx_window1_config.is_repeater_supported = _params.is_repeater_supported;
+    _params.rx_window1_config.is_rx_continuous = false;
+    _params.rx_window1_config.rx_slot = _params.rx_slot;
 
-    if( _params.LoRaMacDeviceClass == CLASS_C )
+    if( _params.dev_class== CLASS_C )
     {
         lora_phy->put_radio_to_standby();
     }
 
-    lora_phy->rx_config(&_params.RxWindow1Config, ( int8_t* )&mcps.get_indication().RxDatarate);
-    RxWindowSetup( _params.RxWindow1Config.RxContinuous, _params.sys_params.MaxRxWindow );
+    lora_phy->rx_config(&_params.rx_window1_config, ( int8_t* )&mcps.get_indication().rx_datarate);
+    RxWindowSetup( _params.rx_window1_config.is_rx_continuous, _params.sys_params.max_rx_win_time );
 }
 
 void LoRaMac::OnRxWindow2TimerEvent( void )
 {
-    _lora_time.TimerStop( &_params.timers.RxWindowTimer2 );
+    _lora_time.TimerStop( &_params.timers.rx_window2_timer );
 
-    _params.RxWindow2Config.Channel = _params.Channel;
-    _params.RxWindow2Config.Frequency = _params.sys_params.Rx2Channel.Frequency;
-    _params.RxWindow2Config.DownlinkDwellTime = _params.sys_params.DownlinkDwellTime;
-    _params.RxWindow2Config.RepeaterSupport = _params.RepeaterSupport;
-    _params.RxWindow2Config.RxSlot = RX_SLOT_WIN_2;
+    _params.rx_window2_config.channel = _params.channel;
+    _params.rx_window2_config.frequency = _params.sys_params.rx2_channel.frequency;
+    _params.rx_window2_config.dl_dwell_time = _params.sys_params.downlink_dwell_time;
+    _params.rx_window2_config.is_repeater_supported = _params.is_repeater_supported;
+    _params.rx_window2_config.rx_slot = RX_SLOT_WIN_2;
 
-    if( _params.LoRaMacDeviceClass != CLASS_C )
+    if( _params.dev_class!= CLASS_C )
     {
-        _params.RxWindow2Config.RxContinuous = false;
+        _params.rx_window2_config.is_rx_continuous = false;
     }
     else
     {
         // Setup continuous listening for class c
-        _params.RxWindow2Config.RxContinuous = true;
+        _params.rx_window2_config.is_rx_continuous = true;
     }
 
-    if(lora_phy->rx_config(&_params.RxWindow2Config, ( int8_t* )&mcps.get_indication().RxDatarate) == true )
+    if(lora_phy->rx_config(&_params.rx_window2_config, ( int8_t* )&mcps.get_indication().rx_datarate) == true )
     {
-        RxWindowSetup( _params.RxWindow2Config.RxContinuous, _params.sys_params.MaxRxWindow );
-        _params.RxSlot = RX_SLOT_WIN_2;
+        RxWindowSetup( _params.rx_window2_config.is_rx_continuous, _params.sys_params.max_rx_win_time );
+        _params.rx_slot= RX_SLOT_WIN_2;
     }
 }
 
 void LoRaMac::OnAckTimeoutTimerEvent( void )
 {
-    _lora_time.TimerStop( &_params.timers.AckTimeoutTimer );
+    _lora_time.TimerStop( &_params.timers.ack_timeout_timer );
 
-    if( _params.NodeAckRequested == true )
+    if( _params.is_node_ack_requested == true )
     {
-        _params.AckTimeoutRetry = true;
-        _params.LoRaMacState &= ~LORAMAC_ACK_REQ;
+        _params.is_ack_retry_timeout_expired = true;
+        _params.mac_state &= ~LORAMAC_ACK_REQ;
     }
-    if( _params.LoRaMacDeviceClass == CLASS_C )
+    if( _params.dev_class== CLASS_C )
     {
-        _params.LoRaMacFlags.Bits.MacDone = 1;
+        _params.flags.bits.mac_done = 1;
     }
 }
 
@@ -1161,12 +1159,12 @@ bool LoRaMac::ValidatePayloadLength( uint8_t lenN, int8_t datarate, uint8_t fOpt
     uint16_t payloadSize = 0;
 
     // Setup PHY request
-    getPhy.UplinkDwellTime = _params.sys_params.UplinkDwellTime;
+    getPhy.UplinkDwellTime = _params.sys_params.uplink_dwell_time;
     getPhy.Datarate = datarate;
     getPhy.Attribute = PHY_MAX_PAYLOAD;
 
     // Get the maximum payload length
-    if( _params.RepeaterSupport == true )
+    if( _params.is_repeater_supported == true )
     {
         getPhy.Attribute = PHY_MAX_PAYLOAD_REPEATER;
     }
@@ -1186,127 +1184,127 @@ bool LoRaMac::ValidatePayloadLength( uint8_t lenN, int8_t datarate, uint8_t fOpt
 
 void LoRaMac::SetMlmeScheduleUplinkIndication( void )
 {
-    mlme.get_indication().MlmeIndication = MLME_SCHEDULE_UPLINK;
-    _params.LoRaMacFlags.Bits.MlmeInd = 1;
+    mlme.get_indication().indication_type = MLME_SCHEDULE_UPLINK;
+    _params.flags.bits.mlme_ind = 1;
 }
 
 // This is not actual transmission. It just schedules a message in response
 // to MCPS request
-LoRaMacStatus_t LoRaMac::Send( LoRaMacHeader_t *macHdr, uint8_t fPort, void *fBuffer, uint16_t fBufferSize )
+lorawan_status_t LoRaMac::Send( loramac_mhdr_t *macHdr, uint8_t fPort, void *fBuffer, uint16_t fBufferSize )
 {
-    LoRaMacFrameCtrl_t fCtrl;
-    LoRaMacStatus_t status = LORAMAC_STATUS_PARAMETER_INVALID;
+    loramac_frame_ctrl_t fCtrl;
+    lorawan_status_t status = LORAWAN_STATUS_PARAMETER_INVALID;
 
-    fCtrl.Value = 0;
-    fCtrl.Bits.FOptsLen      = 0;
-    fCtrl.Bits.FPending      = 0;
-    fCtrl.Bits.Ack           = false;
-    fCtrl.Bits.AdrAckReq     = false;
-    fCtrl.Bits.Adr           = _params.sys_params.AdrCtrlOn;
+    fCtrl.value = 0;
+    fCtrl.bits.fopts_len     = 0;
+    fCtrl.bits.fpending      = 0;
+    fCtrl.bits.ack           = false;
+    fCtrl.bits.adr_ack_req   = false;
+    fCtrl.bits.adr           = _params.sys_params.adr_on;
 
     // Prepare the frame
     status = PrepareFrame( macHdr, &fCtrl, fPort, fBuffer, fBufferSize );
 
     // Validate status
-    if( status != LORAMAC_STATUS_OK )
+    if( status != LORAWAN_STATUS_OK )
     {
         return status;
     }
 
     // Reset confirm parameters
-    mcps.get_confirmation().NbRetries = 0;
-    mcps.get_confirmation().AckReceived = false;
-    mcps.get_confirmation().UpLinkCounter = _params.UpLinkCounter;
+    mcps.get_confirmation().nb_retries = 0;
+    mcps.get_confirmation().ack_received = false;
+    mcps.get_confirmation().ul_frame_counter = _params.ul_frame_counter;
 
     status = ScheduleTx( );
 
     return status;
 }
 
-LoRaMacStatus_t LoRaMac::ScheduleTx( void )
+lorawan_status_t LoRaMac::ScheduleTx( void )
 {
-    TimerTime_t dutyCycleTimeOff = 0;
+    lorawan_time_t dutyCycleTimeOff = 0;
     NextChanParams_t nextChan;
 
     // Check if the device is off
-    if( _params.sys_params.MaxDCycle == 255 )
+    if( _params.sys_params.max_duty_cycle == 255 )
     {
-        return LORAMAC_STATUS_DEVICE_OFF;
+        return LORAWAN_STATUS_DEVICE_OFF;
     }
-    if( _params.sys_params.MaxDCycle == 0 )
+    if( _params.sys_params.max_duty_cycle == 0 )
     {
-        _params.timers.AggregatedTimeOff = 0;
+        _params.timers.aggregated_timeoff = 0;
     }
 
     // Update Backoff
-    CalculateBackOff( _params.LastTxChannel );
+    CalculateBackOff( _params.last_channel_idx );
 
-    nextChan.AggrTimeOff = _params.timers.AggregatedTimeOff;
-    nextChan.Datarate = _params.sys_params.ChannelsDatarate;
-    _params.DutyCycleOn = MBED_CONF_LORA_DUTY_CYCLE_ON;
-    nextChan.DutyCycleEnabled = _params.DutyCycleOn;
-    nextChan.Joined = _params.IsLoRaMacNetworkJoined;
-    nextChan.LastAggrTx = _params.timers.AggregatedLastTxDoneTime;
+    nextChan.AggrTimeOff = _params.timers.aggregated_timeoff;
+    nextChan.Datarate = _params.sys_params.channel_data_rate;
+    _params.is_dutycycle_on = MBED_CONF_LORA_DUTY_CYCLE_ON;
+    nextChan.DutyCycleEnabled = _params.is_dutycycle_on;
+    nextChan.Joined = _params.is_nwk_joined;
+    nextChan.LastAggrTx = _params.timers.aggregated_last_tx_time;
 
     // Select channel
-    while( lora_phy->set_next_channel(&nextChan, &_params.Channel, &dutyCycleTimeOff,
-                                      &_params.timers.AggregatedTimeOff ) == false )
+    while( lora_phy->set_next_channel(&nextChan, &_params.channel, &dutyCycleTimeOff,
+                                      &_params.timers.aggregated_timeoff ) == false )
     {
         // Set the default datarate
-        _params.sys_params.ChannelsDatarate = _params.def_sys_params.ChannelsDatarate;
+        _params.sys_params.channel_data_rate = _params.def_sys_params.channel_data_rate;
         // Update datarate in the function parameters
-        nextChan.Datarate = _params.sys_params.ChannelsDatarate;
+        nextChan.Datarate = _params.sys_params.channel_data_rate;
     }
 
-    tr_debug("Next Channel Idx=%d, DR=%d", _params.Channel, nextChan.Datarate);
+    tr_debug("Next Channel Idx=%d, DR=%d", _params.channel, nextChan.Datarate);
 
     // Compute Rx1 windows parameters
-    uint8_t dr_offset = lora_phy->apply_DR_offset(_params.sys_params.DownlinkDwellTime,
-                                                 _params.sys_params.ChannelsDatarate,
-                                                 _params.sys_params.Rx1DrOffset);
+    uint8_t dr_offset = lora_phy->apply_DR_offset(_params.sys_params.downlink_dwell_time,
+                                                 _params.sys_params.channel_data_rate,
+                                                 _params.sys_params.rx1_dr_offset);
 
-    lora_phy->compute_rx_win_params(dr_offset, _params.sys_params.MinRxSymbols,
-                                     _params.sys_params.SystemMaxRxError,
-                                     &_params.RxWindow1Config );
+    lora_phy->compute_rx_win_params(dr_offset, _params.sys_params.min_rx_symb,
+                                     _params.sys_params.max_sys_rx_error,
+                                     &_params.rx_window1_config );
     // Compute Rx2 windows parameters
-    lora_phy->compute_rx_win_params(_params.sys_params.Rx2Channel.Datarate,
-                                    _params.sys_params.MinRxSymbols,
-                                    _params.sys_params.SystemMaxRxError,
-                                    &_params.RxWindow2Config );
+    lora_phy->compute_rx_win_params(_params.sys_params.rx2_channel.datarate,
+                                    _params.sys_params.min_rx_symb,
+                                    _params.sys_params.max_sys_rx_error,
+                                    &_params.rx_window2_config );
 
-    if( _params.IsLoRaMacNetworkJoined == false )
+    if( _params.is_nwk_joined == false )
     {
-        _params.RxWindow1Delay = _params.sys_params.JoinAcceptDelay1 + _params.RxWindow1Config.WindowOffset;
-        _params.RxWindow2Delay = _params.sys_params.JoinAcceptDelay2 + _params.RxWindow2Config.WindowOffset;
+        _params.rx_window1_delay = _params.sys_params.join_accept_delay1 + _params.rx_window1_config.window_offset;
+        _params.rx_window2_delay = _params.sys_params.join_accept_delay2 + _params.rx_window2_config.window_offset;
     }
     else
     {
-        if( ValidatePayloadLength( _params.LoRaMacTxPayloadLen,
-                                   _params.sys_params.ChannelsDatarate,
+        if( ValidatePayloadLength( _params.payload_length,
+                                   _params.sys_params.channel_data_rate,
                                    mac_commands.GetLength() ) == false )
         {
-            return LORAMAC_STATUS_LENGTH_ERROR;
+            return LORAWAN_STATUS_LENGTH_ERROR;
         }
-        _params.RxWindow1Delay = _params.sys_params.ReceiveDelay1 + _params.RxWindow1Config.WindowOffset;
-        _params.RxWindow2Delay = _params.sys_params.ReceiveDelay2 + _params.RxWindow2Config.WindowOffset;
+        _params.rx_window1_delay = _params.sys_params.recv_delay1 + _params.rx_window1_config.window_offset;
+        _params.rx_window2_delay = _params.sys_params.recv_delay2 + _params.rx_window2_config.window_offset;
     }
 
     // Schedule transmission of frame
     if( dutyCycleTimeOff == 0 )
     {
         // Try to send now
-        return SendFrameOnChannel( _params.Channel );
+        return SendFrameOnChannel( _params.channel );
     }
     else
     {
         // Send later - prepare timer
-        _params.LoRaMacState |= LORAMAC_TX_DELAYED;
+        _params.mac_state |= LORAMAC_TX_DELAYED;
         tr_debug("Next Transmission in %lu ms", dutyCycleTimeOff);
 
-        _lora_time.TimerSetValue( &_params.timers.TxDelayedTimer, dutyCycleTimeOff );
-        _lora_time.TimerStart( &_params.timers.TxDelayedTimer );
+        _lora_time.TimerSetValue( &_params.timers.tx_delayed_timer, dutyCycleTimeOff );
+        _lora_time.TimerStart( &_params.timers.tx_delayed_timer );
 
-        return LORAMAC_STATUS_OK;
+        return LORAWAN_STATUS_OK;
     }
 }
 
@@ -1314,69 +1312,69 @@ void LoRaMac::CalculateBackOff( uint8_t channel )
 {
     CalcBackOffParams_t calcBackOff;
 
-    calcBackOff.Joined = _params.IsLoRaMacNetworkJoined;
-    _params.DutyCycleOn = MBED_CONF_LORA_DUTY_CYCLE_ON;
-    calcBackOff.DutyCycleEnabled = _params.DutyCycleOn;
+    calcBackOff.Joined = _params.is_nwk_joined;
+    _params.is_dutycycle_on = MBED_CONF_LORA_DUTY_CYCLE_ON;
+    calcBackOff.DutyCycleEnabled = _params.is_dutycycle_on;
     calcBackOff.Channel = channel;
-    calcBackOff.ElapsedTime = _lora_time.TimerGetElapsedTime( _params.timers.LoRaMacInitializationTime );
-    calcBackOff.TxTimeOnAir = _params.timers.TxTimeOnAir;
-    calcBackOff.LastTxIsJoinRequest = _params.LastTxIsJoinRequest;
+    calcBackOff.ElapsedTime = _lora_time.TimerGetElapsedTime( _params.timers.mac_init_time );
+    calcBackOff.TxTimeOnAir = _params.timers.tx_toa;
+    calcBackOff.LastTxIsJoinRequest = _params.is_last_tx_join_request;
 
     // Update regional back-off
     lora_phy->calculate_backoff(&calcBackOff);
 
     // Update aggregated time-off
-    _params.timers.AggregatedTimeOff = _params.timers.AggregatedTimeOff +
-            ( _params.timers.TxTimeOnAir * _params.sys_params.AggregatedDCycle - _params.timers.TxTimeOnAir );
+    _params.timers.aggregated_timeoff = _params.timers.aggregated_timeoff +
+            ( _params.timers.tx_toa * _params.sys_params.aggregated_duty_cycle - _params.timers.tx_toa );
 }
 
 void LoRaMac::ResetMacParameters( void )
 {
-    _params.IsLoRaMacNetworkJoined = false;
+    _params.is_nwk_joined = false;
 
     // Counters
-    _params.UpLinkCounter = 0;
-    _params.DownLinkCounter = 0;
-    _params.AdrAckCounter = 0;
+    _params.ul_frame_counter = 0;
+    _params.dl_frame_counter = 0;
+    _params.adr_ack_counter = 0;
 
-    _params.ChannelsNbRepCounter = 0;
+    _params.ul_nb_rep_counter = 0;
 
-    _params.AckTimeoutRetries = 1;
-    _params.AckTimeoutRetriesCounter = 1;
-    _params.AckTimeoutRetry = false;
+    _params.max_ack_timeout_retries = 1;
+    _params.ack_timeout_retry_counter = 1;
+    _params.is_ack_retry_timeout_expired = false;
 
-    _params.sys_params.MaxDCycle = 0;
-    _params.sys_params.AggregatedDCycle = 1;
+    _params.sys_params.max_duty_cycle = 0;
+    _params.sys_params.aggregated_duty_cycle = 1;
 
     mac_commands.ClearCommandBuffer();
     mac_commands.ClearRepeatBuffer();
     mac_commands.ClearMacCommandsInNextTx();
 
-    _params.IsRxWindowsEnabled = true;
+    _params.is_rx_window_enabled = true;
 
-    _params.sys_params.ChannelsTxPower = _params.def_sys_params.ChannelsTxPower;
-    _params.sys_params.ChannelsDatarate = _params.def_sys_params.ChannelsDatarate;
-    _params.sys_params.Rx1DrOffset = _params.def_sys_params.Rx1DrOffset;
-    _params.sys_params.Rx2Channel = _params.def_sys_params.Rx2Channel;
-    _params.sys_params.UplinkDwellTime = _params.def_sys_params.UplinkDwellTime;
-    _params.sys_params.DownlinkDwellTime = _params.def_sys_params.DownlinkDwellTime;
-    _params.sys_params.MaxEirp = _params.def_sys_params.MaxEirp;
-    _params.sys_params.AntennaGain = _params.def_sys_params.AntennaGain;
+    _params.sys_params.channel_tx_power = _params.def_sys_params.channel_tx_power;
+    _params.sys_params.channel_data_rate = _params.def_sys_params.channel_data_rate;
+    _params.sys_params.rx1_dr_offset = _params.def_sys_params.rx1_dr_offset;
+    _params.sys_params.rx2_channel = _params.def_sys_params.rx2_channel;
+    _params.sys_params.uplink_dwell_time = _params.def_sys_params.uplink_dwell_time;
+    _params.sys_params.downlink_dwell_time = _params.def_sys_params.downlink_dwell_time;
+    _params.sys_params.max_eirp = _params.def_sys_params.max_eirp;
+    _params.sys_params.antenna_gain = _params.def_sys_params.antenna_gain;
 
-    _params.NodeAckRequested = false;
-    _params.SrvAckRequested = false;
+    _params.is_node_ack_requested = false;
+    _params.is_srv_ack_requested = false;
 
     // Reset Multicast downlink counters
-    MulticastParams_t *cur = _params.MulticastChannels;
+    multicast_params_t *cur = _params.multicast_channels;
     while( cur != NULL )
     {
-        cur->DownLinkCounter = 0;
+        cur->dl_frame_counter = 0;
         cur = cur->Next;
     }
 
     // Initialize channel index.
-    _params.Channel = 0;
-    _params.LastTxChannel = _params.Channel;
+    _params.channel = 0;
+    _params.last_channel_idx = _params.channel;
 }
 
 bool LoRaMac::IsFPortAllowed( uint8_t fPort )
@@ -1391,7 +1389,7 @@ bool LoRaMac::IsFPortAllowed( uint8_t fPort )
 void LoRaMac::OpenContinuousRx2Window( void )
 {
     handle_rx2_timer_event( );
-    _params.RxSlot = RX_SLOT_WIN_CLASS_C;
+    _params.rx_slot = RX_SLOT_WIN_CLASS_C;
 }
 
 static void memcpy_convert_endianess( uint8_t *dst, const uint8_t *src, uint16_t size )
@@ -1403,7 +1401,7 @@ static void memcpy_convert_endianess( uint8_t *dst, const uint8_t *src, uint16_t
     }
 }
 
-LoRaMacStatus_t LoRaMac::PrepareFrame( LoRaMacHeader_t *macHdr, LoRaMacFrameCtrl_t *fCtrl, uint8_t fPort, void *fBuffer, uint16_t fBufferSize )
+lorawan_status_t LoRaMac::PrepareFrame( loramac_mhdr_t *macHdr, loramac_frame_ctrl_t *fCtrl, uint8_t fPort, void *fBuffer, uint16_t fBufferSize )
 {
     AdrNextParams_t adrNext;
     uint16_t i;
@@ -1411,113 +1409,113 @@ LoRaMacStatus_t LoRaMac::PrepareFrame( LoRaMacHeader_t *macHdr, LoRaMacFrameCtrl
     uint32_t mic = 0;
     const void* payload = fBuffer;
     uint8_t framePort = fPort;
-    LoRaMacStatus_t status = LORAMAC_STATUS_OK;
+    lorawan_status_t status = LORAWAN_STATUS_OK;
 
-    _params.LoRaMacBufferPktLen = 0;
+    _params.buffer_pkt_len = 0;
 
-    _params.NodeAckRequested = false;
+    _params.is_node_ack_requested = false;
 
     if( fBuffer == NULL )
     {
         fBufferSize = 0;
     }
 
-    _params.LoRaMacTxPayloadLen = fBufferSize;
+    _params.payload_length = fBufferSize;
 
-    _params.LoRaMacBuffer[pktHeaderLen++] = macHdr->Value;
+    _params.buffer[pktHeaderLen++] = macHdr->value;
 
-    switch( macHdr->Bits.MType )
+    switch( macHdr->bits.mtype )
     {
         case FRAME_TYPE_JOIN_REQ:
-            _params.LoRaMacBufferPktLen = pktHeaderLen;
+            _params.buffer_pkt_len = pktHeaderLen;
 
-            memcpy_convert_endianess( _params.LoRaMacBuffer + _params.LoRaMacBufferPktLen,
-                                      _params.keys.LoRaMacAppEui, 8 );
-            _params.LoRaMacBufferPktLen += 8;
-            memcpy_convert_endianess( _params.LoRaMacBuffer + _params.LoRaMacBufferPktLen,
-                                      _params.keys.LoRaMacDevEui, 8 );
-            _params.LoRaMacBufferPktLen += 8;
+            memcpy_convert_endianess( _params.buffer + _params.buffer_pkt_len,
+                                      _params.keys.app_eui, 8 );
+            _params.buffer_pkt_len += 8;
+            memcpy_convert_endianess( _params.buffer + _params.buffer_pkt_len,
+                                      _params.keys.dev_eui, 8 );
+            _params.buffer_pkt_len += 8;
 
-            _params.LoRaMacDevNonce = lora_phy->get_radio_rng();
+            _params.dev_nonce = lora_phy->get_radio_rng();
 
-            _params.LoRaMacBuffer[_params.LoRaMacBufferPktLen++] = _params.LoRaMacDevNonce & 0xFF;
-            _params.LoRaMacBuffer[_params.LoRaMacBufferPktLen++] = ( _params.LoRaMacDevNonce >> 8 ) & 0xFF;
+            _params.buffer[_params.buffer_pkt_len++] = _params.dev_nonce & 0xFF;
+            _params.buffer[_params.buffer_pkt_len++] = ( _params.dev_nonce >> 8 ) & 0xFF;
 
-            if (0 != LoRaMacJoinComputeMic( _params.LoRaMacBuffer,
-                                            _params.LoRaMacBufferPktLen & 0xFF,
-                                            _params.keys.LoRaMacAppKey, &mic )) {
-                return LORAMAC_STATUS_CRYPTO_FAIL;
+            if (0 != LoRaMacJoinComputeMic( _params.buffer,
+                                            _params.buffer_pkt_len & 0xFF,
+                                            _params.keys.app_key, &mic )) {
+                return LORAWAN_STATUS_CRYPTO_FAIL;
             }
 
-            _params.LoRaMacBuffer[_params.LoRaMacBufferPktLen++] = mic & 0xFF;
-            _params.LoRaMacBuffer[_params.LoRaMacBufferPktLen++] = ( mic >> 8 ) & 0xFF;
-            _params. LoRaMacBuffer[_params.LoRaMacBufferPktLen++] = ( mic >> 16 ) & 0xFF;
-            _params.LoRaMacBuffer[_params.LoRaMacBufferPktLen++] = ( mic >> 24 ) & 0xFF;
+            _params.buffer[_params.buffer_pkt_len++] = mic & 0xFF;
+            _params.buffer[_params.buffer_pkt_len++] = ( mic >> 8 ) & 0xFF;
+            _params. buffer[_params.buffer_pkt_len++] = ( mic >> 16 ) & 0xFF;
+            _params.buffer[_params.buffer_pkt_len++] = ( mic >> 24 ) & 0xFF;
 
             break;
         case FRAME_TYPE_DATA_CONFIRMED_UP:
-            _params.NodeAckRequested = true;
+            _params.is_node_ack_requested = true;
             //Intentional fallthrough
         case FRAME_TYPE_DATA_UNCONFIRMED_UP:
         {
-            if( _params.IsLoRaMacNetworkJoined == false )
+            if( _params.is_nwk_joined == false )
             {
-                return LORAMAC_STATUS_NO_NETWORK_JOINED; // No network has been joined yet
+                return LORAWAN_STATUS_NO_NETWORK_JOINED; // No network has been joined yet
             }
 
             // Adr next request
             adrNext.UpdateChanMask = true;
-            adrNext.AdrEnabled = fCtrl->Bits.Adr;
-            adrNext.AdrAckCounter = _params.AdrAckCounter;
-            adrNext.Datarate = _params.sys_params.ChannelsDatarate;
-            adrNext.TxPower = _params.sys_params.ChannelsTxPower;
-            adrNext.UplinkDwellTime = _params.sys_params.UplinkDwellTime;
+            adrNext.AdrEnabled = fCtrl->bits.adr;
+            adrNext.AdrAckCounter = _params.adr_ack_counter;
+            adrNext.Datarate = _params.sys_params.channel_data_rate;
+            adrNext.TxPower = _params.sys_params.channel_tx_power;
+            adrNext.UplinkDwellTime = _params.sys_params.uplink_dwell_time;
 
-            fCtrl->Bits.AdrAckReq = lora_phy->get_next_ADR(&adrNext,
-                                                          &_params.sys_params.ChannelsDatarate,
-                                                          &_params.sys_params.ChannelsTxPower,
-                                                          &_params.AdrAckCounter);
+            fCtrl->bits.adr_ack_req = lora_phy->get_next_ADR(&adrNext,
+                                                          &_params.sys_params.channel_data_rate,
+                                                          &_params.sys_params.channel_tx_power,
+                                                          &_params.adr_ack_counter);
 
-            if( _params.SrvAckRequested == true )
+            if( _params.is_srv_ack_requested == true )
             {
-                _params.SrvAckRequested = false;
-                fCtrl->Bits.Ack = 1;
+                _params.is_srv_ack_requested = false;
+                fCtrl->bits.ack = 1;
             }
 
-            _params.LoRaMacBuffer[pktHeaderLen++] = ( _params.LoRaMacDevAddr ) & 0xFF;
-            _params.LoRaMacBuffer[pktHeaderLen++] = ( _params.LoRaMacDevAddr >> 8 ) & 0xFF;
-            _params.LoRaMacBuffer[pktHeaderLen++] = ( _params.LoRaMacDevAddr >> 16 ) & 0xFF;
-            _params.LoRaMacBuffer[pktHeaderLen++] = ( _params.LoRaMacDevAddr >> 24 ) & 0xFF;
+            _params.buffer[pktHeaderLen++] = ( _params.dev_addr ) & 0xFF;
+            _params.buffer[pktHeaderLen++] = ( _params.dev_addr >> 8 ) & 0xFF;
+            _params.buffer[pktHeaderLen++] = ( _params.dev_addr >> 16 ) & 0xFF;
+            _params.buffer[pktHeaderLen++] = ( _params.dev_addr >> 24 ) & 0xFF;
 
-            _params.LoRaMacBuffer[pktHeaderLen++] = fCtrl->Value;
+            _params.buffer[pktHeaderLen++] = fCtrl->value;
 
-            _params.LoRaMacBuffer[pktHeaderLen++] = _params.UpLinkCounter & 0xFF;
-            _params.LoRaMacBuffer[pktHeaderLen++] = ( _params.UpLinkCounter >> 8 ) & 0xFF;
+            _params.buffer[pktHeaderLen++] = _params.ul_frame_counter & 0xFF;
+            _params.buffer[pktHeaderLen++] = ( _params.ul_frame_counter >> 8 ) & 0xFF;
 
             // Copy the MAC commands which must be re-send into the MAC command buffer
             mac_commands.CopyRepeatCommandsToBuffer();
 
             const uint8_t mac_commands_len = mac_commands.GetLength();
-            if( ( payload != NULL ) && ( _params.LoRaMacTxPayloadLen > 0 ) )
+            if( ( payload != NULL ) && ( _params.payload_length > 0 ) )
             {
                 if( mac_commands.IsMacCommandsInNextTx() == true )
                 {
                     if( mac_commands_len <= LORA_MAC_COMMAND_MAX_FOPTS_LENGTH )
                     {
-                        fCtrl->Bits.FOptsLen += mac_commands_len;
+                        fCtrl->bits.fopts_len += mac_commands_len;
 
                         // Update FCtrl field with new value of OptionsLength
-                        _params.LoRaMacBuffer[0x05] = fCtrl->Value;
+                        _params.buffer[0x05] = fCtrl->value;
 
                         const uint8_t *buffer = mac_commands.GetMacCommandsBuffer();
                         for( i = 0; i < mac_commands_len; i++ )
                         {
-                            _params.LoRaMacBuffer[pktHeaderLen++] = buffer[i];
+                            _params.buffer[pktHeaderLen++] = buffer[i];
                         }
                     }
                     else
                     {
-                        _params.LoRaMacTxPayloadLen = mac_commands_len;
+                        _params.payload_length = mac_commands_len;
                         payload = mac_commands.GetMacCommandsBuffer();
                         framePort = 0;
                     }
@@ -1527,7 +1525,7 @@ LoRaMacStatus_t LoRaMac::PrepareFrame( LoRaMacHeader_t *macHdr, LoRaMacFrameCtrl
             {
                 if( ( mac_commands_len > 0 ) && ( mac_commands.IsMacCommandsInNextTx() == true ) )
                 {
-                    _params.LoRaMacTxPayloadLen = mac_commands_len;
+                    _params.payload_length = mac_commands_len;
                     payload = mac_commands.GetMacCommandsBuffer();
                     framePort = 0;
                 }
@@ -1536,149 +1534,148 @@ LoRaMacStatus_t LoRaMac::PrepareFrame( LoRaMacHeader_t *macHdr, LoRaMacFrameCtrl
             // Store MAC commands which must be re-send in case the device does not receive a downlink anymore
             mac_commands.ParseMacCommandsToRepeat();
 
-            if( ( payload != NULL ) && ( _params.LoRaMacTxPayloadLen > 0 ) )
+            if( ( payload != NULL ) && ( _params.payload_length > 0 ) )
             {
-                _params.LoRaMacBuffer[pktHeaderLen++] = framePort;
+                _params.buffer[pktHeaderLen++] = framePort;
 
                 if( framePort == 0 )
                 {
                     // Reset buffer index as the mac commands are being sent on port 0
                     mac_commands.ClearCommandBuffer();
                     if (0 != LoRaMacPayloadEncrypt( (uint8_t* ) payload,
-                                                    _params.LoRaMacTxPayloadLen,
-                                                    _params.keys.LoRaMacNwkSKey,
-                                                    _params.LoRaMacDevAddr,
+                                                    _params.payload_length,
+                                                    _params.keys.nwk_skey,
+                                                    _params.dev_addr,
                                                     UP_LINK,
-                                                    _params.UpLinkCounter,
-                                                    &_params.LoRaMacBuffer[pktHeaderLen] )) {
-                        status = LORAMAC_STATUS_CRYPTO_FAIL;
+                                                    _params.ul_frame_counter,
+                                                    &_params.buffer[pktHeaderLen] )) {
+                        status = LORAWAN_STATUS_CRYPTO_FAIL;
                     }
                 }
                 else
                 {
                     if (0 != LoRaMacPayloadEncrypt( (uint8_t* ) payload,
-                                                    _params.LoRaMacTxPayloadLen,
-                                                    _params.keys.LoRaMacAppSKey,
-                                                    _params.LoRaMacDevAddr,
+                                                    _params.payload_length,
+                                                    _params.keys.app_skey,
+                                                    _params.dev_addr,
                                                     UP_LINK,
-                                                    _params.UpLinkCounter,
-                                                    &_params.LoRaMacBuffer[pktHeaderLen] )) {
-                        status = LORAMAC_STATUS_CRYPTO_FAIL;
+                                                    _params.ul_frame_counter,
+                                                    &_params.buffer[pktHeaderLen] )) {
+                        status = LORAWAN_STATUS_CRYPTO_FAIL;
                     }
                 }
             }
-            _params.LoRaMacBufferPktLen = pktHeaderLen + _params.LoRaMacTxPayloadLen;
+            _params.buffer_pkt_len = pktHeaderLen + _params.payload_length;
 
-            if (0 != LoRaMacComputeMic( _params.LoRaMacBuffer,
-                                        _params.LoRaMacBufferPktLen,
-                                        _params.keys.LoRaMacNwkSKey,
-                                        _params.LoRaMacDevAddr,
+            if (0 != LoRaMacComputeMic( _params.buffer,
+                                        _params.buffer_pkt_len,
+                                        _params.keys.nwk_skey,
+                                        _params.dev_addr,
                                         UP_LINK,
-                                        _params.UpLinkCounter,
+                                        _params.ul_frame_counter,
                                         &mic )) {
-                status = LORAMAC_STATUS_CRYPTO_FAIL;
+                status = LORAWAN_STATUS_CRYPTO_FAIL;
             }
 
-            _params.LoRaMacBuffer[_params.LoRaMacBufferPktLen + 0] = mic & 0xFF;
-            _params.LoRaMacBuffer[_params.LoRaMacBufferPktLen + 1] = ( mic >> 8 ) & 0xFF;
-            _params.LoRaMacBuffer[_params.LoRaMacBufferPktLen + 2] = ( mic >> 16 ) & 0xFF;
-            _params.LoRaMacBuffer[_params.LoRaMacBufferPktLen + 3] = ( mic >> 24 ) & 0xFF;
+            _params.buffer[_params.buffer_pkt_len + 0] = mic & 0xFF;
+            _params.buffer[_params.buffer_pkt_len + 1] = ( mic >> 8 ) & 0xFF;
+            _params.buffer[_params.buffer_pkt_len + 2] = ( mic >> 16 ) & 0xFF;
+            _params.buffer[_params.buffer_pkt_len + 3] = ( mic >> 24 ) & 0xFF;
 
-            _params.LoRaMacBufferPktLen += LORAMAC_MFR_LEN;
+            _params.buffer_pkt_len += LORAMAC_MFR_LEN;
         }
         break;
         case FRAME_TYPE_PROPRIETARY:
-            if( ( fBuffer != NULL ) && (_params.LoRaMacTxPayloadLen > 0 ) )
+            if( ( fBuffer != NULL ) && (_params.payload_length > 0 ) )
             {
-                memcpy( _params.LoRaMacBuffer + pktHeaderLen, ( uint8_t* ) fBuffer, _params.LoRaMacTxPayloadLen );
-                _params.LoRaMacBufferPktLen = pktHeaderLen + _params.LoRaMacTxPayloadLen;
+                memcpy( _params.buffer + pktHeaderLen, ( uint8_t* ) fBuffer, _params.payload_length );
+                _params.buffer_pkt_len = pktHeaderLen + _params.payload_length;
             }
             break;
         default:
-            status = LORAMAC_STATUS_SERVICE_UNKNOWN;
+            status = LORAWAN_STATUS_SERVICE_UNKNOWN;
     }
 
     return status;
 }
 
-LoRaMacStatus_t LoRaMac::SendFrameOnChannel( uint8_t channel )
+lorawan_status_t LoRaMac::SendFrameOnChannel( uint8_t channel )
 {
     TxConfigParams_t txConfig;
     int8_t txPower = 0;
 
     txConfig.Channel = channel;
-    txConfig.Datarate = _params.sys_params.ChannelsDatarate;
-    txConfig.TxPower = _params.sys_params.ChannelsTxPower;
-    txConfig.MaxEirp = _params.sys_params.MaxEirp;
-    txConfig.AntennaGain = _params.sys_params.AntennaGain;
-    txConfig.PktLen = _params.LoRaMacBufferPktLen;
+    txConfig.Datarate = _params.sys_params.channel_data_rate;
+    txConfig.TxPower = _params.sys_params.channel_tx_power;
+    txConfig.MaxEirp = _params.sys_params.max_eirp;
+    txConfig.AntennaGain = _params.sys_params.antenna_gain;
+    txConfig.PktLen = _params.buffer_pkt_len;
 
-    lora_phy->tx_config(&txConfig, &txPower, &_params.timers.TxTimeOnAir);
+    lora_phy->tx_config(&txConfig, &txPower, &_params.timers.tx_toa);
 
-    mlme.get_confirmation().Status = LORAMAC_EVENT_INFO_STATUS_ERROR;
+    mlme.get_confirmation().status = LORAMAC_EVENT_INFO_STATUS_ERROR;
 
-    mcps.get_confirmation().Status = LORAMAC_EVENT_INFO_STATUS_ERROR;
-    mcps.get_confirmation().Datarate = _params.sys_params.ChannelsDatarate;
-    mcps.get_confirmation().TxPower = txPower;
+    mcps.get_confirmation().status = LORAMAC_EVENT_INFO_STATUS_ERROR;
+    mcps.get_confirmation().data_rate = _params.sys_params.channel_data_rate;
+    mcps.get_confirmation().tx_power = txPower;
 
     // Store the time on air
-    mcps.get_confirmation().TxTimeOnAir = _params.timers.TxTimeOnAir;
-    mlme.get_confirmation().TxTimeOnAir = _params.timers.TxTimeOnAir;
+    mcps.get_confirmation().tx_toa = _params.timers.tx_toa;
+    mlme.get_confirmation().tx_toa = _params.timers.tx_toa;
 
     // Starts the MAC layer status check timer
-    _lora_time.TimerSetValue( &_params.timers.MacStateCheckTimer, MAC_STATE_CHECK_TIMEOUT );
-    _lora_time.TimerStart( &_params.timers.MacStateCheckTimer );
+    _lora_time.TimerSetValue( &_params.timers.mac_state_check_timer, MAC_STATE_CHECK_TIMEOUT );
+    _lora_time.TimerStart( &_params.timers.mac_state_check_timer );
 
-    if( _params.IsLoRaMacNetworkJoined == false )
+    if( _params.is_nwk_joined == false )
     {
-        _params.JoinRequestTrials++;
+        _params.join_request_trial_counter++;
     }
 
     // Send now
-    lora_phy->handle_send(_params.LoRaMacBuffer, _params.LoRaMacBufferPktLen);
+    lora_phy->handle_send(_params.buffer, _params.buffer_pkt_len);
 
-    _params.LoRaMacState |= LORAMAC_TX_RUNNING;
+    _params.mac_state |= LORAMAC_TX_RUNNING;
 
-    return LORAMAC_STATUS_OK;
+    return LORAWAN_STATUS_OK;
 }
 
-LoRaMacStatus_t LoRaMac::SetTxContinuousWave( uint16_t timeout )
+lorawan_status_t LoRaMac::SetTxContinuousWave( uint16_t timeout )
 {
     ContinuousWaveParams_t continuousWave;
 
-    continuousWave.Channel = _params.Channel;
-    continuousWave.Datarate = _params.sys_params.ChannelsDatarate;
-    continuousWave.TxPower = _params.sys_params.ChannelsTxPower;
-    continuousWave.MaxEirp = _params.sys_params.MaxEirp;
-    continuousWave.AntennaGain = _params.sys_params.AntennaGain;
+    continuousWave.Channel = _params.channel;
+    continuousWave.Datarate = _params.sys_params.channel_data_rate;
+    continuousWave.TxPower = _params.sys_params.channel_tx_power;
+    continuousWave.MaxEirp = _params.sys_params.max_eirp;
+    continuousWave.AntennaGain = _params.sys_params.antenna_gain;
     continuousWave.Timeout = timeout;
 
     lora_phy->set_tx_cont_mode(&continuousWave);
 
     // Starts the MAC layer status check timer
-    _lora_time.TimerSetValue( &_params.timers.MacStateCheckTimer, MAC_STATE_CHECK_TIMEOUT );
-    _lora_time.TimerStart( &_params.timers.MacStateCheckTimer );
+    _lora_time.TimerSetValue( &_params.timers.mac_state_check_timer, MAC_STATE_CHECK_TIMEOUT );
+    _lora_time.TimerStart( &_params.timers.mac_state_check_timer );
 
-    _params.LoRaMacState |= LORAMAC_TX_RUNNING;
+    _params.mac_state |= LORAMAC_TX_RUNNING;
 
-    return LORAMAC_STATUS_OK;
+    return LORAWAN_STATUS_OK;
 }
 
-LoRaMacStatus_t LoRaMac::SetTxContinuousWave1( uint16_t timeout, uint32_t frequency, uint8_t power )
+lorawan_status_t LoRaMac::SetTxContinuousWave1( uint16_t timeout, uint32_t frequency, uint8_t power )
 {
     lora_phy->setup_tx_cont_wave_mode(frequency, power, timeout);
 
     // Starts the MAC layer status check timer
-    _lora_time.TimerSetValue( &_params.timers.MacStateCheckTimer, MAC_STATE_CHECK_TIMEOUT );
-    _lora_time.TimerStart( &_params.timers.MacStateCheckTimer );
+    _lora_time.TimerSetValue( &_params.timers.mac_state_check_timer, MAC_STATE_CHECK_TIMEOUT );
+    _lora_time.TimerStart( &_params.timers.mac_state_check_timer );
 
-    _params.LoRaMacState |= LORAMAC_TX_RUNNING;
+    _params.mac_state |= LORAMAC_TX_RUNNING;
 
-    return LORAMAC_STATUS_OK;
+    return LORAWAN_STATUS_OK;
 }
 
-LoRaMacStatus_t LoRaMac::LoRaMacInitialization(LoRaMacPrimitives_t *primitives,
-                                               LoRaMacCallback_t *callbacks,
+lorawan_status_t LoRaMac::LoRaMacInitialization(loramac_primitives_t *primitives,
                                                LoRaPHY *phy,
                                                EventQueue *queue)
 {
@@ -1688,9 +1685,9 @@ LoRaMacStatus_t LoRaMac::LoRaMacInitialization(LoRaMacPrimitives_t *primitives,
     //store event queue pointer
     ev_queue = queue;
 
-    if(!primitives || !callbacks)
+    if(!primitives)
     {
-        return LORAMAC_STATUS_PARAMETER_INVALID;
+        return LORAWAN_STATUS_PARAMETER_INVALID;
     }
 
     lora_phy = phy;
@@ -1708,175 +1705,174 @@ LoRaMacStatus_t LoRaMac::LoRaMacInitialization(LoRaMacPrimitives_t *primitives,
     ch_plan.activate_channelplan_subsystem(lora_phy, &mib);
 
     LoRaMacPrimitives = primitives;
-    LoRaMacCallbacks = callbacks;
 
-    _params.LoRaMacFlags.Value = 0;
+    _params.flags.value = 0;
 
-    _params.LoRaMacDeviceClass = CLASS_A;
-    _params.LoRaMacState = LORAMAC_IDLE;
+    _params.dev_class = CLASS_A;
+    _params.mac_state = LORAMAC_IDLE;
 
-    _params.JoinRequestTrials = 0;
-    _params.MaxJoinRequestTrials = 1;
-    _params.RepeaterSupport = false;
+    _params.join_request_trial_counter = 0;
+    _params.max_join_request_trials = 1;
+    _params.is_repeater_supported = false;
 
     // Reset duty cycle times
-    _params.timers.AggregatedLastTxDoneTime = 0;
-    _params.timers.AggregatedTimeOff = 0;
+    _params.timers.aggregated_last_tx_time = 0;
+    _params.timers.aggregated_timeoff = 0;
 
     // Reset to defaults
     getPhy.Attribute = PHY_DUTY_CYCLE;
     phyParam = lora_phy->get_phy_params(&getPhy);
     // load default at this moment. Later can be changed using json
-    _params.DutyCycleOn = ( bool ) phyParam.Value;
+    _params.is_dutycycle_on = ( bool ) phyParam.Value;
 
     getPhy.Attribute = PHY_DEF_TX_POWER;
     phyParam = lora_phy->get_phy_params( &getPhy );
-    _params.def_sys_params.ChannelsTxPower = phyParam.Value;
+    _params.def_sys_params.channel_tx_power = phyParam.Value;
 
     getPhy.Attribute = PHY_DEF_TX_DR;
     phyParam = lora_phy->get_phy_params( &getPhy );
-    _params.def_sys_params.ChannelsDatarate = phyParam.Value;
+    _params.def_sys_params.channel_data_rate = phyParam.Value;
 
     getPhy.Attribute = PHY_MAX_RX_WINDOW;
     phyParam = lora_phy->get_phy_params( &getPhy );
-    _params.def_sys_params.MaxRxWindow = phyParam.Value;
+    _params.def_sys_params.max_rx_win_time = phyParam.Value;
 
     getPhy.Attribute = PHY_RECEIVE_DELAY1;
     phyParam = lora_phy->get_phy_params( &getPhy );
-    _params.def_sys_params.ReceiveDelay1 = phyParam.Value;
+    _params.def_sys_params.recv_delay1 = phyParam.Value;
 
     getPhy.Attribute = PHY_RECEIVE_DELAY2;
     phyParam = lora_phy->get_phy_params( &getPhy );
-    _params.def_sys_params.ReceiveDelay2 = phyParam.Value;
+    _params.def_sys_params.recv_delay2 = phyParam.Value;
 
     getPhy.Attribute = PHY_JOIN_ACCEPT_DELAY1;
     phyParam = lora_phy->get_phy_params( &getPhy );
-    _params.def_sys_params.JoinAcceptDelay1 = phyParam.Value;
+    _params.def_sys_params.join_accept_delay1 = phyParam.Value;
 
     getPhy.Attribute = PHY_JOIN_ACCEPT_DELAY2;
     phyParam = lora_phy->get_phy_params( &getPhy );
-    _params.def_sys_params.JoinAcceptDelay2 = phyParam.Value;
+    _params.def_sys_params.join_accept_delay2 = phyParam.Value;
 
     getPhy.Attribute = PHY_DEF_DR1_OFFSET;
     phyParam = lora_phy->get_phy_params( &getPhy );
-    _params.def_sys_params.Rx1DrOffset = phyParam.Value;
+    _params.def_sys_params.rx1_dr_offset = phyParam.Value;
 
     getPhy.Attribute = PHY_DEF_RX2_FREQUENCY;
     phyParam = lora_phy->get_phy_params( &getPhy );
-    _params.def_sys_params.Rx2Channel.Frequency = phyParam.Value;
+    _params.def_sys_params.rx2_channel.frequency = phyParam.Value;
 
     getPhy.Attribute = PHY_DEF_RX2_DR;
     phyParam = lora_phy->get_phy_params( &getPhy );
-    _params.def_sys_params.Rx2Channel.Datarate = phyParam.Value;
+    _params.def_sys_params.rx2_channel.datarate = phyParam.Value;
 
     getPhy.Attribute = PHY_DEF_UPLINK_DWELL_TIME;
     phyParam = lora_phy->get_phy_params( &getPhy );
-    _params.def_sys_params.UplinkDwellTime = phyParam.Value;
+    _params.def_sys_params.uplink_dwell_time = phyParam.Value;
 
     getPhy.Attribute = PHY_DEF_DOWNLINK_DWELL_TIME;
     phyParam = lora_phy->get_phy_params( &getPhy );
-    _params.def_sys_params.DownlinkDwellTime = phyParam.Value;
+    _params.def_sys_params.downlink_dwell_time = phyParam.Value;
 
     getPhy.Attribute = PHY_DEF_MAX_EIRP;
     phyParam = lora_phy->get_phy_params( &getPhy );
-    _params.def_sys_params.MaxEirp = phyParam.fValue;
+    _params.def_sys_params.max_eirp = phyParam.fValue;
 
     getPhy.Attribute = PHY_DEF_ANTENNA_GAIN;
     phyParam = lora_phy->get_phy_params( &getPhy );
-    _params.def_sys_params.AntennaGain = phyParam.fValue;
+    _params.def_sys_params.antenna_gain = phyParam.fValue;
 
     lora_phy->load_defaults(INIT_TYPE_INIT);
 
     // Init parameters which are not set in function ResetMacParameters
-    _params.def_sys_params.ChannelsNbRep = 1;
-    _params.def_sys_params.SystemMaxRxError = 10;
-    _params.def_sys_params.MinRxSymbols = 6;
+    _params.def_sys_params.retry_num = 1;
+    _params.def_sys_params.max_sys_rx_error = 10;
+    _params.def_sys_params.min_rx_symb = 6;
 
-    _params.sys_params.SystemMaxRxError = _params.def_sys_params.SystemMaxRxError;
-    _params.sys_params.MinRxSymbols = _params.def_sys_params.MinRxSymbols;
-    _params.sys_params.MaxRxWindow = _params.def_sys_params.MaxRxWindow;
-    _params.sys_params.ReceiveDelay1 = _params.def_sys_params.ReceiveDelay1;
-    _params.sys_params.ReceiveDelay2 = _params.def_sys_params.ReceiveDelay2;
-    _params.sys_params.JoinAcceptDelay1 = _params.def_sys_params.JoinAcceptDelay1;
-    _params.sys_params.JoinAcceptDelay2 = _params.def_sys_params.JoinAcceptDelay2;
-    _params.sys_params.ChannelsNbRep = _params.def_sys_params.ChannelsNbRep;
+    _params.sys_params.max_sys_rx_error = _params.def_sys_params.max_sys_rx_error;
+    _params.sys_params.min_rx_symb = _params.def_sys_params.min_rx_symb;
+    _params.sys_params.max_rx_win_time = _params.def_sys_params.max_rx_win_time;
+    _params.sys_params.recv_delay1 = _params.def_sys_params.recv_delay1;
+    _params.sys_params.recv_delay2 = _params.def_sys_params.recv_delay2;
+    _params.sys_params.join_accept_delay1 = _params.def_sys_params.join_accept_delay1;
+    _params.sys_params.join_accept_delay2 = _params.def_sys_params.join_accept_delay2;
+    _params.sys_params.retry_num = _params.def_sys_params.retry_num;
 
     ResetMacParameters( );
 
     // Random seed initialization
     srand(lora_phy->get_radio_rng());
 
-    _params.PublicNetwork = MBED_CONF_LORA_PUBLIC_NETWORK;
-    lora_phy->setup_public_network_mode(_params.PublicNetwork);
+    _params.is_nwk_public = MBED_CONF_LORA_PUBLIC_NETWORK;
+    lora_phy->setup_public_network_mode(_params.is_nwk_public);
     lora_phy->put_radio_to_sleep();
 
     // Initialize timers
-    _lora_time.TimerInit(&_params.timers.MacStateCheckTimer,
+    _lora_time.TimerInit(&_params.timers.mac_state_check_timer,
                          mbed::callback(this, &LoRaMac::handle_mac_state_check_timer_event));
-    _lora_time.TimerSetValue(&_params.timers.MacStateCheckTimer, MAC_STATE_CHECK_TIMEOUT);
+    _lora_time.TimerSetValue(&_params.timers.mac_state_check_timer, MAC_STATE_CHECK_TIMEOUT);
 
-    _lora_time.TimerInit(&_params.timers.TxDelayedTimer,
+    _lora_time.TimerInit(&_params.timers.tx_delayed_timer,
                          mbed::callback(this, &LoRaMac::handle_delayed_tx_timer_event));
-    _lora_time.TimerInit(&_params.timers.RxWindowTimer1,
+    _lora_time.TimerInit(&_params.timers.rx_window1_timer,
                          mbed::callback(this, &LoRaMac::handle_rx1_timer_event));
-    _lora_time.TimerInit(&_params.timers.RxWindowTimer2,
+    _lora_time.TimerInit(&_params.timers.rx_window2_timer,
                          mbed::callback(this, &LoRaMac::handle_rx2_timer_event));
-    _lora_time.TimerInit(&_params.timers.AckTimeoutTimer,
+    _lora_time.TimerInit(&_params.timers.ack_timeout_timer,
                          mbed::callback(this, &LoRaMac::handle_ack_timeout));
 
     // Store the current initialization time
-    _params.timers.LoRaMacInitializationTime = _lora_time.TimerGetCurrentTime();
+    _params.timers.mac_init_time = _lora_time.TimerGetCurrentTime();
 
-    return LORAMAC_STATUS_OK;
+    return LORAWAN_STATUS_OK;
 }
 
-LoRaMacStatus_t LoRaMac::LoRaMacQueryTxPossible( uint8_t size, LoRaMacTxInfo_t* txInfo )
+lorawan_status_t LoRaMac::LoRaMacQueryTxPossible( uint8_t size, loramac_tx_info_t* txInfo )
 {
     AdrNextParams_t adrNext;
     GetPhyParams_t getPhy;
     PhyParam_t phyParam;
-    int8_t datarate = _params.def_sys_params.ChannelsDatarate;
-    int8_t txPower = _params.def_sys_params.ChannelsTxPower;
+    int8_t datarate = _params.def_sys_params.channel_data_rate;
+    int8_t txPower = _params.def_sys_params.channel_tx_power;
     uint8_t fOptLen = mac_commands.GetLength() + mac_commands.GetRepeatLength();
 
     if( txInfo == NULL )
     {
-        return LORAMAC_STATUS_PARAMETER_INVALID;
+        return LORAWAN_STATUS_PARAMETER_INVALID;
     }
 
     // Setup ADR request
     adrNext.UpdateChanMask = false;
-    adrNext.AdrEnabled = _params.sys_params.AdrCtrlOn;
-    adrNext.AdrAckCounter = _params.AdrAckCounter;
-    adrNext.Datarate = _params.sys_params.ChannelsDatarate;
-    adrNext.TxPower = _params.sys_params.ChannelsTxPower;
-    adrNext.UplinkDwellTime = _params.sys_params.UplinkDwellTime;
+    adrNext.AdrEnabled = _params.sys_params.adr_on;
+    adrNext.AdrAckCounter = _params.adr_ack_counter;
+    adrNext.Datarate = _params.sys_params.channel_data_rate;
+    adrNext.TxPower = _params.sys_params.channel_tx_power;
+    adrNext.UplinkDwellTime = _params.sys_params.uplink_dwell_time;
 
     // We call the function for information purposes only. We don't want to
     // apply the datarate, the tx power and the ADR ack counter.
-    lora_phy->get_next_ADR(&adrNext, &datarate, &txPower, &_params.AdrAckCounter);
+    lora_phy->get_next_ADR(&adrNext, &datarate, &txPower, &_params.adr_ack_counter);
 
     // Setup PHY request
-    getPhy.UplinkDwellTime = _params.sys_params.UplinkDwellTime;
+    getPhy.UplinkDwellTime = _params.sys_params.uplink_dwell_time;
     getPhy.Datarate = datarate;
     getPhy.Attribute = PHY_MAX_PAYLOAD;
 
     // Change request in case repeater is supported
-    if( _params.RepeaterSupport == true )
+    if( _params.is_repeater_supported == true )
     {
         getPhy.Attribute = PHY_MAX_PAYLOAD_REPEATER;
     }
     phyParam = lora_phy->get_phy_params( &getPhy );
-    txInfo->CurrentPayloadSize = phyParam.Value;
+    txInfo->current_payload_size = phyParam.Value;
 
     // Verify if the fOpts fit into the maximum payload
-    if( txInfo->CurrentPayloadSize >= fOptLen )
+    if( txInfo->current_payload_size >= fOptLen )
     {
-        txInfo->MaxPossiblePayload = txInfo->CurrentPayloadSize - fOptLen;
+        txInfo->max_possible_payload_size = txInfo->current_payload_size - fOptLen;
     }
     else
     {
-        txInfo->MaxPossiblePayload = txInfo->CurrentPayloadSize;
+        txInfo->max_possible_payload_size = txInfo->current_payload_size;
         // The fOpts don't fit into the maximum payload. Omit the MAC commands to
         // ensure that another uplink is possible.
         fOptLen = 0;
@@ -1887,32 +1883,32 @@ LoRaMacStatus_t LoRaMac::LoRaMacQueryTxPossible( uint8_t size, LoRaMacTxInfo_t* 
     // Verify if the fOpts and the payload fit into the maximum payload
     if( ValidatePayloadLength( size, datarate, fOptLen ) == false )
     {
-        return LORAMAC_STATUS_LENGTH_ERROR;
+        return LORAWAN_STATUS_LENGTH_ERROR;
     }
-    return LORAMAC_STATUS_OK;
+    return LORAWAN_STATUS_OK;
 }
 
-LoRaMacStatus_t LoRaMac::AddChannelPlan(const lora_channelplan_t& plan)
+lorawan_status_t LoRaMac::AddChannelPlan(const lorawan_channelplan_t& plan)
 {
     // Validate if the MAC is in a correct state
-    if( ( _params.LoRaMacState & LORAMAC_TX_RUNNING ) == LORAMAC_TX_RUNNING )
+    if( ( _params.mac_state & LORAMAC_TX_RUNNING ) == LORAMAC_TX_RUNNING )
     {
-        if( ( _params.LoRaMacState & LORAMAC_TX_CONFIG ) != LORAMAC_TX_CONFIG )
+        if( ( _params.mac_state & LORAMAC_TX_CONFIG ) != LORAMAC_TX_CONFIG )
         {
-            return LORAMAC_STATUS_BUSY;
+            return LORAWAN_STATUS_BUSY;
         }
     }
 
     return ch_plan.set_plan(plan);
 }
 
-LoRaMacStatus_t LoRaMac::RemoveChannelPlan()
+lorawan_status_t LoRaMac::RemoveChannelPlan()
 {
-    if( ( _params.LoRaMacState & LORAMAC_TX_RUNNING ) == LORAMAC_TX_RUNNING )
+    if( ( _params.mac_state & LORAMAC_TX_RUNNING ) == LORAMAC_TX_RUNNING )
     {
-        if( ( _params.LoRaMacState & LORAMAC_TX_CONFIG ) != LORAMAC_TX_CONFIG )
+        if( ( _params.mac_state & LORAMAC_TX_CONFIG ) != LORAMAC_TX_CONFIG )
         {
-            return LORAMAC_STATUS_BUSY;
+            return LORAWAN_STATUS_BUSY;
         }
     }
 
@@ -1920,46 +1916,46 @@ LoRaMacStatus_t LoRaMac::RemoveChannelPlan()
 
 }
 
-LoRaMacStatus_t LoRaMac::GetChannelPlan(lora_channelplan_t& plan)
+lorawan_status_t LoRaMac::GetChannelPlan(lorawan_channelplan_t& plan)
 {
     return ch_plan.get_plan(plan, &_params);
 }
 
-LoRaMacStatus_t LoRaMac::RemoveSingleChannel(uint8_t id)
+lorawan_status_t LoRaMac::RemoveSingleChannel(uint8_t id)
 {
-    if( ( _params.LoRaMacState & LORAMAC_TX_RUNNING ) == LORAMAC_TX_RUNNING )
+    if( ( _params.mac_state & LORAMAC_TX_RUNNING ) == LORAMAC_TX_RUNNING )
     {
-        if( ( _params.LoRaMacState & LORAMAC_TX_CONFIG ) != LORAMAC_TX_CONFIG )
+        if( ( _params.mac_state & LORAMAC_TX_CONFIG ) != LORAMAC_TX_CONFIG )
         {
-            return LORAMAC_STATUS_BUSY;
+            return LORAWAN_STATUS_BUSY;
         }
     }
 
     return ch_plan.remove_single_channel(id);
 }
 
-LoRaMacStatus_t LoRaMac::LoRaMacMulticastChannelLink( MulticastParams_t *channelParam )
+lorawan_status_t LoRaMac::LoRaMacMulticastChannelLink( multicast_params_t *channelParam )
 {
     if( channelParam == NULL )
     {
-        return LORAMAC_STATUS_PARAMETER_INVALID;
+        return LORAWAN_STATUS_PARAMETER_INVALID;
     }
-    if( ( _params.LoRaMacState & LORAMAC_TX_RUNNING ) == LORAMAC_TX_RUNNING )
+    if( ( _params.mac_state & LORAMAC_TX_RUNNING ) == LORAMAC_TX_RUNNING )
     {
-        return LORAMAC_STATUS_BUSY;
+        return LORAWAN_STATUS_BUSY;
     }
 
     // Reset downlink counter
-    channelParam->DownLinkCounter = 0;
+    channelParam->dl_frame_counter = 0;
 
-    if( _params.MulticastChannels == NULL )
+    if( _params.multicast_channels == NULL )
     {
         // New node is the fist element
-        _params.MulticastChannels = channelParam;
+        _params.multicast_channels = channelParam;
     }
     else
     {
-        MulticastParams_t *cur = _params.MulticastChannels;
+        multicast_params_t *cur = _params.multicast_channels;
 
         // Search the last node in the list
         while( cur->Next != NULL )
@@ -1970,30 +1966,30 @@ LoRaMacStatus_t LoRaMac::LoRaMacMulticastChannelLink( MulticastParams_t *channel
         cur->Next = channelParam;
     }
 
-    return LORAMAC_STATUS_OK;
+    return LORAWAN_STATUS_OK;
 }
 
-LoRaMacStatus_t LoRaMac::LoRaMacMulticastChannelUnlink( MulticastParams_t *channelParam )
+lorawan_status_t LoRaMac::LoRaMacMulticastChannelUnlink( multicast_params_t *channelParam )
 {
     if( channelParam == NULL )
     {
-        return LORAMAC_STATUS_PARAMETER_INVALID;
+        return LORAWAN_STATUS_PARAMETER_INVALID;
     }
-    if( ( _params.LoRaMacState & LORAMAC_TX_RUNNING ) == LORAMAC_TX_RUNNING )
+    if( ( _params.mac_state & LORAMAC_TX_RUNNING ) == LORAMAC_TX_RUNNING )
     {
-        return LORAMAC_STATUS_BUSY;
+        return LORAWAN_STATUS_BUSY;
     }
 
-    if( _params.MulticastChannels != NULL )
+    if( _params.multicast_channels != NULL )
     {
-        if( _params.MulticastChannels == channelParam )
+        if( _params.multicast_channels == channelParam )
         {
           // First element
-            _params.MulticastChannels = channelParam->Next;
+            _params.multicast_channels = channelParam->Next;
         }
         else
         {
-            MulticastParams_t *cur = _params.MulticastChannels;
+            multicast_params_t *cur = _params.multicast_channels;
 
             // Search the node in the list
             while( cur->Next && cur->Next != channelParam )
@@ -2009,25 +2005,29 @@ LoRaMacStatus_t LoRaMac::LoRaMacMulticastChannelUnlink( MulticastParams_t *chann
         channelParam->Next = NULL;
     }
 
-    return LORAMAC_STATUS_OK;
+    return LORAWAN_STATUS_OK;
 }
 
-LoRaMacStatus_t LoRaMac::LoRaMacMlmeRequest( MlmeReq_t *mlmeRequest )
+lorawan_status_t LoRaMac::LoRaMacMlmeRequest( loramac_mlme_req_t *mlmeRequest )
 {
     return mlme.set_request(mlmeRequest, &_params);
 }
 
-LoRaMacStatus_t LoRaMac::LoRaMacMcpsRequest( McpsReq_t *mcpsRequest )
+lorawan_status_t LoRaMac::LoRaMacMcpsRequest( loramac_mcps_req_t *mcpsRequest )
 {
+    if (_params.mac_state != LORAMAC_IDLE) {
+        return LORAWAN_STATUS_BUSY;
+    }
+
     return mcps.set_request(mcpsRequest, &_params);
 }
 
-LoRaMacStatus_t LoRaMac::LoRaMacMibGetRequestConfirm( MibRequestConfirm_t *mibGet )
+lorawan_status_t LoRaMac::LoRaMacMibGetRequestConfirm( loramac_mib_req_confirm_t *mibGet )
 {
     return mib.get_request(mibGet, &_params);
 }
 
-LoRaMacStatus_t LoRaMac::LoRaMacMibSetRequestConfirm( MibRequestConfirm_t *mibSet )
+lorawan_status_t LoRaMac::LoRaMacMibSetRequestConfirm( loramac_mib_req_confirm_t *mibSet )
 {
     return mib.set_request(mibSet, &_params);
 }
@@ -2048,30 +2048,30 @@ radio_events_t *LoRaMac::GetPhyEventHandlers()
  * Compliance testing                                                      *
  **************************************************************************/
 
-LoRaMacStatus_t LoRaMac::LoRaMacSetTxTimer( uint32_t TxDutyCycleTime )
+lorawan_status_t LoRaMac::LoRaMacSetTxTimer( uint32_t TxDutyCycleTime )
 {
-    _lora_time.TimerSetValue(&TxNextPacketTimer, TxDutyCycleTime);
-    _lora_time.TimerStart(&TxNextPacketTimer);
+    _lora_time.TimerSetValue(&tx_next_packet_timer, TxDutyCycleTime);
+    _lora_time.TimerStart(&tx_next_packet_timer);
 
-    return LORAMAC_STATUS_OK;
+    return LORAWAN_STATUS_OK;
 }
 
-LoRaMacStatus_t LoRaMac::LoRaMacStopTxTimer( )
+ lorawan_status_t LoRaMac::LoRaMacStopTxTimer( )
 {
-    _lora_time.TimerStop(&TxNextPacketTimer);
+    _lora_time.TimerStop(&tx_next_packet_timer);
 
-    return LORAMAC_STATUS_OK;
+    return LORAWAN_STATUS_OK;
 }
 
 void LoRaMac::LoRaMacTestRxWindowsOn( bool enable )
 {
-    _params.IsRxWindowsEnabled = enable;
+    _params.is_rx_window_enabled = enable;
 }
 
 void LoRaMac::LoRaMacTestSetMic( uint16_t txPacketCounter )
 {
-    _params.UpLinkCounter = txPacketCounter;
-    _params.IsUpLinkCounterFixed = true;
+    _params.ul_frame_counter = txPacketCounter;
+    _params.is_ul_frame_counter_fixed = true;
 }
 
 void LoRaMac::LoRaMacTestSetDutyCycleOn( bool enable )
@@ -2082,12 +2082,12 @@ void LoRaMac::LoRaMacTestSetDutyCycleOn( bool enable )
 
     if(lora_phy->verify(&verify, PHY_DUTY_CYCLE) == true)
     {
-        _params.DutyCycleOn = enable;
+        _params.is_dutycycle_on = enable;
     }
 }
 
 void LoRaMac::LoRaMacTestSetChannel( uint8_t channel )
 {
-    _params.Channel = channel;
+    _params.channel = channel;
 }
 #endif

--- a/features/lorawan/lorastack/mac/LoRaMac.h
+++ b/features/lorawan/lorastack/mac/LoRaMac.h
@@ -83,12 +83,11 @@ public:
      * \param   queue [in]- A pointer to the application provided EventQueue.
      *
      * \retval  `LoRaMacStatus_t` The status of the operation. The possible values are:
-     *          \ref LORAMAC_STATUS_OK
-     *          \ref LORAMAC_STATUS_PARAMETER_INVALID
-     *          \ref LORAMAC_STATUS_REGION_NOT_SUPPORTED.
+     *          \ref LORAWAN_STATUS_OK
+     *          \ref LORAWAN_STATUS_PARAMETER_INVALID
+     *          \ref LORAWAN_STATUS_REGION_NOT_SUPPORTED.
      */
-    LoRaMacStatus_t LoRaMacInitialization(LoRaMacPrimitives_t *primitives,
-                                          LoRaMacCallback_t *callbacks,
+    lorawan_status_t LoRaMacInitialization(loramac_primitives_t *primitives,
                                           LoRaPHY *phy,
                                           events::EventQueue *queue);
 
@@ -105,16 +104,16 @@ public:
      *                         size, taking the scheduled MAC commands into account.
      *
      * \retval  `LoRaMacStatus_t` The status of the operation. When the parameters are
-     *          not valid, the function returns \ref LORAMAC_STATUS_PARAMETER_INVALID.
+     *          not valid, the function returns \ref LORAWAN_STATUS_PARAMETER_INVALID.
      *          In case of a length error caused by the applicable payload in combination
-     *          with the MAC commands, the function returns \ref LORAMAC_STATUS_LENGTH_ERROR.
+     *          with the MAC commands, the function returns \ref LORAWAN_STATUS_LENGTH_ERROR.
      *          Please note that if the size of the MAC commands in the queue do
      *          not fit into the payload size on the related datarate, the LoRaMAC will
      *          omit the MAC commands.
      *          If the query is valid, and the LoRaMAC is able to send the frame,
-     *          the function returns \ref LORAMAC_STATUS_OK.
+     *          the function returns \ref LORAWAN_STATUS_OK.
      */
-    LoRaMacStatus_t LoRaMacQueryTxPossible( uint8_t size, LoRaMacTxInfo_t* txInfo );
+    lorawan_status_t LoRaMacQueryTxPossible( uint8_t size, loramac_tx_info_t* txInfo );
 
     /*!
      * \brief   Adds a channel plan to the system.
@@ -127,11 +126,11 @@ public:
      * \param   plan [in] - A reference to application provided channel plan.
      *
      * \retval  `LoRaMacStatus_t` The status of the operation. The possible values are:
-     *          \ref LORAMAC_STATUS_OK
-     *          \ref LORAMAC_STATUS_BUSY
-     *          \ref LORAMAC_STATUS_PARAMETER_INVALID
+     *          \ref LORAWAN_STATUS_OK
+     *          \ref LORAWAN_STATUS_BUSY
+     *          \ref LORAWAN_STATUS_PARAMETER_INVALID
      */
-    LoRaMacStatus_t AddChannelPlan(const lora_channelplan_t& plan);
+    lorawan_status_t AddChannelPlan(const lorawan_channelplan_t& plan);
 
     /*!
      * \brief   Removes a channel plan from the system.
@@ -142,11 +141,11 @@ public:
      *          LoRaWAN Regional Parameters V1.0.2rB.
      *
      * \retval  `LoRaMacStatus_t` The status of the operation. The possible values are:
-     *          \ref LORAMAC_STATUS_OK
-     *          \ref LORAMAC_STATUS_BUSY
-     *          \ref LORAMAC_STATUS_PARAMETER_INVALID
+     *          \ref LORAWAN_STATUS_OK
+     *          \ref LORAWAN_STATUS_BUSY
+     *          \ref LORAWAN_STATUS_PARAMETER_INVALID
      */
-    LoRaMacStatus_t RemoveChannelPlan();
+    lorawan_status_t RemoveChannelPlan();
 
     /*!
      * \brief   Access active channel plan.
@@ -158,11 +157,11 @@ public:
      *                       plan.
      *
      * \retval  `LoRaMacStatus_t` The status of the operation. The possible values are:
-     *          \ref LORAMAC_STATUS_OK
-     *          \ref LORAMAC_STATUS_BUSY
-     *          \ref LORAMAC_STATUS_PARAMETER_INVALID
+     *          \ref LORAWAN_STATUS_OK
+     *          \ref LORAWAN_STATUS_BUSY
+     *          \ref LORAWAN_STATUS_PARAMETER_INVALID
      */
-    LoRaMacStatus_t GetChannelPlan(lora_channelplan_t& plan);
+    lorawan_status_t GetChannelPlan(lorawan_channelplan_t& plan);
 
     /*!
      * \brief   Remove a given channel from the active plan.
@@ -172,11 +171,11 @@ public:
      * \param   id - Id of the channel.
      *
      * \retval  `LoRaMacStatus_t` The status of the operation. The possible values are:
-     *          \ref LORAMAC_STATUS_OK
-     *          \ref LORAMAC_STATUS_BUSY
-     *          \ref LORAMAC_STATUS_PARAMETER_INVALID
+     *          \ref LORAWAN_STATUS_OK
+     *          \ref LORAWAN_STATUS_BUSY
+     *          \ref LORAWAN_STATUS_PARAMETER_INVALID
      */
-    LoRaMacStatus_t RemoveSingleChannel( uint8_t id );
+    lorawan_status_t RemoveSingleChannel( uint8_t id );
 
     /*!
      * \brief   LoRaMAC multicast channel link service.
@@ -186,11 +185,11 @@ public:
      * \param   [in] channelParam - The multicast channel parameters to link.
      *
      * \retval  `LoRaMacStatus_t` The  status of the operation. The possible values are:
-     *          \ref LORAMAC_STATUS_OK
-     *          \ref LORAMAC_STATUS_BUSY
-     *          \ref LORAMAC_STATUS_PARAMETER_INVALID
+     *          \ref LORAWAN_STATUS_OK
+     *          \ref LORAWAN_STATUS_BUSY
+     *          \ref LORAWAN_STATUS_PARAMETER_INVALID
      */
-    LoRaMacStatus_t LoRaMacMulticastChannelLink( MulticastParams_t *channelParam );
+    lorawan_status_t LoRaMacMulticastChannelLink( multicast_params_t *channelParam );
 
     /*!
      * \brief   LoRaMAC multicast channel unlink service.
@@ -200,11 +199,11 @@ public:
      * \param   [in] channelParam - The multicast channel parameters to unlink.
      *
      * \retval  `LoRaMacStatus_t` The status of the operation. The possible values are:
-     *          \ref LORAMAC_STATUS_OK
-     *          \ref LORAMAC_STATUS_BUSY
-     *          \ref LORAMAC_STATUS_PARAMETER_INVALID
+     *          \ref LORAWAN_STATUS_OK
+     *          \ref LORAWAN_STATUS_BUSY
+     *          \ref LORAWAN_STATUS_PARAMETER_INVALID
      */
-    LoRaMacStatus_t LoRaMacMulticastChannelUnlink( MulticastParams_t *channelParam );
+    lorawan_status_t LoRaMacMulticastChannelUnlink( multicast_params_t *channelParam );
 
     /*!
      * \brief   LoRaMAC MIB-GET.
@@ -218,7 +217,7 @@ public:
      * MibRequestConfirm_t mibReq;
      * mibReq.Type = MIB_ADR;
      *
-     * if( LoRaMacMibGetRequestConfirm( &mibReq ) == LORAMAC_STATUS_OK )
+     * if( LoRaMacMibGetRequestConfirm( &mibReq ) == LORAWAN_STATUS_OK )
      * {
      *   // LoRaMAC updated the parameter mibParam.AdrEnable
      * }
@@ -227,11 +226,11 @@ public:
      * \param   [in] mibGet - The MIB-GET request to perform. Refer to \ref MibRequestConfirm_t.
      *
      * \retval  `LoRaMacStatus_t` The status of the operation. The possible values are:
-     *          \ref LORAMAC_STATUS_OK
-     *          \ref LORAMAC_STATUS_SERVICE_UNKNOWN
-     *          \ref LORAMAC_STATUS_PARAMETER_INVALID
+     *          \ref LORAWAN_STATUS_OK
+     *          \ref LORAWAN_STATUS_SERVICE_UNKNOWN
+     *          \ref LORAWAN_STATUS_PARAMETER_INVALID
      */
-    LoRaMacStatus_t LoRaMacMibGetRequestConfirm( MibRequestConfirm_t *mibGet );
+    lorawan_status_t LoRaMacMibGetRequestConfirm( loramac_mib_req_confirm_t *mibGet );
 
     /*!
      * \brief   LoRaMAC MIB-SET.
@@ -247,7 +246,7 @@ public:
      * mibReq.Type = MIB_ADR;
      * mibReq.Param.AdrEnable = true;
      *
-     * if( LoRaMacMibGetRequestConfirm( &mibReq ) == LORAMAC_STATUS_OK )
+     * if( LoRaMacMibGetRequestConfirm( &mibReq ) == LORAWAN_STATUS_OK )
      * {
      *   // LoRaMAC updated the parameter
      * }
@@ -256,12 +255,12 @@ public:
      * \param   [in] mibSet - The MIB-SET request to perform. Refer to \ref MibRequestConfirm_t.
      *
      * \retval  `LoRaMacStatus_t` The status of the operation. The possible values are:
-     *          \ref LORAMAC_STATUS_OK
-     *          \ref LORAMAC_STATUS_BUSY
-     *          \ref LORAMAC_STATUS_SERVICE_UNKNOWN
-     *          \ref LORAMAC_STATUS_PARAMETER_INVALID
+     *          \ref LORAWAN_STATUS_OK
+     *          \ref LORAWAN_STATUS_BUSY
+     *          \ref LORAWAN_STATUS_SERVICE_UNKNOWN
+     *          \ref LORAWAN_STATUS_PARAMETER_INVALID
      */
-    LoRaMacStatus_t LoRaMacMibSetRequestConfirm( MibRequestConfirm_t *mibSet );
+    lorawan_status_t LoRaMacMibSetRequestConfirm( loramac_mib_req_confirm_t *mibSet );
 
     /*!
      * \brief   LoRaMAC MLME request
@@ -291,7 +290,7 @@ public:
      * mlmeReq.Req.Join.AppEui = AppEui;
      * mlmeReq.Req.Join.AppKey = AppKey;
      *
-     * if( LoRaMacMlmeRequest( &mlmeReq ) == LORAMAC_STATUS_OK )
+     * if( LoRaMacMlmeRequest( &mlmeReq ) == LORAWAN_STATUS_OK )
      * {
      *   // Service started successfully. Waiting for the Mlme-Confirm event
      * }
@@ -300,15 +299,15 @@ public:
      * \param   [in] mlmeRequest - The MLME request to perform. Refer to \ref MlmeReq_t.
      *
      * \retval  `LoRaMacStatus_t` The status of the operation. The possible values are:
-     *          \ref LORAMAC_STATUS_OK
-     *          \ref LORAMAC_STATUS_BUSY
-     *          \ref LORAMAC_STATUS_SERVICE_UNKNOWN
-     *          \ref LORAMAC_STATUS_PARAMETER_INVALID
-     *          \ref LORAMAC_STATUS_NO_NETWORK_JOINED
-     *          \ref LORAMAC_STATUS_LENGTH_ERROR
-     *          \ref LORAMAC_STATUS_DEVICE_OFF
+     *          \ref LORAWAN_STATUS_OK
+     *          \ref LORAWAN_STATUS_BUSY
+     *          \ref LORAWAN_STATUS_SERVICE_UNKNOWN
+     *          \ref LORAWAN_STATUS_PARAMETER_INVALID
+     *          \ref LORAWAN_STATUS_NO_NETWORK_JOINED
+     *          \ref LORAWAN_STATUS_LENGTH_ERROR
+     *          \ref LORAWAN_STATUS_DEVICE_OFF
      */
-    LoRaMacStatus_t LoRaMacMlmeRequest( MlmeReq_t *mlmeRequest );
+    lorawan_status_t LoRaMacMlmeRequest( loramac_mlme_req_t *mlmeRequest );
 
     /*!
      * \brief   LoRaMAC MCPS request
@@ -326,7 +325,7 @@ public:
      * mcpsReq.Req.Unconfirmed.fBuffer = myBuffer;
      * mcpsReq.Req.Unconfirmed.fBufferSize = sizeof( myBuffer );
      *
-     * if( LoRaMacMcpsRequest( &mcpsReq ) == LORAMAC_STATUS_OK )
+     * if( LoRaMacMcpsRequest( &mcpsReq ) == LORAWAN_STATUS_OK )
      * {
      *   // Service started successfully. Waiting for the MCPS-Confirm event
      * }
@@ -335,15 +334,15 @@ public:
      * \param   [in] mcpsRequest - The MCPS request to perform. Refer to \ref McpsReq_t.
      *
      * \retval  `LoRaMacStatus_t` The status of the operation. The possible values are:
-     *          \ref LORAMAC_STATUS_OK
-     *          \ref LORAMAC_STATUS_BUSY
-     *          \ref LORAMAC_STATUS_SERVICE_UNKNOWN
-     *          \ref LORAMAC_STATUS_PARAMETER_INVALID
-     *          \ref LORAMAC_STATUS_NO_NETWORK_JOINED
-     *          \ref LORAMAC_STATUS_LENGTH_ERROR
-     *          \ref LORAMAC_STATUS_DEVICE_OFF
+     *          \ref LORAWAN_STATUS_OK
+     *          \ref LORAWAN_STATUS_BUSY
+     *          \ref LORAWAN_STATUS_SERVICE_UNKNOWN
+     *          \ref LORAWAN_STATUS_PARAMETER_INVALID
+     *          \ref LORAWAN_STATUS_NO_NETWORK_JOINED
+     *          \ref LORAWAN_STATUS_LENGTH_ERROR
+     *          \ref LORAWAN_STATUS_DEVICE_OFF
      */
-    LoRaMacStatus_t LoRaMacMcpsRequest( McpsReq_t *mcpsRequest );
+    lorawan_status_t LoRaMacMcpsRequest( loramac_mcps_req_t *mcpsRequest );
 
     /**
      * \brief LoRaMAC layer provides its callback functions for
@@ -368,7 +367,7 @@ public:
      * \param [IN] fBufferSize MAC data buffer size
      * \retval status          Status of the operation.
      */
-    LoRaMacStatus_t Send( LoRaMacHeader_t *macHdr, uint8_t fPort, void *fBuffer, uint16_t fBufferSize );
+    lorawan_status_t Send( loramac_mhdr_t *macHdr, uint8_t fPort, void *fBuffer, uint16_t fBufferSize );
 
     /*!
      * \brief Sets the radio in continuous transmission mode
@@ -378,7 +377,7 @@ public:
      * \param [IN] timeout     Time in seconds while the radio is kept in continuous wave mode
      * \retval status          Status of the operation.
      */
-    LoRaMacStatus_t SetTxContinuousWave( uint16_t timeout );
+    lorawan_status_t SetTxContinuousWave( uint16_t timeout );
 
     /*!
      * \brief Sets the radio in continuous transmission mode
@@ -390,7 +389,7 @@ public:
      * \param [IN] power       RF output power to be set.
      * \retval status          Status of the operation.
      */
-    LoRaMacStatus_t SetTxContinuousWave1( uint16_t timeout, uint32_t frequency, uint8_t power );
+    lorawan_status_t SetTxContinuousWave1( uint16_t timeout, uint32_t frequency, uint8_t power );
 
     /*!
      * \brief Resets MAC specific parameters to default
@@ -414,10 +413,10 @@ public: // Test interface
      * \param   [in] NextTxTime - Periodic time for next uplink.
 
      * \retval  `LoRaMacStatus_t` The status of the operation. The possible values are:
-     *          \ref LORAMAC_STATUS_OK
-     *          \ref LORAMAC_STATUS_PARAMETER_INVALID
+     *          \ref LORAWAN_STATUS_OK
+     *          \ref LORAWAN_STATUS_PARAMETER_INVALID
      */
-    LoRaMacStatus_t LoRaMacSetTxTimer( uint32_t NextTxTime );
+    lorawan_status_t LoRaMacSetTxTimer( uint32_t NextTxTime );
 
     /**
      * \brief   LoRaMAC stop tx timer.
@@ -425,10 +424,10 @@ public: // Test interface
      * \details Stops the next tx timer.
      *
      * \retval  `LoRaMacStatus_t` The status of the operation. The possible values are:
-     *          \ref LORAMAC_STATUS_OK
-     *          \ref LORAMAC_STATUS_PARAMETER_INVALID
+     *          \ref LORAWAN_STATUS_OK
+     *          \ref LORAWAN_STATUS_PARAMETER_INVALID
      */
-    LoRaMacStatus_t LoRaMacStopTxTimer( );
+    lorawan_status_t LoRaMacStopTxTimer( );
 
     /**
      * \brief   Enabled or disables the reception windows
@@ -474,7 +473,7 @@ private:
     /**
      * Timer to handle the application data transmission duty cycle
      */
-    TimerEvent_t TxNextPacketTimer;
+    timer_event_t tx_next_packet_timer;
 #endif
 
 private:
@@ -576,14 +575,14 @@ private:
      * \param [IN] fBufferSize MAC data buffer size
      * \retval status          Status of the operation.
      */
-    LoRaMacStatus_t PrepareFrame( LoRaMacHeader_t *macHdr, LoRaMacFrameCtrl_t *fCtrl, uint8_t fPort, void *fBuffer, uint16_t fBufferSize );
+    lorawan_status_t PrepareFrame( loramac_mhdr_t *macHdr, loramac_frame_ctrl_t *fCtrl, uint8_t fPort, void *fBuffer, uint16_t fBufferSize );
 
     /*
      * \brief Schedules the frame according to the duty cycle
      *
      * \retval Status of the operation
      */
-    LoRaMacStatus_t ScheduleTx( void );
+    lorawan_status_t ScheduleTx( void );
 
     /*
      * \brief Calculates the back-off time for the band of a channel.
@@ -601,7 +600,7 @@ private:
      * \param [IN] channel     Channel to transmit on
      * \retval status          Status of the operation.
      */
-    LoRaMacStatus_t SendFrameOnChannel( uint8_t channel );
+    lorawan_status_t SendFrameOnChannel( uint8_t channel );
 
     /*!
      * \brief Resets MAC specific parameters to default
@@ -669,7 +668,7 @@ private:
     /**
      * Central MAC layer data storage
      */
-    lora_mac_protocol_params _params;
+    loramac_protocol_params _params;
 
     /**
      * Radio event callback handlers for MAC
@@ -679,12 +678,7 @@ private:
     /*!
      * LoRaMac upper layer event functions
      */
-    LoRaMacPrimitives_t *LoRaMacPrimitives;
-
-    /*!
-     * LoRaMac upper layer callback functions
-     */
-    LoRaMacCallback_t *LoRaMacCallbacks;
+    loramac_primitives_t *LoRaMacPrimitives;
 };
 
 

--- a/features/lorawan/lorastack/mac/LoRaMacChannelPlan.cpp
+++ b/features/lorawan/lorastack/mac/LoRaMacChannelPlan.cpp
@@ -39,11 +39,11 @@ void LoRaMacChannelPlan::activate_channelplan_subsystem(LoRaPHY *phy, LoRaMacMib
     _mib = mib;
 }
 
-LoRaMacStatus_t LoRaMacChannelPlan::set_plan(const lora_channelplan_t& plan)
+lorawan_status_t LoRaMacChannelPlan::set_plan(const lorawan_channelplan_t& plan)
 {
     ChannelAddParams_t channelAdd;
-    ChannelParams_t mac_layer_ch_params;
-    LoRaMacStatus_t status;
+    channel_params_t mac_layer_ch_params;
+    lorawan_status_t status;
 
     GetPhyParams_t get_phy;
     PhyParam_t phy_param;
@@ -56,20 +56,20 @@ LoRaMacStatus_t LoRaMacChannelPlan::set_plan(const lora_channelplan_t& plan)
 
     // check if user is setting more channels than supported
     if (plan.nb_channels > max_num_channels) {
-        return LORAMAC_STATUS_PARAMETER_INVALID;
+        return LORAWAN_STATUS_PARAMETER_INVALID;
     }
 
     for (uint8_t i = 0; i < plan.nb_channels; i++) {
-        mac_layer_ch_params.Band = plan.channels[i].ch_param.band;
-        mac_layer_ch_params.DrRange.Fields.Max =
-                plan.channels[i].ch_param.dr_range.lora_mac_fields_s.max;
-        mac_layer_ch_params.DrRange.Fields.Min =
-                plan.channels[i].ch_param.dr_range.lora_mac_fields_s.min;
-        mac_layer_ch_params.DrRange.Value =
+        mac_layer_ch_params.band = plan.channels[i].ch_param.band;
+        mac_layer_ch_params.dr_range.fields.max =
+                plan.channels[i].ch_param.dr_range.fields.max;
+        mac_layer_ch_params.dr_range.fields.min =
+                plan.channels[i].ch_param.dr_range.fields.min;
+        mac_layer_ch_params.dr_range.value =
                 plan.channels[i].ch_param.dr_range.value;
-        mac_layer_ch_params.Frequency =
+        mac_layer_ch_params.frequency =
                 plan.channels[i].ch_param.frequency;
-        mac_layer_ch_params.Rx1Frequency =
+        mac_layer_ch_params.rx1_frequency =
                 plan.channels[i].ch_param.rx1_frequency;
 
         channelAdd.ChannelId = plan.channels[i].id;
@@ -77,23 +77,23 @@ LoRaMacStatus_t LoRaMacChannelPlan::set_plan(const lora_channelplan_t& plan)
 
         status = _lora_phy->add_channel(&channelAdd);
 
-        if (status != LORAMAC_STATUS_OK) {
+        if (status != LORAWAN_STATUS_OK) {
             return status;
         }
     }
 
-    return LORAMAC_STATUS_OK;
+    return LORAWAN_STATUS_OK;
 }
 
-LoRaMacStatus_t LoRaMacChannelPlan::get_plan(lora_channelplan_t& plan,
-                                             lora_mac_protocol_params *params)
+lorawan_status_t LoRaMacChannelPlan::get_plan(lorawan_channelplan_t& plan,
+                                             loramac_protocol_params *params)
 {
     if (params == NULL) {
-        return LORAMAC_STATUS_PARAMETER_INVALID;
+        return LORAWAN_STATUS_PARAMETER_INVALID;
     }
 
-    MibRequestConfirm_t mib_params;
-    LoRaMacStatus_t status;
+    loramac_mib_req_confirm_t mib_confirm;
+    lorawan_status_t status;
 
     GetPhyParams_t get_phy;
     PhyParam_t phy_param;
@@ -112,12 +112,12 @@ LoRaMacStatus_t LoRaMacChannelPlan::get_plan(lora_channelplan_t& plan,
     channel_masks = phy_param.ChannelsMask;
 
     // Request Mib to get channels
-    memset(&mib_params, 0, sizeof(mib_params));
-    mib_params.Type = MIB_CHANNELS;
+    memset(&mib_confirm, 0, sizeof(mib_confirm));
+    mib_confirm.type = MIB_CHANNELS;
 
-    status = _mib->get_request(&mib_params, params);
+    status = _mib->get_request(&mib_confirm, params);
 
-    if (status != LORAMAC_STATUS_OK) {
+    if (status != LORAWAN_STATUS_OK) {
         return status;
     }
 
@@ -129,23 +129,23 @@ LoRaMacStatus_t LoRaMacChannelPlan::get_plan(lora_channelplan_t& plan,
 
         // otherwise add them to the channel_plan struct
         plan.channels[count].id = i;
-        plan.channels[count].ch_param.frequency = mib_params.Param.ChannelList[i].Frequency;
-        plan.channels[count].ch_param.dr_range.value = mib_params.Param.ChannelList[i].DrRange.Value;
-        plan.channels[count].ch_param.dr_range.lora_mac_fields_s.min = mib_params.Param.ChannelList[i].DrRange.Fields.Min;
-        plan.channels[count].ch_param.dr_range.lora_mac_fields_s.max = mib_params.Param.ChannelList[i].DrRange.Fields.Max;
-        plan.channels[count].ch_param.band = mib_params.Param.ChannelList[i].Band;
-        plan.channels[count].ch_param.rx1_frequency = mib_params.Param.ChannelList[i].Rx1Frequency;
+        plan.channels[count].ch_param.frequency = mib_confirm.param.channel_list[i].frequency;
+        plan.channels[count].ch_param.dr_range.value = mib_confirm.param.channel_list[i].dr_range.value;
+        plan.channels[count].ch_param.dr_range.fields.min = mib_confirm.param.channel_list[i].dr_range.fields.min;
+        plan.channels[count].ch_param.dr_range.fields.max = mib_confirm.param.channel_list[i].dr_range.fields.max;
+        plan.channels[count].ch_param.band = mib_confirm.param.channel_list[i].band;
+        plan.channels[count].ch_param.rx1_frequency = mib_confirm.param.channel_list[i].rx1_frequency;
         count++;
     }
 
     plan.nb_channels = count;
 
-    return LORAMAC_STATUS_OK;
+    return LORAWAN_STATUS_OK;
 }
 
-LoRaMacStatus_t LoRaMacChannelPlan::remove_plan()
+lorawan_status_t LoRaMacChannelPlan::remove_plan()
 {
-    LoRaMacStatus_t status = LORAMAC_STATUS_OK;
+    lorawan_status_t status = LORAWAN_STATUS_OK;
 
     GetPhyParams_t get_phy;
     PhyParam_t phy_param;
@@ -181,7 +181,7 @@ LoRaMacStatus_t LoRaMacChannelPlan::remove_plan()
 
         status = remove_single_channel(i);
 
-        if (status != LORAMAC_STATUS_OK) {
+        if (status != LORAWAN_STATUS_OK) {
             return status;
         }
     }
@@ -189,7 +189,7 @@ LoRaMacStatus_t LoRaMacChannelPlan::remove_plan()
     return status;
 }
 
-LoRaMacStatus_t LoRaMacChannelPlan::remove_single_channel(uint8_t channel_id)
+lorawan_status_t LoRaMacChannelPlan::remove_single_channel(uint8_t channel_id)
 {
     GetPhyParams_t get_phy;
     PhyParam_t phy_param;
@@ -206,7 +206,7 @@ LoRaMacStatus_t LoRaMacChannelPlan::remove_single_channel(uint8_t channel_id)
     // channel ID is N-1 where N=MAX_NUM_CHANNELS.
     // So any ID which is larger or equal to the Max number of channels is invalid
     if (channel_id >= max_num_channels) {
-        return LORAMAC_STATUS_PARAMETER_INVALID;
+        return LORAWAN_STATUS_PARAMETER_INVALID;
     }
 
     // Now check the Default channel mask
@@ -219,18 +219,18 @@ LoRaMacStatus_t LoRaMacChannelPlan::remove_single_channel(uint8_t channel_id)
     // have multiple channel masks for various sub-bands. So we check the first
     // mask only and return an error code if user sent a default channel id
     if ((channel_masks[0] & (1U << channel_id)) != 0) {
-        return LORAMAC_STATUS_PARAMETER_INVALID;
+        return LORAWAN_STATUS_PARAMETER_INVALID;
     }
 
     channelRemove.ChannelId = channel_id;
 
     if(_lora_phy->remove_channel(&channelRemove) == false)
     {
-        return LORAMAC_STATUS_PARAMETER_INVALID;
+        return LORAWAN_STATUS_PARAMETER_INVALID;
     }
 
     _lora_phy->put_radio_to_sleep();
 
-    return LORAMAC_STATUS_OK;
+    return LORAWAN_STATUS_OK;
 }
 

--- a/features/lorawan/lorastack/mac/LoRaMacChannelPlan.h
+++ b/features/lorawan/lorastack/mac/LoRaMacChannelPlan.h
@@ -64,10 +64,10 @@ public:
      * @param plan    a reference to application channel plan. PHY layer takes a
      *                copy of the channel parameters provided within.
      *
-     * @return        LORA_MAC_STATUS_OK if everything goes well otherwise
+     * @return        LORAWAN_STATUS_OK if everything goes well otherwise
      *                a negative error code is returned.
      */
-    LoRaMacStatus_t set_plan(const lora_channelplan_t& plan);
+    lorawan_status_t set_plan(const lorawan_channelplan_t& plan);
 
     /** Access the active channel plan
      *
@@ -78,28 +78,28 @@ public:
      *
      * @param params    pointer to active MAC layer parameters.
      *
-     * @return          LORA_MAC_STATUS_OK if everything goes well otherwise
+     * @return          LORAWAN_STATUS_OK if everything goes well otherwise
      *                  a negative error code is returned.
      */
-    LoRaMacStatus_t get_plan(lora_channelplan_t& plan, lora_mac_protocol_params *params);
+    lorawan_status_t get_plan(lorawan_channelplan_t& plan, loramac_protocol_params *params);
 
     /** Remove the active channel plan
      *
      * Drops the whole channel list except the 'Default Channels' ofcourse.
      *
-     * @return        LORA_MAC_STATUS_OK if everything goes well otherwise
+     * @return        LORAWAN_STATUS_OK if everything goes well otherwise
      *                a negative error code is returned.
      */
-    LoRaMacStatus_t remove_plan();
+    lorawan_status_t remove_plan();
 
     /** Remove a single channel from the plan
      *
      * @param id    the channel id which needs to be removed
      *
-     * @return      LORA_MAC_STATUS_OK if everything goes well otherwise
+     * @return      LORAWAN_STATUS_OK if everything goes well otherwise
      *              a negative error code is returned.
      */
-    LoRaMacStatus_t remove_single_channel(uint8_t id);
+    lorawan_status_t remove_single_channel(uint8_t id);
 
 private:
 

--- a/features/lorawan/lorastack/mac/LoRaMacCommand.cpp
+++ b/features/lorawan/lorastack/mac/LoRaMacCommand.cpp
@@ -53,9 +53,9 @@ LoRaMacCommand::~LoRaMacCommand()
 {
 }
 
-LoRaMacStatus_t LoRaMacCommand::AddMacCommand(uint8_t cmd, uint8_t p1, uint8_t p2)
+lorawan_status_t LoRaMacCommand::AddMacCommand(uint8_t cmd, uint8_t p1, uint8_t p2)
 {
-    LoRaMacStatus_t status = LORAMAC_STATUS_BUSY;
+    lorawan_status_t status = LORAWAN_STATUS_BUSY;
     // The maximum buffer length must take MAC commands to re-send into account.
     const uint8_t bufLen = LORA_MAC_COMMAND_MAX_LENGTH - MacCommandsBufferToRepeatIndex;
 
@@ -66,7 +66,7 @@ LoRaMacStatus_t LoRaMacCommand::AddMacCommand(uint8_t cmd, uint8_t p1, uint8_t p
             {
                 MacCommandsBuffer[MacCommandsBufferIndex++] = cmd;
                 // No payload for this command
-                status = LORAMAC_STATUS_OK;
+                status = LORAWAN_STATUS_OK;
             }
             break;
         case MOTE_MAC_LINK_ADR_ANS:
@@ -75,7 +75,7 @@ LoRaMacStatus_t LoRaMacCommand::AddMacCommand(uint8_t cmd, uint8_t p1, uint8_t p
                 MacCommandsBuffer[MacCommandsBufferIndex++] = cmd;
                 // Margin
                 MacCommandsBuffer[MacCommandsBufferIndex++] = p1;
-                status = LORAMAC_STATUS_OK;
+                status = LORAWAN_STATUS_OK;
             }
             break;
         case MOTE_MAC_DUTY_CYCLE_ANS:
@@ -83,7 +83,7 @@ LoRaMacStatus_t LoRaMacCommand::AddMacCommand(uint8_t cmd, uint8_t p1, uint8_t p
             {
                 MacCommandsBuffer[MacCommandsBufferIndex++] = cmd;
                 // No payload for this answer
-                status = LORAMAC_STATUS_OK;
+                status = LORAWAN_STATUS_OK;
             }
             break;
         case MOTE_MAC_RX_PARAM_SETUP_ANS:
@@ -94,7 +94,7 @@ LoRaMacStatus_t LoRaMacCommand::AddMacCommand(uint8_t cmd, uint8_t p1, uint8_t p
                 MacCommandsBuffer[MacCommandsBufferIndex++] = p1;
                 // This is a sticky MAC command answer. Setup indication
                 _lora_mac.SetMlmeScheduleUplinkIndication();
-                status = LORAMAC_STATUS_OK;
+                status = LORAWAN_STATUS_OK;
             }
             break;
         case MOTE_MAC_DEV_STATUS_ANS:
@@ -105,7 +105,7 @@ LoRaMacStatus_t LoRaMacCommand::AddMacCommand(uint8_t cmd, uint8_t p1, uint8_t p
                 // 2nd byte Margin
                 MacCommandsBuffer[MacCommandsBufferIndex++] = p1;
                 MacCommandsBuffer[MacCommandsBufferIndex++] = p2;
-                status = LORAMAC_STATUS_OK;
+                status = LORAWAN_STATUS_OK;
             }
             break;
         case MOTE_MAC_NEW_CHANNEL_ANS:
@@ -114,7 +114,7 @@ LoRaMacStatus_t LoRaMacCommand::AddMacCommand(uint8_t cmd, uint8_t p1, uint8_t p
                 MacCommandsBuffer[MacCommandsBufferIndex++] = cmd;
                 // Status: Datarate range OK, Channel frequency OK
                 MacCommandsBuffer[MacCommandsBufferIndex++] = p1;
-                status = LORAMAC_STATUS_OK;
+                status = LORAWAN_STATUS_OK;
             }
             break;
         case MOTE_MAC_RX_TIMING_SETUP_ANS:
@@ -124,7 +124,7 @@ LoRaMacStatus_t LoRaMacCommand::AddMacCommand(uint8_t cmd, uint8_t p1, uint8_t p
                 // No payload for this answer
                 // This is a sticky MAC command answer. Setup indication
                 _lora_mac.SetMlmeScheduleUplinkIndication();
-                status = LORAMAC_STATUS_OK;
+                status = LORAWAN_STATUS_OK;
             }
             break;
         case MOTE_MAC_TX_PARAM_SETUP_ANS:
@@ -132,7 +132,7 @@ LoRaMacStatus_t LoRaMacCommand::AddMacCommand(uint8_t cmd, uint8_t p1, uint8_t p
             {
                 MacCommandsBuffer[MacCommandsBufferIndex++] = cmd;
                 // No payload for this answer
-                status = LORAMAC_STATUS_OK;
+                status = LORAWAN_STATUS_OK;
             }
             break;
         case MOTE_MAC_DL_CHANNEL_ANS:
@@ -143,13 +143,13 @@ LoRaMacStatus_t LoRaMacCommand::AddMacCommand(uint8_t cmd, uint8_t p1, uint8_t p
                 MacCommandsBuffer[MacCommandsBufferIndex++] = p1;
                 // This is a sticky MAC command answer. Setup indication
                 _lora_mac.SetMlmeScheduleUplinkIndication();
-                status = LORAMAC_STATUS_OK;
+                status = LORAWAN_STATUS_OK;
             }
             break;
         default:
-            return LORAMAC_STATUS_SERVICE_UNKNOWN;
+            return LORAWAN_STATUS_SERVICE_UNKNOWN;
     }
-    if( status == LORAMAC_STATUS_OK )
+    if( status == LORAWAN_STATUS_OK )
     {
         MacCommandsInNextTx = true;
     }
@@ -251,9 +251,11 @@ bool LoRaMacCommand::IsMacCommandsInNextTx() const
     return MacCommandsInNextTx;
 }
 
-void LoRaMacCommand::ProcessMacCommands(uint8_t *payload, uint8_t macIndex, uint8_t commandsSize, uint8_t snr,
-                                        MlmeConfirm_t& MlmeConfirm, LoRaMacCallback_t *LoRaMacCallbacks,
-                                        lora_mac_system_params_t &LoRaMacParams, LoRaPHY &lora_phy)
+void LoRaMacCommand::ProcessMacCommands(uint8_t *payload, uint8_t macIndex,
+                                        uint8_t commandsSize, uint8_t snr,
+                                        loramac_mlme_confirm_t& MlmeConfirm,
+                                        lora_mac_system_params_t &LoRaMacParams,
+                                        LoRaPHY &lora_phy)
 {
     uint8_t status = 0;
 
@@ -263,9 +265,9 @@ void LoRaMacCommand::ProcessMacCommands(uint8_t *payload, uint8_t macIndex, uint
         switch( payload[macIndex++] )
         {
             case SRV_MAC_LINK_CHECK_ANS:
-                MlmeConfirm.Status = LORAMAC_EVENT_INFO_STATUS_OK;
-                MlmeConfirm.DemodMargin = payload[macIndex++];
-                MlmeConfirm.NbGateways = payload[macIndex++];
+                MlmeConfirm.status = LORAMAC_EVENT_INFO_STATUS_OK;
+                MlmeConfirm.demod_margin = payload[macIndex++];
+                MlmeConfirm.nb_gateways = payload[macIndex++];
                 break;
             case SRV_MAC_LINK_ADR_REQ:
                 {
@@ -278,11 +280,11 @@ void LoRaMacCommand::ProcessMacCommands(uint8_t *payload, uint8_t macIndex, uint
                     // Fill parameter structure
                     linkAdrReq.Payload = &payload[macIndex - 1];
                     linkAdrReq.PayloadSize = commandsSize - ( macIndex - 1 );
-                    linkAdrReq.AdrEnabled = LoRaMacParams.AdrCtrlOn;
-                    linkAdrReq.UplinkDwellTime = LoRaMacParams.UplinkDwellTime;
-                    linkAdrReq.CurrentDatarate = LoRaMacParams.ChannelsDatarate;
-                    linkAdrReq.CurrentTxPower = LoRaMacParams.ChannelsTxPower;
-                    linkAdrReq.CurrentNbRep = LoRaMacParams.ChannelsNbRep;
+                    linkAdrReq.AdrEnabled = LoRaMacParams.adr_on;
+                    linkAdrReq.UplinkDwellTime = LoRaMacParams.uplink_dwell_time;
+                    linkAdrReq.CurrentDatarate = LoRaMacParams.channel_data_rate;
+                    linkAdrReq.CurrentTxPower = LoRaMacParams.channel_tx_power;
+                    linkAdrReq.CurrentNbRep = LoRaMacParams.retry_num;
 
                     // Process the ADR requests
                     status = lora_phy.link_ADR_request(&linkAdrReq, &linkAdrDatarate,
@@ -291,9 +293,9 @@ void LoRaMacCommand::ProcessMacCommands(uint8_t *payload, uint8_t macIndex, uint
 
                     if( ( status & 0x07 ) == 0x07 )
                     {
-                        LoRaMacParams.ChannelsDatarate = linkAdrDatarate;
-                        LoRaMacParams.ChannelsTxPower = linkAdrTxPower;
-                        LoRaMacParams.ChannelsNbRep = linkAdrNbRep;
+                        LoRaMacParams.channel_data_rate = linkAdrDatarate;
+                        LoRaMacParams.channel_tx_power = linkAdrTxPower;
+                        LoRaMacParams.retry_num = linkAdrNbRep;
                     }
 
                     // Add the answers to the buffer
@@ -306,8 +308,8 @@ void LoRaMacCommand::ProcessMacCommands(uint8_t *payload, uint8_t macIndex, uint
                 }
                 break;
             case SRV_MAC_DUTY_CYCLE_REQ:
-                LoRaMacParams.MaxDCycle = payload[macIndex++];
-                LoRaMacParams.AggregatedDCycle = 1 << LoRaMacParams.MaxDCycle;
+                LoRaMacParams.max_duty_cycle = payload[macIndex++];
+                LoRaMacParams.aggregated_duty_cycle = 1 << LoRaMacParams.max_duty_cycle;
                 AddMacCommand( MOTE_MAC_DUTY_CYCLE_ANS, 0, 0 );
                 break;
             case SRV_MAC_RX_PARAM_SETUP_REQ:
@@ -329,9 +331,9 @@ void LoRaMacCommand::ProcessMacCommands(uint8_t *payload, uint8_t macIndex, uint
 
                     if( ( status & 0x07 ) == 0x07 )
                     {
-                        LoRaMacParams.Rx2Channel.Datarate = rxParamSetupReq.Datarate;
-                        LoRaMacParams.Rx2Channel.Frequency = rxParamSetupReq.Frequency;
-                        LoRaMacParams.Rx1DrOffset = rxParamSetupReq.DrOffset;
+                        LoRaMacParams.rx2_channel.datarate = rxParamSetupReq.Datarate;
+                        LoRaMacParams.rx2_channel.frequency = rxParamSetupReq.Frequency;
+                        LoRaMacParams.rx1_dr_offset = rxParamSetupReq.DrOffset;
                     }
                     AddMacCommand( MOTE_MAC_RX_PARAM_SETUP_ANS, status, 0 );
                 }
@@ -339,28 +341,26 @@ void LoRaMacCommand::ProcessMacCommands(uint8_t *payload, uint8_t macIndex, uint
             case SRV_MAC_DEV_STATUS_REQ:
                 {
                     uint8_t batteryLevel = BAT_LEVEL_NO_MEASURE;
-                    if( ( LoRaMacCallbacks != NULL ) && ( LoRaMacCallbacks->GetBatteryLevel != NULL ) )
-                    {
-                        batteryLevel = LoRaMacCallbacks->GetBatteryLevel( );
-                    }
+                    // we don't have a mechanism at the moment to measure
+                    // battery levels
                     AddMacCommand( MOTE_MAC_DEV_STATUS_ANS, batteryLevel, snr );
                     break;
                 }
             case SRV_MAC_NEW_CHANNEL_REQ:
                 {
                     NewChannelReqParams_t newChannelReq;
-                    ChannelParams_t chParam;
+                    channel_params_t chParam;
                     status = 0x03;
 
                     newChannelReq.ChannelId = payload[macIndex++];
                     newChannelReq.NewChannel = &chParam;
 
-                    chParam.Frequency = ( uint32_t )payload[macIndex++];
-                    chParam.Frequency |= ( uint32_t )payload[macIndex++] << 8;
-                    chParam.Frequency |= ( uint32_t )payload[macIndex++] << 16;
-                    chParam.Frequency *= 100;
-                    chParam.Rx1Frequency = 0;
-                    chParam.DrRange.Value = payload[macIndex++];
+                    chParam.frequency = ( uint32_t )payload[macIndex++];
+                    chParam.frequency |= ( uint32_t )payload[macIndex++] << 8;
+                    chParam.frequency |= ( uint32_t )payload[macIndex++] << 16;
+                    chParam.frequency *= 100;
+                    chParam.rx1_frequency = 0;
+                    chParam.dr_range.value = payload[macIndex++];
 
                     status = lora_phy.request_new_channel(&newChannelReq);
 
@@ -375,8 +375,8 @@ void LoRaMacCommand::ProcessMacCommands(uint8_t *payload, uint8_t macIndex, uint
                     {
                         delay++;
                     }
-                    LoRaMacParams.ReceiveDelay1 = delay * 1000;
-                    LoRaMacParams.ReceiveDelay2 = LoRaMacParams.ReceiveDelay1 + 1000;
+                    LoRaMacParams.recv_delay1 = delay * 1000;
+                    LoRaMacParams.recv_delay2 = LoRaMacParams.recv_delay1 + 1000;
                     AddMacCommand( MOTE_MAC_RX_TIMING_SETUP_ANS, 0, 0 );
                 }
                 break;
@@ -402,9 +402,9 @@ void LoRaMacCommand::ProcessMacCommands(uint8_t *payload, uint8_t macIndex, uint
                     if( lora_phy.setup_tx_params(&txParamSetupReq ) != -1 )
                     {
                         // Accept command
-                        LoRaMacParams.UplinkDwellTime = txParamSetupReq.UplinkDwellTime;
-                        LoRaMacParams.DownlinkDwellTime = txParamSetupReq.DownlinkDwellTime;
-                        LoRaMacParams.MaxEirp = LoRaMacMaxEirpTable[txParamSetupReq.MaxEirp];
+                        LoRaMacParams.uplink_dwell_time = txParamSetupReq.UplinkDwellTime;
+                        LoRaMacParams.downlink_dwell_time = txParamSetupReq.DownlinkDwellTime;
+                        LoRaMacParams.max_eirp = LoRaMacMaxEirpTable[txParamSetupReq.MaxEirp];
                         // Add command response
                         AddMacCommand( MOTE_MAC_TX_PARAM_SETUP_ANS, 0, 0 );
                     }

--- a/features/lorawan/lorastack/mac/LoRaMacCommand.h
+++ b/features/lorawan/lorastack/mac/LoRaMacCommand.h
@@ -74,7 +74,7 @@ public:
      *
      * \retval status  Function status [0: OK, 1: Unknown command, 2: Buffer full]
      */
-    LoRaMacStatus_t AddMacCommand(uint8_t cmd, uint8_t p1, uint8_t p2);
+    lorawan_status_t AddMacCommand(uint8_t cmd, uint8_t p1, uint8_t p2);
 
     /*!
      * \brief Clear MAC command buffer.
@@ -132,9 +132,11 @@ public:
     /*!
      * \brief Decodes MAC commands in the fOpts field and in the payload
      */
-    void ProcessMacCommands(uint8_t *payload, uint8_t macIndex, uint8_t commandsSize, uint8_t snr,
-                            MlmeConfirm_t &MlmeConfirm, LoRaMacCallback_t *LoRaMacCallbacks,
-                            lora_mac_system_params_t &LoRaMacParams, LoRaPHY &lora_phy);
+    void ProcessMacCommands(uint8_t *payload, uint8_t macIndex,
+                            uint8_t commandsSize, uint8_t snr,
+                            loramac_mlme_confirm_t& MlmeConfirm,
+                            lora_mac_system_params_t& LoRaMacParams,
+                            LoRaPHY& lora_phy);
 
     /*!
      * \brief Verifies if sticky MAC commands are pending.

--- a/features/lorawan/lorastack/mac/LoRaMacCrypto.cpp
+++ b/features/lorawan/lorastack/mac/LoRaMacCrypto.cpp
@@ -298,7 +298,7 @@ int LoRaMacComputeMic( const uint8_t *, uint16_t , const uint8_t *, uint32_t,
     MBED_ASSERT("[LoRaCrypto] Must enable AES, CMAC & CIPHER from mbedTLS");
 
     // Never actually reaches here
-    return LORA_MAC_STATUS_CRYPTO_FAIL;
+    return LORAWAN_STATUS_CRYPTO_FAIL;
 }
 
 int LoRaMacPayloadEncrypt( const uint8_t *, uint16_t , const uint8_t *, uint32_t,
@@ -307,7 +307,7 @@ int LoRaMacPayloadEncrypt( const uint8_t *, uint16_t , const uint8_t *, uint32_t
     MBED_ASSERT("[LoRaCrypto] Must enable AES, CMAC & CIPHER from mbedTLS");
 
     // Never actually reaches here
-    return LORA_MAC_STATUS_CRYPTO_FAIL;
+    return LORAWAN_STATUS_CRYPTO_FAIL;
 }
 
 int LoRaMacPayloadDecrypt( const uint8_t *, uint16_t , const uint8_t *, uint32_t,
@@ -316,14 +316,14 @@ int LoRaMacPayloadDecrypt( const uint8_t *, uint16_t , const uint8_t *, uint32_t
     MBED_ASSERT("[LoRaCrypto] Must enable AES, CMAC & CIPHER from mbedTLS");
 
     // Never actually reaches here
-    return LORA_MAC_STATUS_CRYPTO_FAIL;
+    return LORAWAN_STATUS_CRYPTO_FAIL;
 }
 int LoRaMacJoinComputeMic( const uint8_t *, uint16_t , const uint8_t *, uint32_t * )
 {
     MBED_ASSERT("[LoRaCrypto] Must enable AES, CMAC & CIPHER from mbedTLS");
 
     // Never actually reaches here
-    return LORA_MAC_STATUS_CRYPTO_FAIL;
+    return LORAWAN_STATUS_CRYPTO_FAIL;
 }
 
 int LoRaMacJoinDecrypt( const uint8_t *, uint16_t , const uint8_t *, uint8_t * )
@@ -331,7 +331,7 @@ int LoRaMacJoinDecrypt( const uint8_t *, uint16_t , const uint8_t *, uint8_t * )
     MBED_ASSERT("[LoRaCrypto] Must enable AES, CMAC & CIPHER from mbedTLS");
 
     // Never actually reaches here
-    return LORA_MAC_STATUS_CRYPTO_FAIL;
+    return LORAWAN_STATUS_CRYPTO_FAIL;
 }
 
 int LoRaMacJoinComputeSKeys( const uint8_t *, const uint8_t *, uint16_t , uint8_t *, uint8_t * )
@@ -339,7 +339,7 @@ int LoRaMacJoinComputeSKeys( const uint8_t *, const uint8_t *, uint16_t , uint8_
     MBED_ASSERT("[LoRaCrypto] Must enable AES, CMAC & CIPHER from mbedTLS");
 
     // Never actually reaches here
-    return LORA_MAC_STATUS_CRYPTO_FAIL;
+    return LORAWAN_STATUS_CRYPTO_FAIL;
 }
 
 #endif

--- a/features/lorawan/lorastack/mac/LoRaMacMcps.h
+++ b/features/lorawan/lorastack/mac/LoRaMacMcps.h
@@ -67,16 +67,16 @@ public:
      * @param mcpsRequest    pointer to MCPS request structure
      * @param params         pointer to MAC protocol parameters
      *
-     * @return               LORA_MAC_STATUS_OK if everything goes well otherwise
+     * @return               LORAWAN_STATUS_OK if everything goes well otherwise
      *                       a negative error code is returned.
      */
-    LoRaMacStatus_t set_request(McpsReq_t *mcpsRequest, lora_mac_protocol_params *params);
+    lorawan_status_t set_request(loramac_mcps_req_t *mcpsRequest, loramac_protocol_params *params);
 
     /** Grants access to MCPS confirmation data
      *
      * @return               a reference to MCPS confirm data structure
      */
-    inline McpsConfirm_t& get_confirmation()
+    inline loramac_mcps_confirm_t& get_confirmation()
     {
         return confirmation;
     }
@@ -85,7 +85,7 @@ public:
      *
      * @return               a reference to MCPS indication data structure
      */
-    inline McpsIndication_t& get_indication()
+    inline loramac_mcps_indication_t& get_indication()
     {
         return indication;
     }
@@ -102,12 +102,12 @@ private:
     /**
      * Structure to hold MCPS indication data.
      */
-    McpsIndication_t indication;
+    loramac_mcps_indication_t indication;
 
     /**
      * Structure to hold MCPS confirm data.
      */
-    McpsConfirm_t confirmation;
+    loramac_mcps_confirm_t confirmation;
 };
 
 #endif /* MBED_OS_LORAWAN_MAC_MCPS_H_ */

--- a/features/lorawan/lorastack/mac/LoRaMacMib.h
+++ b/features/lorawan/lorastack/mac/LoRaMacMib.h
@@ -67,10 +67,11 @@ public:
      * @param mibSet [in]    pointer to MIB request structure
      * @param params         pointer to MAC protocol parameters which will be modified
      *
-     * @return               LORA_MAC_STATUS_OK if everything goes well otherwise
+     * @return               LORAWAN_STATUS_OK if everything goes well otherwise
      *                       a negative error code is returned.
      */
-    LoRaMacStatus_t set_request(MibRequestConfirm_t *mibSet, lora_mac_protocol_params *params);
+    lorawan_status_t set_request(loramac_mib_req_confirm_t *mibSet,
+                                 loramac_protocol_params *params);
 
     /** Provides access to the given MIB parameter
      *
@@ -80,10 +81,11 @@ public:
      * @param mibGet [out]   pointer to MIB request structure which will be filled in
      * @param params         pointer to MAC protocol parameters
      *
-     * @return               LORA_MAC_STATUS_OK if everything goes well otherwise
+     * @return               LORAWAN_STATUS_OK if everything goes well otherwise
      *                       a negative error code is returned.
      */
-    LoRaMacStatus_t get_request(MibRequestConfirm_t *mibGet, lora_mac_protocol_params *params);
+    lorawan_status_t get_request(loramac_mib_req_confirm_t *mibGet,
+                                 loramac_protocol_params *params);
 
 private:
 

--- a/features/lorawan/lorastack/mac/LoRaMacMlme.h
+++ b/features/lorawan/lorastack/mac/LoRaMacMlme.h
@@ -69,16 +69,16 @@ public:
      * @param mlmeRequest    pointer to MLME request structure
      * @param params         pointer to MAC protocol parameters
      *
-     * @return               LORA_MAC_STATUS_OK if everything goes well otherwise
+     * @return               LORAWAN_STATUS_OK if everything goes well otherwise
      *                       a negative error code is returned.
      */
-    LoRaMacStatus_t set_request(MlmeReq_t *mlmeRequest, lora_mac_protocol_params *params);
+    lorawan_status_t set_request(loramac_mlme_req_t *mlmeRequest, loramac_protocol_params *params);
 
     /** Grants access to MLME confirmation data
      *
      * @return               a reference to MLME confirm data structure
      */
-    inline MlmeConfirm_t& get_confirmation()
+    inline loramac_mlme_confirm_t& get_confirmation()
     {
         return confirmation;
     }
@@ -87,7 +87,7 @@ public:
      *
      * @return               a reference to MLME indication data structure
      */
-    inline MlmeIndication_t& get_indication()
+    inline loramac_mlme_indication_t& get_indication()
     {
         return indication;
     }
@@ -104,12 +104,12 @@ private:
     /**
      * Structure to hold MLME indication data.
      */
-    MlmeIndication_t indication;
+    loramac_mlme_indication_t indication;
 
     /**
      * Structure to hold MLME confirm data.
      */
-    MlmeConfirm_t confirmation;
+    loramac_mlme_confirm_t confirmation;
 };
 
 #endif /* MBED_OS_LORAWAN_MAC_MLME_H_ */

--- a/features/lorawan/lorastack/phy/LoRaPHY.h
+++ b/features/lorawan/lorastack/phy/LoRaPHY.h
@@ -136,7 +136,7 @@ public:
      *
      * \retval True, if the configuration was applied successfully.
      */
-    virtual bool rx_config(RxConfigParams_t* rxConfig, int8_t* datarate ) = 0;
+    virtual bool rx_config(rx_config_params_t* rxConfig, int8_t* datarate ) = 0;
 
     /*
      * RX window precise timing
@@ -193,7 +193,7 @@ public:
     virtual void compute_rx_win_params(int8_t datarate,
                                                  uint8_t minRxSymbols,
                                                  uint32_t rxError,
-                                                 RxConfigParams_t *rxConfigParams) = 0;
+                                                 rx_config_params_t *rxConfigParams) = 0;
     /*!
      * \brief TX configuration.
      *
@@ -206,7 +206,7 @@ public:
      * \retval True, if the configuration was applied successfully.
      */
     virtual bool tx_config(TxConfigParams_t* txConfig, int8_t* txPower,
-                                TimerTime_t* txTimeOnAir ) = 0;
+                                lorawan_time_t* txTimeOnAir ) = 0;
 
     /*!
      * \brief The function processes a Link ADR Request.
@@ -296,8 +296,8 @@ public:
      * \retval Function status [1: OK, 0: Unable to find a channel on the current datarate].
      */
     virtual bool set_next_channel(NextChanParams_t* nextChanParams,
-                                   uint8_t* channel, TimerTime_t* time,
-                                   TimerTime_t* aggregatedTimeOff ) = 0;
+                                   uint8_t* channel, lorawan_time_t* time,
+                                   lorawan_time_t* aggregatedTimeOff ) = 0;
 
     /*!
      * \brief Adds a channel.
@@ -306,7 +306,7 @@ public:
      *
      * \retval The status of the operation.
      */
-    virtual LoRaMacStatus_t add_channel(ChannelAddParams_t* channelAdd ) = 0;
+    virtual lorawan_status_t add_channel(ChannelAddParams_t* channelAdd ) = 0;
 
     /*!
      * \brief Removes a channel.
@@ -418,7 +418,7 @@ protected:
         /*!
          * A pointer to the channels.
          */
-        ChannelParams_t* Channels;
+        channel_params_t* Channels;
         /*!
          * The minimum possible TX power.
          */
@@ -434,11 +434,11 @@ protected:
         /*!
          * A pointer to region specific channels.
          */
-        ChannelParams_t* Channels;
+        channel_params_t* Channels;
         /*!
          * A pointer to region specific bands.
          */
-        Band_t* Bands;
+        band_t* Bands;
         /*!
          * Set to true, if the last uplink was a join request.
          */
@@ -458,11 +458,11 @@ protected:
         /*!
          * The elapsed time since initialization.
          */
-        TimerTime_t ElapsedTime;
+        lorawan_time_t ElapsedTime;
         /*!
          * The time on air of the last TX frame.
          */
-        TimerTime_t TxTimeOnAir;
+        lorawan_time_t TxTimeOnAir;
     }RegionCommonCalcBackOffParams_t;
 
     /*!
@@ -473,7 +473,7 @@ protected:
      *
      * \retval Duty cycle restriction.
      */
-    uint16_t get_join_DC( TimerTime_t elapsedTime );
+    uint16_t get_join_DC( lorawan_time_t elapsedTime );
 
     /*!
      * \brief Verifies, if a value is in a given range.
@@ -508,7 +508,7 @@ protected:
      * \retval True if the datarate is supported, false if not.
      */
     bool verify_channel_DR( uint8_t nbChannels, uint16_t* channelsMask, int8_t dr,
-                                int8_t minDr, int8_t maxDr, ChannelParams_t* channels );
+                                int8_t minDr, int8_t maxDr, channel_params_t* channels );
 
     /*!
      * \brief Disables a channel in a given channels mask.
@@ -560,7 +560,7 @@ protected:
      *
      * \param [in] lastTxDone The time of the last TX done.
      */
-    void set_last_tx_done( bool joined, Band_t* band, TimerTime_t lastTxDone );
+    void set_last_tx_done( bool joined, band_t* band, lorawan_time_t lastTxDone );
 
     /*!
      * \brief Updates the time-offs of the bands.
@@ -576,7 +576,7 @@ protected:
      *
      * \retval The time which must be waited to perform the next uplink.
      */
-    TimerTime_t update_band_timeoff( bool joined, bool dutyCycle, Band_t* bands, uint8_t nbBands );
+    lorawan_time_t update_band_timeoff( bool joined, bool dutyCycle, band_t* bands, uint8_t nbBands );
 
     /*!
      * \brief Parses the parameter of an LinkAdrRequest.

--- a/features/lorawan/lorastack/phy/LoRaPHYAS923.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHYAS923.cpp
@@ -321,7 +321,7 @@ static bool VerifyTxFreq( uint32_t freq )
 
 uint8_t LoRaPHYAS923::CountNbOfEnabledChannels(bool joined, uint8_t datarate,
                                                uint16_t* channelsMask,
-                                               ChannelParams_t* channels, Band_t* bands,
+                                               channel_params_t* channels, band_t* bands,
                                                uint8_t* enabledChannels, uint8_t* delayTx)
 {
     uint8_t nbEnabledChannels = 0;
@@ -333,7 +333,7 @@ uint8_t LoRaPHYAS923::CountNbOfEnabledChannels(bool joined, uint8_t datarate,
         {
             if( ( channelsMask[k] & ( 1 << j ) ) != 0 )
             {
-                if( channels[i + j].Frequency == 0 )
+                if( channels[i + j].frequency == 0 )
                 { // Check if the channel is enabled
                     continue;
                 }
@@ -344,12 +344,12 @@ uint8_t LoRaPHYAS923::CountNbOfEnabledChannels(bool joined, uint8_t datarate,
                         continue;
                     }
                 }
-                if( val_in_range( datarate, channels[i + j].DrRange.Fields.Min,
-                                              channels[i + j].DrRange.Fields.Max ) == 0 )
+                if( val_in_range( datarate, channels[i + j].dr_range.fields.min,
+                                              channels[i + j].dr_range.fields.max ) == 0 )
                 { // Check if the current channel selection supports the given datarate
                     continue;
                 }
-                if( bands[channels[i + j].Band].TimeOff > 0 )
+                if( bands[channels[i + j].band].off_time > 0 )
                 { // Check if the band is available for transmission
                     delayTransmission++;
                     continue;
@@ -366,7 +366,7 @@ uint8_t LoRaPHYAS923::CountNbOfEnabledChannels(bool joined, uint8_t datarate,
 LoRaPHYAS923::LoRaPHYAS923(LoRaWANTimeHandler &lora_time)
     : LoRaPHY(lora_time)
 {
-    const Band_t band0 = AS923_BAND0;
+    const band_t band0 = AS923_BAND0;
     Bands[0] = band0;
 }
 
@@ -562,7 +562,7 @@ PhyParam_t LoRaPHYAS923::get_phy_params(GetPhyParams_t* getPhy)
 
 void LoRaPHYAS923::set_band_tx_done(SetBandTxDoneParams_t* txDone)
 {
-    set_last_tx_done( txDone->Joined, &Bands[Channels[txDone->Channel].Band], txDone->LastTxDoneTime );
+    set_last_tx_done( txDone->Joined, &Bands[Channels[txDone->Channel].band], txDone->LastTxDoneTime );
 }
 
 void LoRaPHYAS923::load_defaults(InitType_t type)
@@ -572,8 +572,8 @@ void LoRaPHYAS923::load_defaults(InitType_t type)
         case INIT_TYPE_INIT:
         {
             // Channels
-            const ChannelParams_t channel1 = AS923_LC1;
-            const ChannelParams_t channel2 = AS923_LC2;
+            const channel_params_t channel1 = AS923_LC1;
+            const channel_params_t channel2 = AS923_LC2;
             Channels[0] = channel1;
             Channels[1] = channel2;
 
@@ -647,12 +647,12 @@ bool LoRaPHYAS923::verify(VerifyParams_t* verify, PhyAttribute_t phyAttribute)
 
 void LoRaPHYAS923::apply_cf_list(ApplyCFListParams_t* applyCFList)
 {
-    ChannelParams_t newChannel;
+    channel_params_t newChannel;
     ChannelAddParams_t channelAdd;
     ChannelRemoveParams_t channelRemove;
 
     // Setup default datarate range
-    newChannel.DrRange.Value = ( DR_5 << 4 ) | DR_0;
+    newChannel.dr_range.value = ( DR_5 << 4 ) | DR_0;
 
     // Size of the optional CF list
     if( applyCFList->Size != 16 )
@@ -666,22 +666,22 @@ void LoRaPHYAS923::apply_cf_list(ApplyCFListParams_t* applyCFList)
         if( chanIdx < ( AS923_NUMB_CHANNELS_CF_LIST + AS923_NUMB_DEFAULT_CHANNELS ) )
         {
             // Channel frequency
-            newChannel.Frequency = (uint32_t) applyCFList->Payload[i];
-            newChannel.Frequency |= ( (uint32_t) applyCFList->Payload[i + 1] << 8 );
-            newChannel.Frequency |= ( (uint32_t) applyCFList->Payload[i + 2] << 16 );
-            newChannel.Frequency *= 100;
+            newChannel.frequency = (uint32_t) applyCFList->Payload[i];
+            newChannel.frequency |= ( (uint32_t) applyCFList->Payload[i + 1] << 8 );
+            newChannel.frequency |= ( (uint32_t) applyCFList->Payload[i + 2] << 16 );
+            newChannel.frequency *= 100;
 
             // Initialize alternative frequency to 0
-            newChannel.Rx1Frequency = 0;
+            newChannel.rx1_frequency = 0;
         }
         else
         {
-            newChannel.Frequency = 0;
-            newChannel.DrRange.Value = 0;
-            newChannel.Rx1Frequency = 0;
+            newChannel.frequency = 0;
+            newChannel.dr_range.value = 0;
+            newChannel.rx1_frequency = 0;
         }
 
-        if( newChannel.Frequency != 0 )
+        if( newChannel.frequency != 0 )
         {
             channelAdd.NewChannel = &newChannel;
             channelAdd.ChannelId = chanIdx;
@@ -791,47 +791,47 @@ bool LoRaPHYAS923::get_next_ADR(AdrNextParams_t* adrNext, int8_t* drOut,
 
 void LoRaPHYAS923::compute_rx_win_params(int8_t datarate, uint8_t minRxSymbols,
                                          uint32_t rxError,
-                                         RxConfigParams_t *rxConfigParams)
+                                         rx_config_params_t *rxConfigParams)
 {
     double tSymbol = 0.0;
 
     // Get the datarate, perform a boundary check
-    rxConfigParams->Datarate = MIN( datarate, AS923_RX_MAX_DATARATE );
-    rxConfigParams->Bandwidth = GetBandwidth( rxConfigParams->Datarate );
+    rxConfigParams->datarate = MIN( datarate, AS923_RX_MAX_DATARATE );
+    rxConfigParams->bandwidth = GetBandwidth( rxConfigParams->datarate );
 
-    if( rxConfigParams->Datarate == DR_7 )
+    if( rxConfigParams->datarate == DR_7 )
     { // FSK
-        tSymbol = compute_symb_timeout_fsk( DataratesAS923[rxConfigParams->Datarate] );
+        tSymbol = compute_symb_timeout_fsk( DataratesAS923[rxConfigParams->datarate] );
     }
     else
     { // LoRa
-        tSymbol = compute_symb_timeout_lora( DataratesAS923[rxConfigParams->Datarate], BandwidthsAS923[rxConfigParams->Datarate] );
+        tSymbol = compute_symb_timeout_lora( DataratesAS923[rxConfigParams->datarate], BandwidthsAS923[rxConfigParams->datarate] );
     }
 
-    get_rx_window_params( tSymbol, minRxSymbols, rxError, RADIO_WAKEUP_TIME, &rxConfigParams->WindowTimeout, &rxConfigParams->WindowOffset );
+    get_rx_window_params( tSymbol, minRxSymbols, rxError, RADIO_WAKEUP_TIME, &rxConfigParams->window_timeout, &rxConfigParams->window_offset );
 }
 
-bool LoRaPHYAS923::rx_config(RxConfigParams_t* rxConfig, int8_t* datarate)
+bool LoRaPHYAS923::rx_config(rx_config_params_t* rxConfig, int8_t* datarate)
 {
     radio_modems_t modem;
-    int8_t dr = rxConfig->Datarate;
+    int8_t dr = rxConfig->datarate;
     uint8_t maxPayload = 0;
     int8_t phyDr = 0;
-    uint32_t frequency = rxConfig->Frequency;
+    uint32_t frequency = rxConfig->frequency;
 
     if( _radio->get_status() != RF_IDLE )
     {
         return false;
     }
 
-    if( rxConfig->RxSlot == RX_SLOT_WIN_1 )
+    if( rxConfig->rx_slot == RX_SLOT_WIN_1 )
     {
         // Apply window 1 frequency
-        frequency = Channels[rxConfig->Channel].Frequency;
+        frequency = Channels[rxConfig->channel].frequency;
         // Apply the alternative RX 1 window frequency, if it is available
-        if( Channels[rxConfig->Channel].Rx1Frequency != 0 )
+        if( Channels[rxConfig->channel].rx1_frequency != 0 )
         {
-            frequency = Channels[rxConfig->Channel].Rx1Frequency;
+            frequency = Channels[rxConfig->channel].rx1_frequency;
         }
     }
 
@@ -845,19 +845,19 @@ bool LoRaPHYAS923::rx_config(RxConfigParams_t* rxConfig, int8_t* datarate)
     {
         modem = MODEM_FSK;
         _radio->set_rx_config(modem, 50000, phyDr * 1000, 0, 83333, 5,
-                              rxConfig->WindowTimeout, false, 0, true, 0,
-                              0, false, rxConfig->RxContinuous);
+                              rxConfig->window_timeout, false, 0, true, 0,
+                              0, false, rxConfig->is_rx_continuous);
     }
     else
     {
         modem = MODEM_LORA;
-        _radio->set_rx_config(modem, rxConfig->Bandwidth, phyDr, 1, 0, 8,
-                              rxConfig->WindowTimeout, false, 0, false, 0, 0,
-                              true, rxConfig->RxContinuous);
+        _radio->set_rx_config(modem, rxConfig->bandwidth, phyDr, 1, 0, 8,
+                              rxConfig->window_timeout, false, 0, false, 0, 0,
+                              true, rxConfig->is_rx_continuous);
     }
 
     // Check for repeater support
-    if( rxConfig->RepeaterSupport == true )
+    if( rxConfig->is_repeater_supported == true )
     {
         maxPayload = MaxPayloadOfDatarateRepeaterDwell0AS923[dr];
     }
@@ -873,11 +873,11 @@ bool LoRaPHYAS923::rx_config(RxConfigParams_t* rxConfig, int8_t* datarate)
 }
 
 bool LoRaPHYAS923::tx_config(TxConfigParams_t* txConfig, int8_t* txPower,
-                             TimerTime_t* txTimeOnAir)
+                             lorawan_time_t* txTimeOnAir)
 {
     radio_modems_t modem;
     int8_t phyDr = DataratesAS923[txConfig->Datarate];
-    int8_t txPowerLimited = LimitTxPower( txConfig->TxPower, Bands[Channels[txConfig->Channel].Band].TxMaxPower, txConfig->Datarate, ChannelsMask );
+    int8_t txPowerLimited = LimitTxPower( txConfig->TxPower, Bands[Channels[txConfig->Channel].band].max_tx_pwr, txConfig->Datarate, ChannelsMask );
     uint32_t bandwidth = GetBandwidth( txConfig->Datarate );
     int8_t phyTxPower = 0;
 
@@ -885,7 +885,7 @@ bool LoRaPHYAS923::tx_config(TxConfigParams_t* txConfig, int8_t* txPower,
     phyTxPower = compute_tx_power( txPowerLimited, txConfig->MaxEirp, txConfig->AntennaGain );
 
     // Setup the radio frequency
-    _radio->set_channel(Channels[txConfig->Channel].Frequency);
+    _radio->set_channel(Channels[txConfig->Channel].frequency);
 
     if( txConfig->Datarate == DR_7 )
     { // High Speed FSK channel
@@ -956,7 +956,7 @@ uint8_t LoRaPHYAS923::link_ADR_request(LinkAdrReqParams_t* linkAdrReq,
             {
                 if( linkAdrParams.ChMaskCtrl == 6 )
                 {
-                    if( Channels[i].Frequency != 0 )
+                    if( Channels[i].frequency != 0 )
                     {
                         chMask |= 1 << i;
                     }
@@ -964,7 +964,7 @@ uint8_t LoRaPHYAS923::link_ADR_request(LinkAdrReqParams_t* linkAdrReq,
                 else
                 {
                     if( ( ( chMask & ( 1 << i ) ) != 0 ) &&
-                        ( Channels[i].Frequency == 0 ) )
+                        ( Channels[i].frequency == 0 ) )
                     {// Trying to enable an undefined channel
                         status &= 0xFE; // Channel mask KO
                     }
@@ -1046,7 +1046,7 @@ uint8_t LoRaPHYAS923::request_new_channel(NewChannelReqParams_t* newChannelReq)
     ChannelAddParams_t channelAdd;
     ChannelRemoveParams_t channelRemove;
 
-    if( newChannelReq->NewChannel->Frequency == 0 )
+    if( newChannelReq->NewChannel->frequency == 0 )
     {
         channelRemove.ChannelId = newChannelReq->ChannelId;
 
@@ -1063,21 +1063,21 @@ uint8_t LoRaPHYAS923::request_new_channel(NewChannelReqParams_t* newChannelReq)
 
         switch( add_channel (&channelAdd ))
         {
-            case LORAMAC_STATUS_OK:
+            case LORAWAN_STATUS_OK:
             {
                 break;
             }
-            case LORAMAC_STATUS_FREQUENCY_INVALID:
+            case LORAWAN_STATUS_FREQUENCY_INVALID:
             {
                 status &= 0xFE;
                 break;
             }
-            case LORAMAC_STATUS_DATARATE_INVALID:
+            case LORAWAN_STATUS_DATARATE_INVALID:
             {
                 status &= 0xFD;
                 break;
             }
-            case LORAMAC_STATUS_FREQ_AND_DR_INVALID:
+            case LORAWAN_STATUS_FREQ_AND_DR_INVALID:
             {
                 status &= 0xFC;
                 break;
@@ -1110,7 +1110,7 @@ uint8_t LoRaPHYAS923::dl_channel_request(DlChannelReqParams_t* dlChannelReq)
     }
 
     // Verify if an uplink frequency exists
-    if( Channels[dlChannelReq->ChannelId].Frequency == 0 )
+    if( Channels[dlChannelReq->ChannelId].frequency == 0 )
     {
         status &= 0xFD;
     }
@@ -1118,7 +1118,7 @@ uint8_t LoRaPHYAS923::dl_channel_request(DlChannelReqParams_t* dlChannelReq)
     // Apply Rx1 frequency, if the status is OK
     if( status == 0x03 )
     {
-        Channels[dlChannelReq->ChannelId].Rx1Frequency = dlChannelReq->Rx1Frequency;
+        Channels[dlChannelReq->ChannelId].rx1_frequency = dlChannelReq->Rx1Frequency;
     }
 
     return status;
@@ -1147,14 +1147,14 @@ void LoRaPHYAS923::calculate_backoff(CalcBackOffParams_t* calcBackOff)
 }
 
 bool LoRaPHYAS923::set_next_channel(NextChanParams_t* nextChanParams,
-                                    uint8_t* channel, TimerTime_t* time,
-                                    TimerTime_t* aggregatedTimeOff)
+                                    uint8_t* channel, lorawan_time_t* time,
+                                    lorawan_time_t* aggregatedTimeOff)
 {
     uint8_t channelNext = 0;
     uint8_t nbEnabledChannels = 0;
     uint8_t delayTx = 0;
     uint8_t enabledChannels[AS923_MAX_NB_CHANNELS] = { 0 };
-    TimerTime_t nextTxDelay = 0;
+    lorawan_time_t nextTxDelay = 0;
 
     if( num_active_channels( ChannelsMask, 0, 1 ) == 0 )
     { // Reactivate default channels
@@ -1190,7 +1190,7 @@ bool LoRaPHYAS923::set_next_channel(NextChanParams_t* nextChanParams,
             // Perform carrier sense for AS923_CARRIER_SENSE_TIME
             // If the channel is free, we can stop the LBT mechanism
             if( _radio->perform_carrier_sense(MODEM_LORA,
-                                              Channels[channelNext].Frequency,
+                                              Channels[channelNext].frequency,
                                               AS923_RSSI_FREE_TH,
                                               AS923_CARRIER_SENSE_TIME ) == true)
             {
@@ -1217,7 +1217,7 @@ bool LoRaPHYAS923::set_next_channel(NextChanParams_t* nextChanParams,
     }
 }
 
-LoRaMacStatus_t LoRaPHYAS923::add_channel(ChannelAddParams_t* channelAdd)
+lorawan_status_t LoRaPHYAS923::add_channel(ChannelAddParams_t* channelAdd)
 {
     uint8_t band = 0;
     bool drInvalid = false;
@@ -1226,19 +1226,19 @@ LoRaMacStatus_t LoRaPHYAS923::add_channel(ChannelAddParams_t* channelAdd)
 
     if( id >= AS923_MAX_NB_CHANNELS )
     {
-        return LORAMAC_STATUS_PARAMETER_INVALID;
+        return LORAWAN_STATUS_PARAMETER_INVALID;
     }
 
     // Validate the datarate range
-    if( val_in_range( channelAdd->NewChannel->DrRange.Fields.Min, AS923_TX_MIN_DATARATE, AS923_TX_MAX_DATARATE ) == 0 )
+    if( val_in_range( channelAdd->NewChannel->dr_range.fields.min, AS923_TX_MIN_DATARATE, AS923_TX_MAX_DATARATE ) == 0 )
     {
         drInvalid = true;
     }
-    if( val_in_range( channelAdd->NewChannel->DrRange.Fields.Max, AS923_TX_MIN_DATARATE, AS923_TX_MAX_DATARATE ) == 0 )
+    if( val_in_range( channelAdd->NewChannel->dr_range.fields.max, AS923_TX_MIN_DATARATE, AS923_TX_MAX_DATARATE ) == 0 )
     {
         drInvalid = true;
     }
-    if( channelAdd->NewChannel->DrRange.Fields.Min > channelAdd->NewChannel->DrRange.Fields.Max )
+    if( channelAdd->NewChannel->dr_range.fields.min > channelAdd->NewChannel->dr_range.fields.max )
     {
         drInvalid = true;
     }
@@ -1247,17 +1247,17 @@ LoRaMacStatus_t LoRaPHYAS923::add_channel(ChannelAddParams_t* channelAdd)
     if( id < AS923_NUMB_DEFAULT_CHANNELS )
     {
         // Validate the datarate range for min: must be DR_0
-        if( channelAdd->NewChannel->DrRange.Fields.Min > DR_0 )
+        if( channelAdd->NewChannel->dr_range.fields.min > DR_0 )
         {
             drInvalid = true;
         }
         // Validate the datarate range for max: must be DR_5 <= Max <= TX_MAX_DATARATE
-        if( val_in_range( channelAdd->NewChannel->DrRange.Fields.Max, DR_5, AS923_TX_MAX_DATARATE ) == 0 )
+        if( val_in_range( channelAdd->NewChannel->dr_range.fields.max, DR_5, AS923_TX_MAX_DATARATE ) == 0 )
         {
             drInvalid = true;
         }
         // We are not allowed to change the frequency
-        if( channelAdd->NewChannel->Frequency != Channels[id].Frequency )
+        if( channelAdd->NewChannel->frequency != Channels[id].frequency )
         {
             freqInvalid = true;
         }
@@ -1266,7 +1266,7 @@ LoRaMacStatus_t LoRaPHYAS923::add_channel(ChannelAddParams_t* channelAdd)
     // Check frequency
     if( freqInvalid == false )
     {
-        if( VerifyTxFreq( channelAdd->NewChannel->Frequency ) == false )
+        if( VerifyTxFreq( channelAdd->NewChannel->frequency ) == false )
         {
             freqInvalid = true;
         }
@@ -1275,21 +1275,21 @@ LoRaMacStatus_t LoRaPHYAS923::add_channel(ChannelAddParams_t* channelAdd)
     // Check status
     if( ( drInvalid == true ) && ( freqInvalid == true ) )
     {
-        return LORAMAC_STATUS_FREQ_AND_DR_INVALID;
+        return LORAWAN_STATUS_FREQ_AND_DR_INVALID;
     }
     if( drInvalid == true )
     {
-        return LORAMAC_STATUS_DATARATE_INVALID;
+        return LORAWAN_STATUS_DATARATE_INVALID;
     }
     if( freqInvalid == true )
     {
-        return LORAMAC_STATUS_FREQUENCY_INVALID;
+        return LORAWAN_STATUS_FREQUENCY_INVALID;
     }
 
     memcpy( &(Channels[id]), channelAdd->NewChannel, sizeof( Channels[id] ) );
-    Channels[id].Band = band;
+    Channels[id].band = band;
     ChannelsMask[0] |= ( 1 << id );
-    return LORAMAC_STATUS_OK;
+    return LORAWAN_STATUS_OK;
 }
 
 bool LoRaPHYAS923::remove_channel(ChannelRemoveParams_t* channelRemove)
@@ -1302,7 +1302,7 @@ bool LoRaPHYAS923::remove_channel(ChannelRemoveParams_t* channelRemove)
     }
 
     // Remove the channel from the list of channels
-    const ChannelParams_t empty_channel = { 0, 0, { 0 }, 0 };
+    const channel_params_t empty_channel = { 0, 0, { 0 }, 0 };
     Channels[id] = empty_channel;
 
     return disable_channel( ChannelsMask, id, AS923_MAX_NB_CHANNELS );
@@ -1310,9 +1310,9 @@ bool LoRaPHYAS923::remove_channel(ChannelRemoveParams_t* channelRemove)
 
 void LoRaPHYAS923::set_tx_cont_mode(ContinuousWaveParams_t* continuousWave)
 {
-    int8_t txPowerLimited = LimitTxPower( continuousWave->TxPower, Bands[Channels[continuousWave->Channel].Band].TxMaxPower, continuousWave->Datarate, ChannelsMask );
+    int8_t txPowerLimited = LimitTxPower( continuousWave->TxPower, Bands[Channels[continuousWave->Channel].band].max_tx_pwr, continuousWave->Datarate, ChannelsMask );
     int8_t phyTxPower = 0;
-    uint32_t frequency = Channels[continuousWave->Channel].Frequency;
+    uint32_t frequency = Channels[continuousWave->Channel].frequency;
 
     // Calculate physical TX power
     phyTxPower = compute_tx_power( txPowerLimited, continuousWave->MaxEirp, continuousWave->AntennaGain );

--- a/features/lorawan/lorastack/phy/LoRaPHYAS923.h
+++ b/features/lorawan/lorastack/phy/LoRaPHYAS923.h
@@ -131,7 +131,7 @@ public:
      *
      * \retval True, if the configuration was applied successfully.
      */
-    virtual bool rx_config(RxConfigParams_t* rxConfig, int8_t* datarate );
+    virtual bool rx_config(rx_config_params_t* rxConfig, int8_t* datarate );
 
     /*
      * RX window precise timing.
@@ -187,7 +187,7 @@ public:
     virtual void compute_rx_win_params(int8_t datarate,
                                                  uint8_t minRxSymbols,
                                                  uint32_t rxError,
-                                                 RxConfigParams_t *rxConfigParams);
+                                                 rx_config_params_t *rxConfigParams);
 
     /*!
      * \brief TX configuration.
@@ -201,7 +201,7 @@ public:
      * \retval True, if the configuration was applied successfully.
      */
     virtual bool tx_config(TxConfigParams_t* txConfig, int8_t* txPower,
-                                TimerTime_t* txTimeOnAir );
+                                lorawan_time_t* txTimeOnAir );
 
     /*!
      * \brief The function processes a Link ADR Request.
@@ -291,8 +291,8 @@ public:
      * \retval Function status [1: OK, 0: Unable to find a channel on the current datarate].
      */
     virtual bool set_next_channel(NextChanParams_t* nextChanParams,
-                                   uint8_t* channel, TimerTime_t* time,
-                                   TimerTime_t* aggregatedTimeOff );
+                                   uint8_t* channel, lorawan_time_t* time,
+                                   lorawan_time_t* aggregatedTimeOff );
 
     /*!
      * \brief Adds a channel.
@@ -301,7 +301,7 @@ public:
      *
      * \retval The status of the operation.
      */
-    virtual LoRaMacStatus_t add_channel(ChannelAddParams_t* channelAdd );
+    virtual lorawan_status_t add_channel(ChannelAddParams_t* channelAdd );
 
     /*!
      * \brief Removes a channel.
@@ -335,19 +335,19 @@ public:
 private:
     uint8_t CountNbOfEnabledChannels(bool joined, uint8_t datarate,
                                      uint16_t* channelsMask,
-                                     ChannelParams_t* channels, Band_t* bands,
+                                     channel_params_t* channels, band_t* bands,
                                      uint8_t* enabledChannels, uint8_t* delayTx);
 
     // Global attributes
     /*!
      * LoRaMAC channels
      */
-    ChannelParams_t Channels[AS923_MAX_NB_CHANNELS];
+    channel_params_t Channels[AS923_MAX_NB_CHANNELS];
 
     /*!
      * LoRaMac bands
      */
-    Band_t Bands[AS923_MAX_NB_BANDS];
+    band_t Bands[AS923_MAX_NB_BANDS];
 
     /*!
      * LoRaMac channels mask

--- a/features/lorawan/lorastack/phy/LoRaPHYAU915.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHYAU915.cpp
@@ -263,8 +263,8 @@ static int8_t LimitTxPower(int8_t txPower, int8_t maxBandTxPower,
 
 uint8_t LoRaPHYAU915::CountNbOfEnabledChannels(uint8_t datarate,
                                                uint16_t* channelsMask,
-                                               ChannelParams_t* channels,
-                                               Band_t* bands, uint8_t* enabledChannels,
+                                               channel_params_t* channels,
+                                               band_t* bands, uint8_t* enabledChannels,
                                                uint8_t* delayTx)
 {
     uint8_t nbEnabledChannels = 0;
@@ -273,14 +273,14 @@ uint8_t LoRaPHYAU915::CountNbOfEnabledChannels(uint8_t datarate,
     for (uint8_t i = 0, k = 0; i < AU915_MAX_NB_CHANNELS; i += 16, k++) {
         for (uint8_t j = 0; j < 16; j++) {
             if ((channelsMask[k] & (1 << j)) != 0) {
-                if (channels[i + j].Frequency == 0) { // Check if the channel is enabled
+                if (channels[i + j].frequency == 0) { // Check if the channel is enabled
                     continue;
                 }
-                if (val_in_range(datarate, channels[i + j].DrRange.Fields.Min,
-                                 channels[i + j].DrRange.Fields.Max) == 0) { // Check if the current channel selection supports the given datarate
+                if (val_in_range(datarate, channels[i + j].dr_range.fields.min,
+                                 channels[i + j].dr_range.fields.max) == 0) { // Check if the current channel selection supports the given datarate
                     continue;
                 }
-                if (bands[channels[i + j].Band].TimeOff > 0) { // Check if the band is available for transmission
+                if (bands[channels[i + j].band].off_time > 0) { // Check if the band is available for transmission
                     delayTransmission++;
                     continue;
                 }
@@ -296,7 +296,7 @@ uint8_t LoRaPHYAU915::CountNbOfEnabledChannels(uint8_t datarate,
 LoRaPHYAU915::LoRaPHYAU915(LoRaWANTimeHandler &lora_time)
     : LoRaPHY(lora_time)
 {
-    const Band_t band0 = AU915_BAND0;
+    const band_t band0 = AU915_BAND0;
     Bands[0] = band0;
 }
 
@@ -430,7 +430,7 @@ PhyParam_t LoRaPHYAU915::get_phy_params(GetPhyParams_t* getPhy)
 
 void LoRaPHYAU915::set_band_tx_done(SetBandTxDoneParams_t* txDone)
 {
-    set_last_tx_done(txDone->Joined, &Bands[Channels[txDone->Channel].Band],
+    set_last_tx_done(txDone->Joined, &Bands[Channels[txDone->Channel].band],
                      txDone->LastTxDoneTime);
 }
 
@@ -441,17 +441,17 @@ void LoRaPHYAU915::load_defaults(InitType_t type)
             // Channels
             // 125 kHz channels
             for (uint8_t i = 0; i < AU915_MAX_NB_CHANNELS - 8; i++) {
-                Channels[i].Frequency = 915200000 + i * 200000;
-                Channels[i].DrRange.Value = ( DR_5 << 4) | DR_0;
-                Channels[i].Band = 0;
+                Channels[i].frequency = 915200000 + i * 200000;
+                Channels[i].dr_range.value = ( DR_5 << 4) | DR_0;
+                Channels[i].band = 0;
             }
             // 500 kHz channels
             for (uint8_t i = AU915_MAX_NB_CHANNELS - 8;
                     i < AU915_MAX_NB_CHANNELS; i++) {
-                Channels[i].Frequency = 915900000
+                Channels[i].frequency = 915900000
                         + (i - ( AU915_MAX_NB_CHANNELS - 8)) * 1600000;
-                Channels[i].DrRange.Value = ( DR_6 << 4) | DR_6;
-                Channels[i].Band = 0;
+                Channels[i].dr_range.value = ( DR_6 << 4) | DR_6;
+                Channels[i].band = 0;
             }
 
             // Initialize channels default mask
@@ -611,38 +611,38 @@ bool LoRaPHYAU915::get_next_ADR(AdrNextParams_t* adrNext, int8_t* drOut,
 
 void LoRaPHYAU915::compute_rx_win_params(int8_t datarate, uint8_t minRxSymbols,
                                          uint32_t rxError,
-                                         RxConfigParams_t *rxConfigParams)
+                                         rx_config_params_t *rxConfigParams)
 {
     double tSymbol = 0.0;
 
     // Get the datarate, perform a boundary check
-    rxConfigParams->Datarate = MIN(datarate, AU915_RX_MAX_DATARATE);
-    rxConfigParams->Bandwidth = GetBandwidth(rxConfigParams->Datarate);
+    rxConfigParams->datarate = MIN(datarate, AU915_RX_MAX_DATARATE);
+    rxConfigParams->bandwidth = GetBandwidth(rxConfigParams->datarate);
 
     tSymbol = compute_symb_timeout_lora(
-            DataratesAU915[rxConfigParams->Datarate],
-            BandwidthsAU915[rxConfigParams->Datarate]);
+            DataratesAU915[rxConfigParams->datarate],
+            BandwidthsAU915[rxConfigParams->datarate]);
 
     get_rx_window_params(tSymbol, minRxSymbols, rxError, RADIO_WAKEUP_TIME,
-                         &rxConfigParams->WindowTimeout,
-                         &rxConfigParams->WindowOffset);
+                         &rxConfigParams->window_timeout,
+                         &rxConfigParams->window_offset);
 }
 
-bool LoRaPHYAU915::rx_config(RxConfigParams_t* rxConfig, int8_t* datarate)
+bool LoRaPHYAU915::rx_config(rx_config_params_t* rxConfig, int8_t* datarate)
 {
-    int8_t dr = rxConfig->Datarate;
+    int8_t dr = rxConfig->datarate;
     uint8_t maxPayload = 0;
     int8_t phyDr = 0;
-    uint32_t frequency = rxConfig->Frequency;
+    uint32_t frequency = rxConfig->frequency;
 
     if (_radio->get_status() != RF_IDLE) {
         return false;
     }
 
-    if (rxConfig->RxSlot == RX_SLOT_WIN_1) {
+    if (rxConfig->rx_slot == RX_SLOT_WIN_1) {
         // Apply window 1 frequency
         frequency = AU915_FIRST_RX1_CHANNEL
-                + (rxConfig->Channel % 8) * AU915_STEPWIDTH_RX1_CHANNEL;
+                + (rxConfig->channel % 8) * AU915_STEPWIDTH_RX1_CHANNEL;
     }
 
     // Read the physical datarate from the datarates table
@@ -651,11 +651,11 @@ bool LoRaPHYAU915::rx_config(RxConfigParams_t* rxConfig, int8_t* datarate)
     _radio->set_channel(frequency);
 
     // Radio configuration
-    _radio->set_rx_config(MODEM_LORA, rxConfig->Bandwidth, phyDr, 1, 0, 8,
-                          rxConfig->WindowTimeout, false, 0, false, 0, 0, true,
-                          rxConfig->RxContinuous);
+    _radio->set_rx_config(MODEM_LORA, rxConfig->bandwidth, phyDr, 1, 0, 8,
+                          rxConfig->window_timeout, false, 0, false, 0, 0, true,
+                          rxConfig->is_rx_continuous);
 
-    if (rxConfig->RepeaterSupport == true) {
+    if (rxConfig->is_repeater_supported == true) {
         maxPayload = MaxPayloadOfDatarateRepeaterAU915[dr];
     } else {
         maxPayload = MaxPayloadOfDatarateAU915[dr];
@@ -668,12 +668,12 @@ bool LoRaPHYAU915::rx_config(RxConfigParams_t* rxConfig, int8_t* datarate)
 }
 
 bool LoRaPHYAU915::tx_config(TxConfigParams_t* txConfig, int8_t* txPower,
-                             TimerTime_t* txTimeOnAir)
+                             lorawan_time_t* txTimeOnAir)
 {
     int8_t phyDr = DataratesAU915[txConfig->Datarate];
     int8_t txPowerLimited = LimitTxPower(
             txConfig->TxPower,
-            Bands[Channels[txConfig->Channel].Band].TxMaxPower,
+            Bands[Channels[txConfig->Channel].band].max_tx_pwr,
             txConfig->Datarate, ChannelsMask);
     uint32_t bandwidth = GetBandwidth(txConfig->Datarate);
     int8_t phyTxPower = 0;
@@ -683,7 +683,7 @@ bool LoRaPHYAU915::tx_config(TxConfigParams_t* txConfig, int8_t* txPower,
                                   txConfig->AntennaGain);
 
     // Setup the radio frequency
-    _radio->set_channel(Channels[txConfig->Channel].Frequency);
+    _radio->set_channel(Channels[txConfig->Channel].frequency);
 
     _radio->set_tx_config(MODEM_LORA, phyTxPower, 0, bandwidth, phyDr, 1, 8,
                           false, true, 0, 0, false, 3000);
@@ -885,13 +885,13 @@ void LoRaPHYAU915::calculate_backoff(CalcBackOffParams_t* calcBackOff)
 }
 
 bool LoRaPHYAU915::set_next_channel(NextChanParams_t* nextChanParams,
-                                    uint8_t* channel, TimerTime_t* time,
-                                    TimerTime_t* aggregatedTimeOff)
+                                    uint8_t* channel, lorawan_time_t* time,
+                                    lorawan_time_t* aggregatedTimeOff)
 {
     uint8_t nbEnabledChannels = 0;
     uint8_t delayTx = 0;
     uint8_t enabledChannels[AU915_MAX_NB_CHANNELS] = { 0 };
-    TimerTime_t nextTxDelay = 0;
+    lorawan_time_t nextTxDelay = 0;
 
     // Count 125kHz channels
     if (num_active_channels(ChannelsMaskRemaining, 0, 4) == 0) { // Reactivate default channels
@@ -946,24 +946,24 @@ bool LoRaPHYAU915::set_next_channel(NextChanParams_t* nextChanParams,
     }
 }
 
-LoRaMacStatus_t LoRaPHYAU915::add_channel(ChannelAddParams_t* channelAdd)
+lorawan_status_t LoRaPHYAU915::add_channel(ChannelAddParams_t* channelAdd)
 {
-    return LORAMAC_STATUS_PARAMETER_INVALID;
+    return LORAWAN_STATUS_PARAMETER_INVALID;
 }
 
 bool LoRaPHYAU915::remove_channel(ChannelRemoveParams_t* channelRemove)
 {
-    return LORAMAC_STATUS_PARAMETER_INVALID;
+    return LORAWAN_STATUS_PARAMETER_INVALID;
 }
 
 void LoRaPHYAU915::set_tx_cont_mode(ContinuousWaveParams_t* continuousWave)
 {
     int8_t txPowerLimited = LimitTxPower(
             continuousWave->TxPower,
-            Bands[Channels[continuousWave->Channel].Band].TxMaxPower,
+            Bands[Channels[continuousWave->Channel].band].max_tx_pwr,
             continuousWave->Datarate, ChannelsMask);
     int8_t phyTxPower = 0;
-    uint32_t frequency = Channels[continuousWave->Channel].Frequency;
+    uint32_t frequency = Channels[continuousWave->Channel].frequency;
 
     // Calculate physical TX power
     phyTxPower = compute_tx_power(txPowerLimited, continuousWave->MaxEirp,

--- a/features/lorawan/lorastack/phy/LoRaPHYAU915.h
+++ b/features/lorawan/lorastack/phy/LoRaPHYAU915.h
@@ -133,7 +133,7 @@ public:
      *
      * \retval True, if the configuration was applied successfully.
      */
-    virtual bool rx_config(RxConfigParams_t* rxConfig, int8_t* datarate );
+    virtual bool rx_config(rx_config_params_t* rxConfig, int8_t* datarate );
 
     /*
      * RX window precise timing
@@ -189,7 +189,7 @@ public:
     virtual void compute_rx_win_params(int8_t datarate,
                                                  uint8_t minRxSymbols,
                                                  uint32_t rxError,
-                                                 RxConfigParams_t *rxConfigParams);
+                                                 rx_config_params_t *rxConfigParams);
 
     /*!
      * \brief TX configuration.
@@ -203,7 +203,7 @@ public:
      * \retval True, if the configuration was applied successfully.
      */
     virtual bool tx_config(TxConfigParams_t* txConfig, int8_t* txPower,
-                                TimerTime_t* txTimeOnAir );
+                                lorawan_time_t* txTimeOnAir );
 
     /*!
      * \brief The function processes a Link ADR Request.
@@ -294,8 +294,8 @@ public:
      * \retval The function status [1: OK, 0: Unable to find a channel on the current datarate].
      */
     virtual bool set_next_channel(NextChanParams_t* nextChanParams,
-                                   uint8_t* channel, TimerTime_t* time,
-                                   TimerTime_t* aggregatedTimeOff );
+                                   uint8_t* channel, lorawan_time_t* time,
+                                   lorawan_time_t* aggregatedTimeOff );
 
     /*!
      * \brief Adds a channel.
@@ -304,7 +304,7 @@ public:
      *
      * \retval The status of the operation.
      */
-    virtual LoRaMacStatus_t add_channel(ChannelAddParams_t* channelAdd );
+    virtual lorawan_status_t add_channel(ChannelAddParams_t* channelAdd );
 
     /*!
      * \brief Removes a channel.
@@ -338,8 +338,8 @@ public:
 private:
     uint8_t CountNbOfEnabledChannels(uint8_t datarate,
                                      uint16_t* channelsMask,
-                                     ChannelParams_t* channels,
-                                     Band_t* bands, uint8_t* enabledChannels,
+                                     channel_params_t* channels,
+                                     band_t* bands, uint8_t* enabledChannels,
                                      uint8_t* delayTx);
 
 
@@ -347,12 +347,12 @@ private:
     /*!
      * LoRaMAC channels
      */
-    ChannelParams_t Channels[AU915_MAX_NB_CHANNELS];
+    channel_params_t Channels[AU915_MAX_NB_CHANNELS];
 
     /*!
      * LoRaMac bands
      */
-    Band_t Bands[AU915_MAX_NB_BANDS];
+    band_t Bands[AU915_MAX_NB_BANDS];
 
     /*!
      * LoRaMac channels mask

--- a/features/lorawan/lorastack/phy/LoRaPHYCN470.h
+++ b/features/lorawan/lorastack/phy/LoRaPHYCN470.h
@@ -133,7 +133,7 @@ public:
      *
      * \retval True, if the configuration was applied successfully.
      */
-    virtual bool rx_config(RxConfigParams_t* rxConfig, int8_t* datarate );
+    virtual bool rx_config(rx_config_params_t* rxConfig, int8_t* datarate );
 
     /*
      * RX window precise timing
@@ -189,7 +189,7 @@ public:
     virtual void compute_rx_win_params(int8_t datarate,
                                                  uint8_t minRxSymbols,
                                                  uint32_t rxError,
-                                                 RxConfigParams_t *rxConfigParams);
+                                                 rx_config_params_t *rxConfigParams);
 
     /*!
      * \brief TX configuration.
@@ -203,7 +203,7 @@ public:
      * \retval True, if the configuration was applied successfully.
      */
     virtual bool tx_config(TxConfigParams_t* txConfig, int8_t* txPower,
-                                TimerTime_t* txTimeOnAir );
+                                lorawan_time_t* txTimeOnAir );
 
     /*!
      * \brief The function processes a Link ADR request.
@@ -294,8 +294,8 @@ public:
      * \retval Function status [1: OK, 0: Unable to find a channel on the current datarate].
      */
     virtual bool set_next_channel(NextChanParams_t* nextChanParams,
-                                   uint8_t* channel, TimerTime_t* time,
-                                   TimerTime_t* aggregatedTimeOff );
+                                   uint8_t* channel, lorawan_time_t* time,
+                                   lorawan_time_t* aggregatedTimeOff );
 
     /*!
      * \brief Adds a channel.
@@ -304,7 +304,7 @@ public:
      *
      * \retval The status of the operation.
      */
-    virtual LoRaMacStatus_t add_channel(ChannelAddParams_t* channelAdd );
+    virtual lorawan_status_t add_channel(ChannelAddParams_t* channelAdd );
 
     /*!
      * \brief Removes a channel.
@@ -336,7 +336,7 @@ public:
     virtual uint8_t apply_DR_offset(uint8_t downlinkDwellTime, int8_t dr, int8_t drOffset );
 
 private:
-    uint8_t CountNbOfEnabledChannels( uint8_t datarate, uint16_t* channelsMask, ChannelParams_t* channels, Band_t* bands, uint8_t* enabledChannels, uint8_t* delayTx );
+    uint8_t CountNbOfEnabledChannels( uint8_t datarate, uint16_t* channelsMask, channel_params_t* channels, band_t* bands, uint8_t* enabledChannels, uint8_t* delayTx );
     bool RegionCN470ChanMaskSet( ChanMaskSetParams_t* chanMaskSet );
 
 
@@ -344,12 +344,12 @@ private:
     /*!
      * LoRaMAC channels
      */
-    ChannelParams_t Channels[CN470_MAX_NB_CHANNELS];
+    channel_params_t Channels[CN470_MAX_NB_CHANNELS];
 
     /*!
      * LoRaMac bands
      */
-    Band_t Bands[CN470_MAX_NB_BANDS];
+    band_t Bands[CN470_MAX_NB_BANDS];
 
     /*!
      * LoRaMac channels mask

--- a/features/lorawan/lorastack/phy/LoRaPHYCN779.h
+++ b/features/lorawan/lorastack/phy/LoRaPHYCN779.h
@@ -124,7 +124,7 @@ public:
      *
      * \retval True, if the configuration was applied successfully.
      */
-    virtual bool rx_config(RxConfigParams_t* rxConfig, int8_t* datarate );
+    virtual bool rx_config(rx_config_params_t* rxConfig, int8_t* datarate );
 
     /*
      * RX window precise timing
@@ -180,7 +180,7 @@ public:
     virtual void compute_rx_win_params(int8_t datarate,
                                                  uint8_t minRxSymbols,
                                                  uint32_t rxError,
-                                                 RxConfigParams_t *rxConfigParams);
+                                                 rx_config_params_t *rxConfigParams);
 
     /*!
      * \brief TX configuration.
@@ -194,7 +194,7 @@ public:
      * \retval True, if the configuration was applied successfully.
      */
     virtual bool tx_config(TxConfigParams_t* txConfig, int8_t* txPower,
-                                TimerTime_t* txTimeOnAir );
+                                lorawan_time_t* txTimeOnAir );
 
     /*!
      * \brief The function processes a Link ADR request.
@@ -285,8 +285,8 @@ public:
      * \retval Function status [1: OK, 0: Unable to find a channel on the current datarate].
      */
     virtual bool set_next_channel(NextChanParams_t* nextChanParams,
-                                   uint8_t* channel, TimerTime_t* time,
-                                   TimerTime_t* aggregatedTimeOff );
+                                   uint8_t* channel, lorawan_time_t* time,
+                                   lorawan_time_t* aggregatedTimeOff );
 
     /*!
      * \brief Adds a channel.
@@ -295,7 +295,7 @@ public:
      *
      * \retval The status of the operation.
      */
-    virtual LoRaMacStatus_t add_channel(ChannelAddParams_t* channelAdd );
+    virtual lorawan_status_t add_channel(ChannelAddParams_t* channelAdd );
 
     /*!
      * \brief Removes a channel.
@@ -327,18 +327,18 @@ public:
     virtual uint8_t apply_DR_offset(uint8_t downlinkDwellTime, int8_t dr, int8_t drOffset );
 
 private:
-    uint8_t CountNbOfEnabledChannels( bool joined, uint8_t datarate, uint16_t* channelsMask, ChannelParams_t* channels, Band_t* bands, uint8_t* enabledChannels, uint8_t* delayTx );
+    uint8_t CountNbOfEnabledChannels( bool joined, uint8_t datarate, uint16_t* channelsMask, channel_params_t* channels, band_t* bands, uint8_t* enabledChannels, uint8_t* delayTx );
 
     // Global attributes
     /*!
      * LoRaMAC channels
      */
-    ChannelParams_t Channels[CN779_MAX_NB_CHANNELS];
+    channel_params_t Channels[CN779_MAX_NB_CHANNELS];
 
     /*!
      * LoRaMac bands
      */
-    Band_t Bands[CN779_MAX_NB_BANDS];
+    band_t Bands[CN779_MAX_NB_BANDS];
 
     /*!
      * LoRaMac channels mask

--- a/features/lorawan/lorastack/phy/LoRaPHYEU433.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHYEU433.cpp
@@ -286,7 +286,7 @@ static bool VerifyTxFreq( uint32_t freq, LoRaRadio *radio )
     return true;
 }
 
-uint8_t LoRaPHYEU433::CountNbOfEnabledChannels( bool joined, uint8_t datarate, uint16_t* channelsMask, ChannelParams_t* channels, Band_t* bands, uint8_t* enabledChannels, uint8_t* delayTx )
+uint8_t LoRaPHYEU433::CountNbOfEnabledChannels( bool joined, uint8_t datarate, uint16_t* channelsMask, channel_params_t* channels, band_t* bands, uint8_t* enabledChannels, uint8_t* delayTx )
 {
     uint8_t nbEnabledChannels = 0;
     uint8_t delayTransmission = 0;
@@ -297,7 +297,7 @@ uint8_t LoRaPHYEU433::CountNbOfEnabledChannels( bool joined, uint8_t datarate, u
         {
             if( ( channelsMask[k] & ( 1 << j ) ) != 0 )
             {
-                if( channels[i + j].Frequency == 0 )
+                if( channels[i + j].frequency == 0 )
                 { // Check if the channel is enabled
                     continue;
                 }
@@ -308,12 +308,12 @@ uint8_t LoRaPHYEU433::CountNbOfEnabledChannels( bool joined, uint8_t datarate, u
                         continue;
                     }
                 }
-                if( val_in_range( datarate, channels[i + j].DrRange.Fields.Min,
-                                              channels[i + j].DrRange.Fields.Max ) == 0 )
+                if( val_in_range( datarate, channels[i + j].dr_range.fields.min,
+                                              channels[i + j].dr_range.fields.max ) == 0 )
                 { // Check if the current channel selection supports the given datarate
                     continue;
                 }
-                if( bands[channels[i + j].Band].TimeOff > 0 )
+                if( bands[channels[i + j].band].off_time > 0 )
                 { // Check if the band is available for transmission
                     delayTransmission++;
                     continue;
@@ -330,7 +330,7 @@ uint8_t LoRaPHYEU433::CountNbOfEnabledChannels( bool joined, uint8_t datarate, u
 LoRaPHYEU433::LoRaPHYEU433(LoRaWANTimeHandler &lora_time)
     : LoRaPHY(lora_time)
 {
-    const Band_t band0 = EU433_BAND0;
+    const band_t band0 = EU433_BAND0;
     Bands[0] = band0;
 }
 
@@ -487,7 +487,7 @@ PhyParam_t LoRaPHYEU433::get_phy_params(GetPhyParams_t* getPhy)
 
 void LoRaPHYEU433::set_band_tx_done(SetBandTxDoneParams_t* txDone)
 {
-    set_last_tx_done( txDone->Joined, &Bands[Channels[txDone->Channel].Band], txDone->LastTxDoneTime );
+    set_last_tx_done( txDone->Joined, &Bands[Channels[txDone->Channel].band], txDone->LastTxDoneTime );
 }
 
 void LoRaPHYEU433::load_defaults(InitType_t type)
@@ -497,9 +497,9 @@ void LoRaPHYEU433::load_defaults(InitType_t type)
         case INIT_TYPE_INIT:
         {
             // Channels
-            const ChannelParams_t channel1 = EU433_LC1;
-            const ChannelParams_t channel2 = EU433_LC2;
-            const ChannelParams_t channel3 = EU433_LC3;
+            const channel_params_t channel1 = EU433_LC1;
+            const channel_params_t channel2 = EU433_LC2;
+            const channel_params_t channel3 = EU433_LC3;
             Channels[0] = channel1;
             Channels[1] = channel2;
             Channels[2] = channel3;
@@ -565,12 +565,12 @@ bool LoRaPHYEU433::verify(VerifyParams_t* verify, PhyAttribute_t phyAttribute)
 
 void LoRaPHYEU433::apply_cf_list(ApplyCFListParams_t* applyCFList)
 {
-    ChannelParams_t newChannel;
+    channel_params_t newChannel;
     ChannelAddParams_t channelAdd;
     ChannelRemoveParams_t channelRemove;
 
     // Setup default datarate range
-    newChannel.DrRange.Value = ( DR_5 << 4 ) | DR_0;
+    newChannel.dr_range.value = ( DR_5 << 4 ) | DR_0;
 
     // Size of the optional CF list
     if( applyCFList->Size != 16 )
@@ -584,22 +584,22 @@ void LoRaPHYEU433::apply_cf_list(ApplyCFListParams_t* applyCFList)
         if( chanIdx < ( EU433_NUMB_CHANNELS_CF_LIST + EU433_NUMB_DEFAULT_CHANNELS ) )
         {
             // Channel frequency
-            newChannel.Frequency = (uint32_t) applyCFList->Payload[i];
-            newChannel.Frequency |= ( (uint32_t) applyCFList->Payload[i + 1] << 8 );
-            newChannel.Frequency |= ( (uint32_t) applyCFList->Payload[i + 2] << 16 );
-            newChannel.Frequency *= 100;
+            newChannel.frequency = (uint32_t) applyCFList->Payload[i];
+            newChannel.frequency |= ( (uint32_t) applyCFList->Payload[i + 1] << 8 );
+            newChannel.frequency |= ( (uint32_t) applyCFList->Payload[i + 2] << 16 );
+            newChannel.frequency *= 100;
 
             // Initialize alternative frequency to 0
-            newChannel.Rx1Frequency = 0;
+            newChannel.rx1_frequency = 0;
         }
         else
         {
-            newChannel.Frequency = 0;
-            newChannel.DrRange.Value = 0;
-            newChannel.Rx1Frequency = 0;
+            newChannel.frequency = 0;
+            newChannel.dr_range.value = 0;
+            newChannel.rx1_frequency = 0;
         }
 
-        if( newChannel.Frequency != 0 )
+        if( newChannel.frequency != 0 )
         {
             channelAdd.NewChannel = &newChannel;
             channelAdd.ChannelId = chanIdx;
@@ -699,47 +699,47 @@ bool LoRaPHYEU433::get_next_ADR(AdrNextParams_t* adrNext, int8_t* drOut,
 
 void LoRaPHYEU433::compute_rx_win_params(int8_t datarate, uint8_t minRxSymbols,
                                          uint32_t rxError,
-                                         RxConfigParams_t *rxConfigParams)
+                                         rx_config_params_t *rxConfigParams)
 {
     double tSymbol = 0.0;
 
     // Get the datarate, perform a boundary check
-    rxConfigParams->Datarate = MIN( datarate, EU433_RX_MAX_DATARATE );
-    rxConfigParams->Bandwidth = GetBandwidth( rxConfigParams->Datarate );
+    rxConfigParams->datarate = MIN( datarate, EU433_RX_MAX_DATARATE );
+    rxConfigParams->bandwidth = GetBandwidth( rxConfigParams->datarate );
 
-    if( rxConfigParams->Datarate == DR_7 )
+    if( rxConfigParams->datarate == DR_7 )
     { // FSK
-        tSymbol = compute_symb_timeout_fsk( DataratesEU433[rxConfigParams->Datarate] );
+        tSymbol = compute_symb_timeout_fsk( DataratesEU433[rxConfigParams->datarate] );
     }
     else
     { // LoRa
-        tSymbol = compute_symb_timeout_lora( DataratesEU433[rxConfigParams->Datarate], BandwidthsEU433[rxConfigParams->Datarate] );
+        tSymbol = compute_symb_timeout_lora( DataratesEU433[rxConfigParams->datarate], BandwidthsEU433[rxConfigParams->datarate] );
     }
 
-    get_rx_window_params( tSymbol, minRxSymbols, rxError, RADIO_WAKEUP_TIME, &rxConfigParams->WindowTimeout, &rxConfigParams->WindowOffset );
+    get_rx_window_params( tSymbol, minRxSymbols, rxError, RADIO_WAKEUP_TIME, &rxConfigParams->window_timeout, &rxConfigParams->window_offset );
 }
 
-bool LoRaPHYEU433::rx_config(RxConfigParams_t* rxConfig, int8_t* datarate)
+bool LoRaPHYEU433::rx_config(rx_config_params_t* rxConfig, int8_t* datarate)
 {
     radio_modems_t modem;
-    int8_t dr = rxConfig->Datarate;
+    int8_t dr = rxConfig->datarate;
     uint8_t maxPayload = 0;
     int8_t phyDr = 0;
-    uint32_t frequency = rxConfig->Frequency;
+    uint32_t frequency = rxConfig->frequency;
 
     if( _radio->get_status() != RF_IDLE )
     {
         return false;
     }
 
-    if( rxConfig->RxSlot == RX_SLOT_WIN_1 )
+    if( rxConfig->rx_slot == RX_SLOT_WIN_1 )
     {
         // Apply window 1 frequency
-        frequency = Channels[rxConfig->Channel].Frequency;
+        frequency = Channels[rxConfig->channel].frequency;
         // Apply the alternative RX 1 window frequency, if it is available
-        if( Channels[rxConfig->Channel].Rx1Frequency != 0 )
+        if( Channels[rxConfig->channel].rx1_frequency != 0 )
         {
-            frequency = Channels[rxConfig->Channel].Rx1Frequency;
+            frequency = Channels[rxConfig->channel].rx1_frequency;
         }
     }
 
@@ -753,18 +753,18 @@ bool LoRaPHYEU433::rx_config(RxConfigParams_t* rxConfig, int8_t* datarate)
     {
         modem = MODEM_FSK;
         _radio->set_rx_config( modem, 50000, phyDr * 1000, 0, 83333, 5,
-                               rxConfig->WindowTimeout, false, 0, true, 0, 0,
-                               false, rxConfig->RxContinuous );
+                               rxConfig->window_timeout, false, 0, true, 0, 0,
+                               false, rxConfig->is_rx_continuous );
     }
     else
     {
         modem = MODEM_LORA;
-        _radio->set_rx_config( modem, rxConfig->Bandwidth, phyDr, 1, 0, 8,
-                               rxConfig->WindowTimeout, false, 0, false, 0, 0,
-                               true, rxConfig->RxContinuous );
+        _radio->set_rx_config( modem, rxConfig->bandwidth, phyDr, 1, 0, 8,
+                               rxConfig->window_timeout, false, 0, false, 0, 0,
+                               true, rxConfig->is_rx_continuous );
     }
 
-    if( rxConfig->RepeaterSupport == true )
+    if( rxConfig->is_repeater_supported == true )
     {
         maxPayload = MaxPayloadOfDatarateRepeaterEU433[dr];
     }
@@ -779,11 +779,11 @@ bool LoRaPHYEU433::rx_config(RxConfigParams_t* rxConfig, int8_t* datarate)
 }
 
 bool LoRaPHYEU433::tx_config(TxConfigParams_t* txConfig, int8_t* txPower,
-                             TimerTime_t* txTimeOnAir)
+                             lorawan_time_t* txTimeOnAir)
 {
     radio_modems_t modem;
     int8_t phyDr = DataratesEU433[txConfig->Datarate];
-    int8_t txPowerLimited = LimitTxPower( txConfig->TxPower, Bands[Channels[txConfig->Channel].Band].TxMaxPower, txConfig->Datarate, ChannelsMask );
+    int8_t txPowerLimited = LimitTxPower( txConfig->TxPower, Bands[Channels[txConfig->Channel].band].max_tx_pwr, txConfig->Datarate, ChannelsMask );
     uint32_t bandwidth = GetBandwidth( txConfig->Datarate );
     int8_t phyTxPower = 0;
 
@@ -791,7 +791,7 @@ bool LoRaPHYEU433::tx_config(TxConfigParams_t* txConfig, int8_t* txPower,
     phyTxPower = compute_tx_power( txPowerLimited, txConfig->MaxEirp, txConfig->AntennaGain );
 
     // Setup the radio frequency
-    _radio->set_channel( Channels[txConfig->Channel].Frequency );
+    _radio->set_channel( Channels[txConfig->Channel].frequency );
 
     if( txConfig->Datarate == DR_7 )
     { // High Speed FSK channel
@@ -860,7 +860,7 @@ uint8_t LoRaPHYEU433::link_ADR_request(LinkAdrReqParams_t* linkAdrReq,
             {
                 if( linkAdrParams.ChMaskCtrl == 6 )
                 {
-                    if( Channels[i].Frequency != 0 )
+                    if( Channels[i].frequency != 0 )
                     {
                         chMask |= 1 << i;
                     }
@@ -868,7 +868,7 @@ uint8_t LoRaPHYEU433::link_ADR_request(LinkAdrReqParams_t* linkAdrReq,
                 else
                 {
                     if( ( ( chMask & ( 1 << i ) ) != 0 ) &&
-                        ( Channels[i].Frequency == 0 ) )
+                        ( Channels[i].frequency == 0 ) )
                     {// Trying to enable an undefined channel
                         status &= 0xFE; // Channel mask KO
                     }
@@ -950,7 +950,7 @@ uint8_t LoRaPHYEU433::request_new_channel(NewChannelReqParams_t* newChannelReq)
     ChannelAddParams_t channelAdd;
     ChannelRemoveParams_t channelRemove;
 
-    if( newChannelReq->NewChannel->Frequency == 0 )
+    if( newChannelReq->NewChannel->frequency == 0 )
     {
         channelRemove.ChannelId = newChannelReq->ChannelId;
 
@@ -967,21 +967,21 @@ uint8_t LoRaPHYEU433::request_new_channel(NewChannelReqParams_t* newChannelReq)
 
         switch( add_channel( &channelAdd ) )
         {
-            case LORAMAC_STATUS_OK:
+            case LORAWAN_STATUS_OK:
             {
                 break;
             }
-            case LORAMAC_STATUS_FREQUENCY_INVALID:
+            case LORAWAN_STATUS_FREQUENCY_INVALID:
             {
                 status &= 0xFE;
                 break;
             }
-            case LORAMAC_STATUS_DATARATE_INVALID:
+            case LORAWAN_STATUS_DATARATE_INVALID:
             {
                 status &= 0xFD;
                 break;
             }
-            case LORAMAC_STATUS_FREQ_AND_DR_INVALID:
+            case LORAWAN_STATUS_FREQ_AND_DR_INVALID:
             {
                 status &= 0xFC;
                 break;
@@ -1013,7 +1013,7 @@ uint8_t LoRaPHYEU433::dl_channel_request(DlChannelReqParams_t* dlChannelReq)
     }
 
     // Verify if an uplink frequency exists
-    if( Channels[dlChannelReq->ChannelId].Frequency == 0 )
+    if( Channels[dlChannelReq->ChannelId].frequency == 0 )
     {
         status &= 0xFD;
     }
@@ -1021,7 +1021,7 @@ uint8_t LoRaPHYEU433::dl_channel_request(DlChannelReqParams_t* dlChannelReq)
     // Apply Rx1 frequency, if the status is OK
     if( status == 0x03 )
     {
-        Channels[dlChannelReq->ChannelId].Rx1Frequency = dlChannelReq->Rx1Frequency;
+        Channels[dlChannelReq->ChannelId].rx1_frequency = dlChannelReq->Rx1Frequency;
     }
 
     return status;
@@ -1075,13 +1075,13 @@ void LoRaPHYEU433::calculate_backoff(CalcBackOffParams_t* calcBackOff)
 }
 
 bool LoRaPHYEU433::set_next_channel(NextChanParams_t* nextChanParams,
-                                    uint8_t* channel, TimerTime_t* time,
-                                    TimerTime_t* aggregatedTimeOff)
+                                    uint8_t* channel, lorawan_time_t* time,
+                                    lorawan_time_t* aggregatedTimeOff)
 {
     uint8_t nbEnabledChannels = 0;
     uint8_t delayTx = 0;
     uint8_t enabledChannels[EU433_MAX_NB_CHANNELS] = { 0 };
-    TimerTime_t nextTxDelay = 0;
+    lorawan_time_t nextTxDelay = 0;
 
     if( num_active_channels( ChannelsMask, 0, 1 ) == 0 )
     { // Reactivate default channels
@@ -1130,7 +1130,7 @@ bool LoRaPHYEU433::set_next_channel(NextChanParams_t* nextChanParams,
     }
 }
 
-LoRaMacStatus_t LoRaPHYEU433::add_channel(ChannelAddParams_t* channelAdd)
+lorawan_status_t LoRaPHYEU433::add_channel(ChannelAddParams_t* channelAdd)
 {
     uint8_t band = 0;
     bool drInvalid = false;
@@ -1139,19 +1139,19 @@ LoRaMacStatus_t LoRaPHYEU433::add_channel(ChannelAddParams_t* channelAdd)
 
     if( id >= EU433_MAX_NB_CHANNELS )
     {
-        return LORAMAC_STATUS_PARAMETER_INVALID;
+        return LORAWAN_STATUS_PARAMETER_INVALID;
     }
 
     // Validate the datarate range
-    if( val_in_range( channelAdd->NewChannel->DrRange.Fields.Min, EU433_TX_MIN_DATARATE, EU433_TX_MAX_DATARATE ) == 0 )
+    if( val_in_range( channelAdd->NewChannel->dr_range.fields.min, EU433_TX_MIN_DATARATE, EU433_TX_MAX_DATARATE ) == 0 )
     {
         drInvalid = true;
     }
-    if( val_in_range( channelAdd->NewChannel->DrRange.Fields.Max, EU433_TX_MIN_DATARATE, EU433_TX_MAX_DATARATE ) == 0 )
+    if( val_in_range( channelAdd->NewChannel->dr_range.fields.max, EU433_TX_MIN_DATARATE, EU433_TX_MAX_DATARATE ) == 0 )
     {
         drInvalid = true;
     }
-    if( channelAdd->NewChannel->DrRange.Fields.Min > channelAdd->NewChannel->DrRange.Fields.Max )
+    if( channelAdd->NewChannel->dr_range.fields.min > channelAdd->NewChannel->dr_range.fields.max )
     {
         drInvalid = true;
     }
@@ -1160,17 +1160,17 @@ LoRaMacStatus_t LoRaPHYEU433::add_channel(ChannelAddParams_t* channelAdd)
     if( id < EU433_NUMB_DEFAULT_CHANNELS )
     {
         // Validate the datarate range for min: must be DR_0
-        if( channelAdd->NewChannel->DrRange.Fields.Min > DR_0 )
+        if( channelAdd->NewChannel->dr_range.fields.min > DR_0 )
         {
             drInvalid = true;
         }
         // Validate the datarate range for max: must be DR_5 <= Max <= TX_MAX_DATARATE
-        if( val_in_range( channelAdd->NewChannel->DrRange.Fields.Max, DR_5, EU433_TX_MAX_DATARATE ) == 0 )
+        if( val_in_range( channelAdd->NewChannel->dr_range.fields.max, DR_5, EU433_TX_MAX_DATARATE ) == 0 )
         {
             drInvalid = true;
         }
         // We are not allowed to change the frequency
-        if( channelAdd->NewChannel->Frequency != Channels[id].Frequency )
+        if( channelAdd->NewChannel->frequency != Channels[id].frequency )
         {
             freqInvalid = true;
         }
@@ -1179,7 +1179,7 @@ LoRaMacStatus_t LoRaPHYEU433::add_channel(ChannelAddParams_t* channelAdd)
     // Check frequency
     if( freqInvalid == false )
     {
-        if( VerifyTxFreq( channelAdd->NewChannel->Frequency, _radio ) == false )
+        if( VerifyTxFreq( channelAdd->NewChannel->frequency, _radio ) == false )
         {
             freqInvalid = true;
         }
@@ -1188,21 +1188,21 @@ LoRaMacStatus_t LoRaPHYEU433::add_channel(ChannelAddParams_t* channelAdd)
     // Check status
     if( ( drInvalid == true ) && ( freqInvalid == true ) )
     {
-        return LORAMAC_STATUS_FREQ_AND_DR_INVALID;
+        return LORAWAN_STATUS_FREQ_AND_DR_INVALID;
     }
     if( drInvalid == true )
     {
-        return LORAMAC_STATUS_DATARATE_INVALID;
+        return LORAWAN_STATUS_DATARATE_INVALID;
     }
     if( freqInvalid == true )
     {
-        return LORAMAC_STATUS_FREQUENCY_INVALID;
+        return LORAWAN_STATUS_FREQUENCY_INVALID;
     }
 
     memcpy( &(Channels[id]), channelAdd->NewChannel, sizeof( Channels[id] ) );
-    Channels[id].Band = band;
+    Channels[id].band = band;
     ChannelsMask[0] |= ( 1 << id );
-    return LORAMAC_STATUS_OK;
+    return LORAWAN_STATUS_OK;
 }
 
 bool LoRaPHYEU433::remove_channel(ChannelRemoveParams_t* channelRemove)
@@ -1215,7 +1215,7 @@ bool LoRaPHYEU433::remove_channel(ChannelRemoveParams_t* channelRemove)
     }
 
     // Remove the channel from the list of channels
-    const ChannelParams_t empty_channel = { 0, 0, { 0 }, 0 };
+    const channel_params_t empty_channel = { 0, 0, { 0 }, 0 };
     Channels[id] = empty_channel;
 
     return disable_channel( ChannelsMask, id, EU433_MAX_NB_CHANNELS );
@@ -1223,9 +1223,9 @@ bool LoRaPHYEU433::remove_channel(ChannelRemoveParams_t* channelRemove)
 
 void LoRaPHYEU433::set_tx_cont_mode(ContinuousWaveParams_t* continuousWave)
 {
-    int8_t txPowerLimited = LimitTxPower( continuousWave->TxPower, Bands[Channels[continuousWave->Channel].Band].TxMaxPower, continuousWave->Datarate, ChannelsMask );
+    int8_t txPowerLimited = LimitTxPower( continuousWave->TxPower, Bands[Channels[continuousWave->Channel].band].max_tx_pwr, continuousWave->Datarate, ChannelsMask );
     int8_t phyTxPower = 0;
-    uint32_t frequency = Channels[continuousWave->Channel].Frequency;
+    uint32_t frequency = Channels[continuousWave->Channel].frequency;
 
     // Calculate physical TX power
     phyTxPower = compute_tx_power( txPowerLimited, continuousWave->MaxEirp, continuousWave->AntennaGain );

--- a/features/lorawan/lorastack/phy/LoRaPHYEU433.h
+++ b/features/lorawan/lorastack/phy/LoRaPHYEU433.h
@@ -130,7 +130,7 @@ public:
      *
      * \retval True, if the configuration was applied successfully.
      */
-    virtual bool rx_config(RxConfigParams_t* rxConfig, int8_t* datarate );
+    virtual bool rx_config(rx_config_params_t* rxConfig, int8_t* datarate );
 
     /*
      * RX window precise timing
@@ -186,7 +186,7 @@ public:
     virtual void compute_rx_win_params(int8_t datarate,
                                                  uint8_t minRxSymbols,
                                                  uint32_t rxError,
-                                                 RxConfigParams_t *rxConfigParams);
+                                                 rx_config_params_t *rxConfigParams);
 
     /*!
      * \brief TX configuration.
@@ -200,7 +200,7 @@ public:
      * \retval True, if the configuration was applied successfully.
      */
     virtual bool tx_config(TxConfigParams_t* txConfig, int8_t* txPower,
-                                TimerTime_t* txTimeOnAir );
+                                lorawan_time_t* txTimeOnAir );
 
     /*!
      * \brief The function processes a Link ADR request.
@@ -291,8 +291,8 @@ public:
      * \retval Function status [1: OK, 0: Unable to find a channel on the current datarate].
      */
     virtual bool set_next_channel(NextChanParams_t* nextChanParams,
-                                   uint8_t* channel, TimerTime_t* time,
-                                   TimerTime_t* aggregatedTimeOff );
+                                   uint8_t* channel, lorawan_time_t* time,
+                                   lorawan_time_t* aggregatedTimeOff );
 
     /*!
      * \brief Adds a channel.
@@ -301,7 +301,7 @@ public:
      *
      * \retval The status of the operation.
      */
-    virtual LoRaMacStatus_t add_channel(ChannelAddParams_t* channelAdd );
+    virtual lorawan_status_t add_channel(ChannelAddParams_t* channelAdd );
 
     /*!
      * \brief Removes a channel.
@@ -333,18 +333,18 @@ public:
     virtual uint8_t apply_DR_offset(uint8_t downlinkDwellTime, int8_t dr, int8_t drOffset );
 
 private:
-    uint8_t CountNbOfEnabledChannels( bool joined, uint8_t datarate, uint16_t* channelsMask, ChannelParams_t* channels, Band_t* bands, uint8_t* enabledChannels, uint8_t* delayTx );
+    uint8_t CountNbOfEnabledChannels( bool joined, uint8_t datarate, uint16_t* channelsMask, channel_params_t* channels, band_t* bands, uint8_t* enabledChannels, uint8_t* delayTx );
 
     // Global attributes
     /*!
      * LoRaMAC channels
      */
-    ChannelParams_t Channels[EU433_MAX_NB_CHANNELS];
+    channel_params_t Channels[EU433_MAX_NB_CHANNELS];
 
     /*!
      * LoRaMac bands
      */
-    Band_t Bands[EU433_MAX_NB_BANDS];
+    band_t Bands[EU433_MAX_NB_BANDS];
 
     /*!
      * LoRaMac channels mask

--- a/features/lorawan/lorastack/phy/LoRaPHYEU868.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHYEU868.cpp
@@ -331,7 +331,7 @@ static bool VerifyTxFreq( uint32_t freq, uint8_t *band, LoRaRadio *radio )
     return true;
 }
 
-uint8_t LoRaPHYEU868::CountNbOfEnabledChannels( bool joined, uint8_t datarate, uint16_t* channelsMask, ChannelParams_t* channels, Band_t* bands, uint8_t* enabledChannels, uint8_t* delayTx )
+uint8_t LoRaPHYEU868::CountNbOfEnabledChannels( bool joined, uint8_t datarate, uint16_t* channelsMask, channel_params_t* channels, band_t* bands, uint8_t* enabledChannels, uint8_t* delayTx )
 {
     uint8_t nbEnabledChannels = 0;
     uint8_t delayTransmission = 0;
@@ -342,7 +342,7 @@ uint8_t LoRaPHYEU868::CountNbOfEnabledChannels( bool joined, uint8_t datarate, u
         {
             if( ( channelsMask[k] & ( 1 << j ) ) != 0 )
             {
-                if( channels[i + j].Frequency == 0 )
+                if( channels[i + j].frequency == 0 )
                 { // Check if the channel is enabled
                     continue;
                 }
@@ -353,12 +353,12 @@ uint8_t LoRaPHYEU868::CountNbOfEnabledChannels( bool joined, uint8_t datarate, u
                         continue;
                     }
                 }
-                if( val_in_range( datarate, channels[i + j].DrRange.Fields.Min,
-                                              channels[i + j].DrRange.Fields.Max ) == 0 )
+                if( val_in_range( datarate, channels[i + j].dr_range.fields.min,
+                                              channels[i + j].dr_range.fields.max ) == 0 )
                 { // Check if the current channel selection supports the given datarate
                     continue;
                 }
-                if( bands[channels[i + j].Band].TimeOff > 0 )
+                if( bands[channels[i + j].band].off_time > 0 )
                 { // Check if the band is available for transmission
                     delayTransmission++;
                     continue;
@@ -375,11 +375,11 @@ uint8_t LoRaPHYEU868::CountNbOfEnabledChannels( bool joined, uint8_t datarate, u
 LoRaPHYEU868::LoRaPHYEU868(LoRaWANTimeHandler &lora_time)
     : LoRaPHY(lora_time)
 {
-    const Band_t band0 = EU868_BAND0;
-    const Band_t band1 = EU868_BAND1;
-    const Band_t band2 = EU868_BAND2;
-    const Band_t band3 = EU868_BAND3;
-    const Band_t band4 = EU868_BAND4;
+    const band_t band0 = EU868_BAND0;
+    const band_t band1 = EU868_BAND1;
+    const band_t band2 = EU868_BAND2;
+    const band_t band3 = EU868_BAND3;
+    const band_t band4 = EU868_BAND4;
 
     Bands[0] = band0;
     Bands[1] = band1;
@@ -541,7 +541,7 @@ PhyParam_t LoRaPHYEU868::get_phy_params(GetPhyParams_t* getPhy)
 
 void LoRaPHYEU868::set_band_tx_done(SetBandTxDoneParams_t* txDone)
 {
-    set_last_tx_done( txDone->Joined, &Bands[Channels[txDone->Channel].Band], txDone->LastTxDoneTime );
+    set_last_tx_done( txDone->Joined, &Bands[Channels[txDone->Channel].band], txDone->LastTxDoneTime );
 }
 
 void LoRaPHYEU868::load_defaults(InitType_t type)
@@ -551,9 +551,9 @@ void LoRaPHYEU868::load_defaults(InitType_t type)
         case INIT_TYPE_INIT:
         {
             // Channels
-            const ChannelParams_t channel1 = EU868_LC1;
-            const ChannelParams_t channel2 = EU868_LC2;
-            const ChannelParams_t channel3 = EU868_LC3;
+            const channel_params_t channel1 = EU868_LC1;
+            const channel_params_t channel2 = EU868_LC2;
+            const channel_params_t channel3 = EU868_LC3;
             Channels[0] = channel1;
             Channels[1] = channel2;
             Channels[2] = channel3;
@@ -619,12 +619,12 @@ bool LoRaPHYEU868::verify(VerifyParams_t* verify, PhyAttribute_t phyAttribute)
 
 void LoRaPHYEU868::apply_cf_list(ApplyCFListParams_t* applyCFList)
 {
-    ChannelParams_t newChannel;
+    channel_params_t newChannel;
     ChannelAddParams_t channelAdd;
     ChannelRemoveParams_t channelRemove;
 
     // Setup default datarate range
-    newChannel.DrRange.Value = ( DR_5 << 4 ) | DR_0;
+    newChannel.dr_range.value = ( DR_5 << 4 ) | DR_0;
 
     // Size of the optional CF list
     if( applyCFList->Size != 16 )
@@ -638,22 +638,22 @@ void LoRaPHYEU868::apply_cf_list(ApplyCFListParams_t* applyCFList)
         if( chanIdx < ( EU868_NUMB_CHANNELS_CF_LIST + EU868_NUMB_DEFAULT_CHANNELS ) )
         {
             // Channel frequency
-            newChannel.Frequency = (uint32_t) applyCFList->Payload[i];
-            newChannel.Frequency |= ( (uint32_t) applyCFList->Payload[i + 1] << 8 );
-            newChannel.Frequency |= ( (uint32_t) applyCFList->Payload[i + 2] << 16 );
-            newChannel.Frequency *= 100;
+            newChannel.frequency = (uint32_t) applyCFList->Payload[i];
+            newChannel.frequency |= ( (uint32_t) applyCFList->Payload[i + 1] << 8 );
+            newChannel.frequency |= ( (uint32_t) applyCFList->Payload[i + 2] << 16 );
+            newChannel.frequency *= 100;
 
             // Initialize alternative frequency to 0
-            newChannel.Rx1Frequency = 0;
+            newChannel.rx1_frequency = 0;
         }
         else
         {
-            newChannel.Frequency = 0;
-            newChannel.DrRange.Value = 0;
-            newChannel.Rx1Frequency = 0;
+            newChannel.frequency = 0;
+            newChannel.dr_range.value = 0;
+            newChannel.rx1_frequency = 0;
         }
 
-        if( newChannel.Frequency != 0 )
+        if( newChannel.frequency != 0 )
         {
             channelAdd.NewChannel = &newChannel;
             channelAdd.ChannelId = chanIdx;
@@ -753,47 +753,47 @@ bool LoRaPHYEU868::get_next_ADR(AdrNextParams_t* adrNext, int8_t* drOut,
 
 void LoRaPHYEU868::compute_rx_win_params(int8_t datarate, uint8_t minRxSymbols,
                                          uint32_t rxError,
-                                         RxConfigParams_t *rxConfigParams)
+                                         rx_config_params_t *rxConfigParams)
 {
     double tSymbol = 0.0;
 
     // Get the datarate, perform a boundary check
-    rxConfigParams->Datarate = MIN( datarate, EU868_RX_MAX_DATARATE );
-    rxConfigParams->Bandwidth = GetBandwidth( rxConfigParams->Datarate );
+    rxConfigParams->datarate = MIN( datarate, EU868_RX_MAX_DATARATE );
+    rxConfigParams->bandwidth = GetBandwidth( rxConfigParams->datarate );
 
-    if( rxConfigParams->Datarate == DR_7 )
+    if( rxConfigParams->datarate == DR_7 )
     { // FSK
-        tSymbol = compute_symb_timeout_fsk( DataratesEU868[rxConfigParams->Datarate] );
+        tSymbol = compute_symb_timeout_fsk( DataratesEU868[rxConfigParams->datarate] );
     }
     else
     { // LoRa
-        tSymbol = compute_symb_timeout_lora( DataratesEU868[rxConfigParams->Datarate], BandwidthsEU868[rxConfigParams->Datarate] );
+        tSymbol = compute_symb_timeout_lora( DataratesEU868[rxConfigParams->datarate], BandwidthsEU868[rxConfigParams->datarate] );
     }
 
-    get_rx_window_params( tSymbol, minRxSymbols, rxError, RADIO_WAKEUP_TIME, &rxConfigParams->WindowTimeout, &rxConfigParams->WindowOffset );
+    get_rx_window_params( tSymbol, minRxSymbols, rxError, RADIO_WAKEUP_TIME, &rxConfigParams->window_timeout, &rxConfigParams->window_offset );
 }
 
-bool LoRaPHYEU868::rx_config(RxConfigParams_t* rxConfig, int8_t* datarate)
+bool LoRaPHYEU868::rx_config(rx_config_params_t* rxConfig, int8_t* datarate)
 {
     radio_modems_t modem;
-    int8_t dr = rxConfig->Datarate;
+    int8_t dr = rxConfig->datarate;
     uint8_t maxPayload = 0;
     int8_t phyDr = 0;
-    uint32_t frequency = rxConfig->Frequency;
+    uint32_t frequency = rxConfig->frequency;
 
     if( _radio->get_status() != RF_IDLE )
     {
         return false;
     }
 
-    if( rxConfig->RxSlot == RX_SLOT_WIN_1 )
+    if( rxConfig->rx_slot == RX_SLOT_WIN_1 )
     {
         // Apply window 1 frequency
-        frequency = Channels[rxConfig->Channel].Frequency;
+        frequency = Channels[rxConfig->channel].frequency;
         // Apply the alternative RX 1 window frequency, if it is available
-        if( Channels[rxConfig->Channel].Rx1Frequency != 0 )
+        if( Channels[rxConfig->channel].rx1_frequency != 0 )
         {
-            frequency = Channels[rxConfig->Channel].Rx1Frequency;
+            frequency = Channels[rxConfig->channel].rx1_frequency;
         }
     }
 
@@ -806,15 +806,15 @@ bool LoRaPHYEU868::rx_config(RxConfigParams_t* rxConfig, int8_t* datarate)
     if( dr == DR_7 )
     {
         modem = MODEM_FSK;
-        _radio->set_rx_config( modem, 50000, phyDr * 1000, 0, 83333, 5, rxConfig->WindowTimeout, false, 0, true, 0, 0, false, rxConfig->RxContinuous );
+        _radio->set_rx_config( modem, 50000, phyDr * 1000, 0, 83333, 5, rxConfig->window_timeout, false, 0, true, 0, 0, false, rxConfig->is_rx_continuous );
     }
     else
     {
         modem = MODEM_LORA;
-        _radio->set_rx_config( modem, rxConfig->Bandwidth, phyDr, 1, 0, 8, rxConfig->WindowTimeout, false, 0, false, 0, 0, true, rxConfig->RxContinuous );
+        _radio->set_rx_config( modem, rxConfig->bandwidth, phyDr, 1, 0, 8, rxConfig->window_timeout, false, 0, false, 0, 0, true, rxConfig->is_rx_continuous );
     }
 
-    if( rxConfig->RepeaterSupport == true )
+    if( rxConfig->is_repeater_supported == true )
     {
         maxPayload = MaxPayloadOfDatarateRepeaterEU868[dr];
     }
@@ -830,11 +830,11 @@ bool LoRaPHYEU868::rx_config(RxConfigParams_t* rxConfig, int8_t* datarate)
 }
 
 bool LoRaPHYEU868::tx_config(TxConfigParams_t* txConfig, int8_t* txPower,
-                             TimerTime_t* txTimeOnAir)
+                             lorawan_time_t* txTimeOnAir)
 {
     radio_modems_t modem;
     int8_t phyDr = DataratesEU868[txConfig->Datarate];
-    int8_t txPowerLimited = LimitTxPower( txConfig->TxPower, Bands[Channels[txConfig->Channel].Band].TxMaxPower, txConfig->Datarate, ChannelsMask );
+    int8_t txPowerLimited = LimitTxPower( txConfig->TxPower, Bands[Channels[txConfig->Channel].band].max_tx_pwr, txConfig->Datarate, ChannelsMask );
     uint32_t bandwidth = GetBandwidth( txConfig->Datarate );
     int8_t phyTxPower = 0;
 
@@ -842,7 +842,7 @@ bool LoRaPHYEU868::tx_config(TxConfigParams_t* txConfig, int8_t* txPower,
     phyTxPower = compute_tx_power( txPowerLimited, txConfig->MaxEirp, txConfig->AntennaGain );
 
     // Setup the radio frequency
-    _radio->set_channel( Channels[txConfig->Channel].Frequency );
+    _radio->set_channel( Channels[txConfig->Channel].frequency );
 
     if( txConfig->Datarate == DR_7 )
     { // High Speed FSK channel
@@ -911,7 +911,7 @@ uint8_t LoRaPHYEU868::link_ADR_request(LinkAdrReqParams_t* linkAdrReq,
             {
                 if( linkAdrParams.ChMaskCtrl == 6 )
                 {
-                    if( Channels[i].Frequency != 0 )
+                    if( Channels[i].frequency != 0 )
                     {
                         chMask |= 1 << i;
                     }
@@ -919,7 +919,7 @@ uint8_t LoRaPHYEU868::link_ADR_request(LinkAdrReqParams_t* linkAdrReq,
                 else
                 {
                     if( ( ( chMask & ( 1 << i ) ) != 0 ) &&
-                        ( Channels[i].Frequency == 0 ) )
+                        ( Channels[i].frequency == 0 ) )
                     {// Trying to enable an undefined channel
                         status &= 0xFE; // Channel mask KO
                     }
@@ -1001,7 +1001,7 @@ uint8_t LoRaPHYEU868::request_new_channel(NewChannelReqParams_t* newChannelReq)
     ChannelAddParams_t channelAdd;
     ChannelRemoveParams_t channelRemove;
 
-    if( newChannelReq->NewChannel->Frequency == 0 )
+    if( newChannelReq->NewChannel->frequency == 0 )
     {
         channelRemove.ChannelId = newChannelReq->ChannelId;
 
@@ -1018,21 +1018,21 @@ uint8_t LoRaPHYEU868::request_new_channel(NewChannelReqParams_t* newChannelReq)
 
         switch( add_channel( &channelAdd ) )
         {
-            case LORAMAC_STATUS_OK:
+            case LORAWAN_STATUS_OK:
             {
                 break;
             }
-            case LORAMAC_STATUS_FREQUENCY_INVALID:
+            case LORAWAN_STATUS_FREQUENCY_INVALID:
             {
                 status &= 0xFE;
                 break;
             }
-            case LORAMAC_STATUS_DATARATE_INVALID:
+            case LORAWAN_STATUS_DATARATE_INVALID:
             {
                 status &= 0xFD;
                 break;
             }
-            case LORAMAC_STATUS_FREQ_AND_DR_INVALID:
+            case LORAWAN_STATUS_FREQ_AND_DR_INVALID:
             {
                 status &= 0xFC;
                 break;
@@ -1065,7 +1065,7 @@ uint8_t LoRaPHYEU868::dl_channel_request(DlChannelReqParams_t* dlChannelReq)
     }
 
     // Verify if an uplink frequency exists
-    if( Channels[dlChannelReq->ChannelId].Frequency == 0 )
+    if( Channels[dlChannelReq->ChannelId].frequency == 0 )
     {
         status &= 0xFD;
     }
@@ -1073,7 +1073,7 @@ uint8_t LoRaPHYEU868::dl_channel_request(DlChannelReqParams_t* dlChannelReq)
     // Apply Rx1 frequency, if the status is OK
     if( status == 0x03 )
     {
-        Channels[dlChannelReq->ChannelId].Rx1Frequency = dlChannelReq->Rx1Frequency;
+        Channels[dlChannelReq->ChannelId].rx1_frequency = dlChannelReq->Rx1Frequency;
     }
 
     return status;
@@ -1127,13 +1127,13 @@ void LoRaPHYEU868::calculate_backoff(CalcBackOffParams_t* calcBackOff)
 }
 
 bool LoRaPHYEU868::set_next_channel(NextChanParams_t* nextChanParams,
-                                    uint8_t* channel, TimerTime_t* time,
-                                    TimerTime_t* aggregatedTimeOff)
+                                    uint8_t* channel, lorawan_time_t* time,
+                                    lorawan_time_t* aggregatedTimeOff)
 {
     uint8_t nbEnabledChannels = 0;
     uint8_t delayTx = 0;
     uint8_t enabledChannels[EU868_MAX_NB_CHANNELS] = { 0 };
-    TimerTime_t nextTxDelay = 0;
+    lorawan_time_t nextTxDelay = 0;
 
     if( num_active_channels( ChannelsMask, 0, 1 ) == 0 )
     { // Reactivate default channels
@@ -1182,7 +1182,7 @@ bool LoRaPHYEU868::set_next_channel(NextChanParams_t* nextChanParams,
     }
 }
 
-LoRaMacStatus_t LoRaPHYEU868::add_channel(ChannelAddParams_t* channelAdd)
+lorawan_status_t LoRaPHYEU868::add_channel(ChannelAddParams_t* channelAdd)
 {
     uint8_t band = 0;
     bool drInvalid = false;
@@ -1191,19 +1191,19 @@ LoRaMacStatus_t LoRaPHYEU868::add_channel(ChannelAddParams_t* channelAdd)
 
     if( id >= EU868_MAX_NB_CHANNELS )
     {
-        return LORAMAC_STATUS_PARAMETER_INVALID;
+        return LORAWAN_STATUS_PARAMETER_INVALID;
     }
 
     // Validate the datarate range
-    if( val_in_range( channelAdd->NewChannel->DrRange.Fields.Min, EU868_TX_MIN_DATARATE, EU868_TX_MAX_DATARATE ) == 0 )
+    if( val_in_range( channelAdd->NewChannel->dr_range.fields.min, EU868_TX_MIN_DATARATE, EU868_TX_MAX_DATARATE ) == 0 )
     {
         drInvalid = true;
     }
-    if( val_in_range( channelAdd->NewChannel->DrRange.Fields.Max, EU868_TX_MIN_DATARATE, EU868_TX_MAX_DATARATE ) == 0 )
+    if( val_in_range( channelAdd->NewChannel->dr_range.fields.max, EU868_TX_MIN_DATARATE, EU868_TX_MAX_DATARATE ) == 0 )
     {
         drInvalid = true;
     }
-    if( channelAdd->NewChannel->DrRange.Fields.Min > channelAdd->NewChannel->DrRange.Fields.Max )
+    if( channelAdd->NewChannel->dr_range.fields.min > channelAdd->NewChannel->dr_range.fields.max )
     {
         drInvalid = true;
     }
@@ -1212,17 +1212,17 @@ LoRaMacStatus_t LoRaPHYEU868::add_channel(ChannelAddParams_t* channelAdd)
     if( id < EU868_NUMB_DEFAULT_CHANNELS )
     {
         // Validate the datarate range for min: must be DR_0
-        if( channelAdd->NewChannel->DrRange.Fields.Min > DR_0 )
+        if( channelAdd->NewChannel->dr_range.fields.min > DR_0 )
         {
             drInvalid = true;
         }
         // Validate the datarate range for max: must be DR_5 <= Max <= TX_MAX_DATARATE
-        if( val_in_range( channelAdd->NewChannel->DrRange.Fields.Max, DR_5, EU868_TX_MAX_DATARATE ) == 0 )
+        if( val_in_range( channelAdd->NewChannel->dr_range.fields.max, DR_5, EU868_TX_MAX_DATARATE ) == 0 )
         {
             drInvalid = true;
         }
         // We are not allowed to change the frequency
-        if( channelAdd->NewChannel->Frequency != Channels[id].Frequency )
+        if( channelAdd->NewChannel->frequency != Channels[id].frequency )
         {
             freqInvalid = true;
         }
@@ -1231,7 +1231,7 @@ LoRaMacStatus_t LoRaPHYEU868::add_channel(ChannelAddParams_t* channelAdd)
     // Check frequency
     if( freqInvalid == false )
     {
-        if( VerifyTxFreq( channelAdd->NewChannel->Frequency, &band, _radio ) == false )
+        if( VerifyTxFreq( channelAdd->NewChannel->frequency, &band, _radio ) == false )
         {
             freqInvalid = true;
         }
@@ -1240,21 +1240,21 @@ LoRaMacStatus_t LoRaPHYEU868::add_channel(ChannelAddParams_t* channelAdd)
     // Check status
     if( ( drInvalid == true ) && ( freqInvalid == true ) )
     {
-        return LORAMAC_STATUS_FREQ_AND_DR_INVALID;
+        return LORAWAN_STATUS_FREQ_AND_DR_INVALID;
     }
     if( drInvalid == true )
     {
-        return LORAMAC_STATUS_DATARATE_INVALID;
+        return LORAWAN_STATUS_DATARATE_INVALID;
     }
     if( freqInvalid == true )
     {
-        return LORAMAC_STATUS_FREQUENCY_INVALID;
+        return LORAWAN_STATUS_FREQUENCY_INVALID;
     }
 
     memcpy( &(Channels[id]), channelAdd->NewChannel, sizeof( Channels[id] ) );
-    Channels[id].Band = band;
+    Channels[id].band = band;
     ChannelsMask[0] |= ( 1 << id );
-    return LORAMAC_STATUS_OK;
+    return LORAWAN_STATUS_OK;
 }
 
 bool LoRaPHYEU868::remove_channel(ChannelRemoveParams_t* channelRemove)
@@ -1267,7 +1267,7 @@ bool LoRaPHYEU868::remove_channel(ChannelRemoveParams_t* channelRemove)
     }
 
     // Remove the channel from the list of channels
-    const ChannelParams_t empty_channel = { 0, 0, { 0 }, 0 };
+    const channel_params_t empty_channel = { 0, 0, { 0 }, 0 };
     Channels[id] = empty_channel;
 
     return disable_channel( ChannelsMask, id, EU868_MAX_NB_CHANNELS );
@@ -1275,9 +1275,9 @@ bool LoRaPHYEU868::remove_channel(ChannelRemoveParams_t* channelRemove)
 
 void LoRaPHYEU868::set_tx_cont_mode(ContinuousWaveParams_t* continuousWave)
 {
-    int8_t txPowerLimited = LimitTxPower( continuousWave->TxPower, Bands[Channels[continuousWave->Channel].Band].TxMaxPower, continuousWave->Datarate, ChannelsMask );
+    int8_t txPowerLimited = LimitTxPower( continuousWave->TxPower, Bands[Channels[continuousWave->Channel].band].max_tx_pwr, continuousWave->Datarate, ChannelsMask );
     int8_t phyTxPower = 0;
-    uint32_t frequency = Channels[continuousWave->Channel].Frequency;
+    uint32_t frequency = Channels[continuousWave->Channel].frequency;
 
     // Calculate physical TX power
     phyTxPower = compute_tx_power( txPowerLimited, continuousWave->MaxEirp, continuousWave->AntennaGain );

--- a/features/lorawan/lorastack/phy/LoRaPHYEU868.h
+++ b/features/lorawan/lorastack/phy/LoRaPHYEU868.h
@@ -129,7 +129,7 @@ public:
      *
      * \retval True, if the configuration was applied successfully.
      */
-    virtual bool rx_config(RxConfigParams_t* rxConfig, int8_t* datarate );
+    virtual bool rx_config(rx_config_params_t* rxConfig, int8_t* datarate );
 
     /*
      * RX window precise timing
@@ -185,7 +185,7 @@ public:
     virtual void compute_rx_win_params(int8_t datarate,
                                                  uint8_t minRxSymbols,
                                                  uint32_t rxError,
-                                                 RxConfigParams_t *rxConfigParams);
+                                                 rx_config_params_t *rxConfigParams);
 
     /*!
      * \brief TX configuration.
@@ -199,7 +199,7 @@ public:
      * \retval True, if the configuration was applied successfully.
      */
     virtual bool tx_config(TxConfigParams_t* txConfig, int8_t* txPower,
-                                TimerTime_t* txTimeOnAir );
+                                lorawan_time_t* txTimeOnAir );
 
     /*!
      * \brief The function processes a Link ADR request.
@@ -289,8 +289,8 @@ public:
      * \retval The function status [1: OK, 0: Unable to find a channel on the current datarate].
      */
     virtual bool set_next_channel(NextChanParams_t* nextChanParams,
-                                   uint8_t* channel, TimerTime_t* time,
-                                   TimerTime_t* aggregatedTimeOff );
+                                   uint8_t* channel, lorawan_time_t* time,
+                                   lorawan_time_t* aggregatedTimeOff );
 
     /*!
      * \brief Adds a channel.
@@ -299,7 +299,7 @@ public:
      *
      * \retval The status of the operation.
      */
-    virtual LoRaMacStatus_t add_channel(ChannelAddParams_t* channelAdd );
+    virtual lorawan_status_t add_channel(ChannelAddParams_t* channelAdd );
 
     /*!
      * \brief Removes a channel.
@@ -331,18 +331,18 @@ public:
     virtual uint8_t apply_DR_offset(uint8_t downlinkDwellTime, int8_t dr, int8_t drOffset );
 
 private:
-    uint8_t CountNbOfEnabledChannels( bool joined, uint8_t datarate, uint16_t* channelsMask, ChannelParams_t* channels, Band_t* bands, uint8_t* enabledChannels, uint8_t* delayTx );
+    uint8_t CountNbOfEnabledChannels( bool joined, uint8_t datarate, uint16_t* channelsMask, channel_params_t* channels, band_t* bands, uint8_t* enabledChannels, uint8_t* delayTx );
 
     // Global attributes
     /*!
      * LoRaMAC channels
      */
-    ChannelParams_t Channels[EU868_MAX_NB_CHANNELS];
+    channel_params_t Channels[EU868_MAX_NB_CHANNELS];
 
     /*!
      * LoRaMac bands
      */
-    Band_t Bands[EU868_MAX_NB_BANDS];
+    band_t Bands[EU868_MAX_NB_BANDS];
 
     /*!
      * LoRaMac channels mask

--- a/features/lorawan/lorastack/phy/LoRaPHYIN865.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHYIN865.cpp
@@ -293,7 +293,7 @@ static bool VerifyTxFreq( uint32_t freq, uint8_t *band, LoRaRadio *radio )
     return true;
 }
 
-uint8_t LoRaPHYIN865::CountNbOfEnabledChannels( bool joined, uint8_t datarate, uint16_t* channelsMask, ChannelParams_t* channels, Band_t* bands, uint8_t* enabledChannels, uint8_t* delayTx )
+uint8_t LoRaPHYIN865::CountNbOfEnabledChannels( bool joined, uint8_t datarate, uint16_t* channelsMask, channel_params_t* channels, band_t* bands, uint8_t* enabledChannels, uint8_t* delayTx )
 {
     uint8_t nbEnabledChannels = 0;
     uint8_t delayTransmission = 0;
@@ -304,7 +304,7 @@ uint8_t LoRaPHYIN865::CountNbOfEnabledChannels( bool joined, uint8_t datarate, u
         {
             if( ( channelsMask[k] & ( 1 << j ) ) != 0 )
             {
-                if( channels[i + j].Frequency == 0 )
+                if( channels[i + j].frequency == 0 )
                 { // Check if the channel is enabled
                     continue;
                 }
@@ -315,12 +315,12 @@ uint8_t LoRaPHYIN865::CountNbOfEnabledChannels( bool joined, uint8_t datarate, u
                         continue;
                     }
                 }
-                if( val_in_range( datarate, channels[i + j].DrRange.Fields.Min,
-                                              channels[i + j].DrRange.Fields.Max ) == 0 )
+                if( val_in_range( datarate, channels[i + j].dr_range.fields.min,
+                                              channels[i + j].dr_range.fields.max ) == 0 )
                 { // Check if the current channel selection supports the given datarate
                     continue;
                 }
-                if( bands[channels[i + j].Band].TimeOff > 0 )
+                if( bands[channels[i + j].band].off_time > 0 )
                 { // Check if the band is available for transmission
                     delayTransmission++;
                     continue;
@@ -337,7 +337,7 @@ uint8_t LoRaPHYIN865::CountNbOfEnabledChannels( bool joined, uint8_t datarate, u
 LoRaPHYIN865::LoRaPHYIN865(LoRaWANTimeHandler &lora_time)
     : LoRaPHY(lora_time)
 {
-    const Band_t band0 = IN865_BAND0;
+    const band_t band0 = IN865_BAND0;
     Bands[0] = band0;
 }
 
@@ -494,7 +494,7 @@ PhyParam_t LoRaPHYIN865::get_phy_params(GetPhyParams_t* getPhy)
 
 void LoRaPHYIN865::set_band_tx_done(SetBandTxDoneParams_t* txDone)
 {
-    set_last_tx_done( txDone->Joined, &Bands[Channels[txDone->Channel].Band], txDone->LastTxDoneTime );
+    set_last_tx_done( txDone->Joined, &Bands[Channels[txDone->Channel].band], txDone->LastTxDoneTime );
 }
 
 void LoRaPHYIN865::load_defaults(InitType_t type)
@@ -504,9 +504,9 @@ void LoRaPHYIN865::load_defaults(InitType_t type)
         case INIT_TYPE_INIT:
         {
             // Channels
-            const ChannelParams_t channel1 = IN865_LC1;
-            const ChannelParams_t channel2 = IN865_LC2;
-            const ChannelParams_t channel3 = IN865_LC3;
+            const channel_params_t channel1 = IN865_LC1;
+            const channel_params_t channel2 = IN865_LC2;
+            const channel_params_t channel3 = IN865_LC3;
             Channels[0] = channel1;
             Channels[1] = channel2;
             Channels[2] = channel3;
@@ -572,12 +572,12 @@ bool LoRaPHYIN865::verify(VerifyParams_t* verify, PhyAttribute_t phyAttribute)
 
 void LoRaPHYIN865::apply_cf_list(ApplyCFListParams_t* applyCFList)
 {
-    ChannelParams_t newChannel;
+    channel_params_t newChannel;
     ChannelAddParams_t channelAdd;
     ChannelRemoveParams_t channelRemove;
 
     // Setup default datarate range
-    newChannel.DrRange.Value = ( DR_5 << 4 ) | DR_0;
+    newChannel.dr_range.value = ( DR_5 << 4 ) | DR_0;
 
     // Size of the optional CF list
     if( applyCFList->Size != 16 )
@@ -591,22 +591,22 @@ void LoRaPHYIN865::apply_cf_list(ApplyCFListParams_t* applyCFList)
         if( chanIdx < ( IN865_NUMB_CHANNELS_CF_LIST + IN865_NUMB_DEFAULT_CHANNELS ) )
         {
             // Channel frequency
-            newChannel.Frequency = (uint32_t) applyCFList->Payload[i];
-            newChannel.Frequency |= ( (uint32_t) applyCFList->Payload[i + 1] << 8 );
-            newChannel.Frequency |= ( (uint32_t) applyCFList->Payload[i + 2] << 16 );
-            newChannel.Frequency *= 100;
+            newChannel.frequency = (uint32_t) applyCFList->Payload[i];
+            newChannel.frequency |= ( (uint32_t) applyCFList->Payload[i + 1] << 8 );
+            newChannel.frequency |= ( (uint32_t) applyCFList->Payload[i + 2] << 16 );
+            newChannel.frequency *= 100;
 
             // Initialize alternative frequency to 0
-            newChannel.Rx1Frequency = 0;
+            newChannel.rx1_frequency = 0;
         }
         else
         {
-            newChannel.Frequency = 0;
-            newChannel.DrRange.Value = 0;
-            newChannel.Rx1Frequency = 0;
+            newChannel.frequency = 0;
+            newChannel.dr_range.value = 0;
+            newChannel.rx1_frequency = 0;
         }
 
-        if( newChannel.Frequency != 0 )
+        if( newChannel.frequency != 0 )
         {
             channelAdd.NewChannel = &newChannel;
             channelAdd.ChannelId = chanIdx;
@@ -706,47 +706,47 @@ bool LoRaPHYIN865::get_next_ADR(AdrNextParams_t* adrNext, int8_t* drOut,
 
 void LoRaPHYIN865::compute_rx_win_params(int8_t datarate, uint8_t minRxSymbols,
                                          uint32_t rxError,
-                                         RxConfigParams_t *rxConfigParams)
+                                         rx_config_params_t *rxConfigParams)
 {
     double tSymbol = 0.0;
 
     // Get the datarate, perform a boundary check
-    rxConfigParams->Datarate = MIN( datarate, IN865_RX_MAX_DATARATE );
-    rxConfigParams->Bandwidth = GetBandwidth( rxConfigParams->Datarate );
+    rxConfigParams->datarate = MIN( datarate, IN865_RX_MAX_DATARATE );
+    rxConfigParams->bandwidth = GetBandwidth( rxConfigParams->datarate );
 
-    if( rxConfigParams->Datarate == DR_7 )
+    if( rxConfigParams->datarate == DR_7 )
     { // FSK
-        tSymbol = compute_symb_timeout_fsk( DataratesIN865[rxConfigParams->Datarate] );
+        tSymbol = compute_symb_timeout_fsk( DataratesIN865[rxConfigParams->datarate] );
     }
     else
     { // LoRa
-        tSymbol = compute_symb_timeout_lora( DataratesIN865[rxConfigParams->Datarate], BandwidthsIN865[rxConfigParams->Datarate] );
+        tSymbol = compute_symb_timeout_lora( DataratesIN865[rxConfigParams->datarate], BandwidthsIN865[rxConfigParams->datarate] );
     }
 
-    get_rx_window_params( tSymbol, minRxSymbols, rxError, RADIO_WAKEUP_TIME, &rxConfigParams->WindowTimeout, &rxConfigParams->WindowOffset );
+    get_rx_window_params( tSymbol, minRxSymbols, rxError, RADIO_WAKEUP_TIME, &rxConfigParams->window_timeout, &rxConfigParams->window_offset );
 }
 
-bool LoRaPHYIN865::rx_config(RxConfigParams_t* rxConfig, int8_t* datarate)
+bool LoRaPHYIN865::rx_config(rx_config_params_t* rxConfig, int8_t* datarate)
 {
     radio_modems_t modem;
-    int8_t dr = rxConfig->Datarate;
+    int8_t dr = rxConfig->datarate;
     uint8_t maxPayload = 0;
     int8_t phyDr = 0;
-    uint32_t frequency = rxConfig->Frequency;
+    uint32_t frequency = rxConfig->frequency;
 
     if( _radio->get_status() != RF_IDLE )
     {
         return false;
     }
 
-    if( rxConfig->RxSlot == RX_SLOT_WIN_1 )
+    if( rxConfig->rx_slot == RX_SLOT_WIN_1 )
     {
         // Apply window 1 frequency
-        frequency = Channels[rxConfig->Channel].Frequency;
+        frequency = Channels[rxConfig->channel].frequency;
         // Apply the alternative RX 1 window frequency, if it is available
-        if( Channels[rxConfig->Channel].Rx1Frequency != 0 )
+        if( Channels[rxConfig->channel].rx1_frequency != 0 )
         {
-            frequency = Channels[rxConfig->Channel].Rx1Frequency;
+            frequency = Channels[rxConfig->channel].rx1_frequency;
         }
     }
 
@@ -759,15 +759,15 @@ bool LoRaPHYIN865::rx_config(RxConfigParams_t* rxConfig, int8_t* datarate)
     if( dr == DR_7 )
     {
         modem = MODEM_FSK;
-        _radio->set_rx_config( modem, 50000, phyDr * 1000, 0, 83333, 5, rxConfig->WindowTimeout, false, 0, true, 0, 0, false, rxConfig->RxContinuous );
+        _radio->set_rx_config( modem, 50000, phyDr * 1000, 0, 83333, 5, rxConfig->window_timeout, false, 0, true, 0, 0, false, rxConfig->is_rx_continuous );
     }
     else
     {
         modem = MODEM_LORA;
-        _radio->set_rx_config( modem, rxConfig->Bandwidth, phyDr, 1, 0, 8, rxConfig->WindowTimeout, false, 0, false, 0, 0, true, rxConfig->RxContinuous );
+        _radio->set_rx_config( modem, rxConfig->bandwidth, phyDr, 1, 0, 8, rxConfig->window_timeout, false, 0, false, 0, 0, true, rxConfig->is_rx_continuous );
     }
 
-    if( rxConfig->RepeaterSupport == true )
+    if( rxConfig->is_repeater_supported == true )
     {
         maxPayload = MaxPayloadOfDatarateRepeaterIN865[dr];
     }
@@ -781,11 +781,11 @@ bool LoRaPHYIN865::rx_config(RxConfigParams_t* rxConfig, int8_t* datarate)
     return true;
 }
 
-bool LoRaPHYIN865::tx_config(TxConfigParams_t* txConfig, int8_t* txPower, TimerTime_t* txTimeOnAir)
+bool LoRaPHYIN865::tx_config(TxConfigParams_t* txConfig, int8_t* txPower, lorawan_time_t* txTimeOnAir)
 {
     radio_modems_t modem;
     int8_t phyDr = DataratesIN865[txConfig->Datarate];
-    int8_t txPowerLimited = LimitTxPower( txConfig->TxPower, Bands[Channels[txConfig->Channel].Band].TxMaxPower, txConfig->Datarate, ChannelsMask );
+    int8_t txPowerLimited = LimitTxPower( txConfig->TxPower, Bands[Channels[txConfig->Channel].band].max_tx_pwr, txConfig->Datarate, ChannelsMask );
     uint32_t bandwidth = GetBandwidth( txConfig->Datarate );
     int8_t phyTxPower = 0;
 
@@ -793,7 +793,7 @@ bool LoRaPHYIN865::tx_config(TxConfigParams_t* txConfig, int8_t* txPower, TimerT
     phyTxPower = compute_tx_power( txPowerLimited, txConfig->MaxEirp, txConfig->AntennaGain );
 
     // Setup the radio frequency
-    _radio->set_channel( Channels[txConfig->Channel].Frequency );
+    _radio->set_channel( Channels[txConfig->Channel].frequency );
 
     if( txConfig->Datarate == DR_7 )
     { // High Speed FSK channel
@@ -862,7 +862,7 @@ uint8_t LoRaPHYIN865::link_ADR_request(LinkAdrReqParams_t* linkAdrReq,
             {
                 if( linkAdrParams.ChMaskCtrl == 6 )
                 {
-                    if( Channels[i].Frequency != 0 )
+                    if( Channels[i].frequency != 0 )
                     {
                         chMask |= 1 << i;
                     }
@@ -870,7 +870,7 @@ uint8_t LoRaPHYIN865::link_ADR_request(LinkAdrReqParams_t* linkAdrReq,
                 else
                 {
                     if( ( ( chMask & ( 1 << i ) ) != 0 ) &&
-                        ( Channels[i].Frequency == 0 ) )
+                        ( Channels[i].frequency == 0 ) )
                     {// Trying to enable an undefined channel
                         status &= 0xFE; // Channel mask KO
                     }
@@ -952,7 +952,7 @@ uint8_t LoRaPHYIN865::request_new_channel(NewChannelReqParams_t* newChannelReq)
     ChannelAddParams_t channelAdd;
     ChannelRemoveParams_t channelRemove;
 
-    if( newChannelReq->NewChannel->Frequency == 0 )
+    if( newChannelReq->NewChannel->frequency == 0 )
     {
         channelRemove.ChannelId = newChannelReq->ChannelId;
 
@@ -969,21 +969,21 @@ uint8_t LoRaPHYIN865::request_new_channel(NewChannelReqParams_t* newChannelReq)
 
         switch( add_channel( &channelAdd ) )
         {
-            case LORAMAC_STATUS_OK:
+            case LORAWAN_STATUS_OK:
             {
                 break;
             }
-            case LORAMAC_STATUS_FREQUENCY_INVALID:
+            case LORAWAN_STATUS_FREQUENCY_INVALID:
             {
                 status &= 0xFE;
                 break;
             }
-            case LORAMAC_STATUS_DATARATE_INVALID:
+            case LORAWAN_STATUS_DATARATE_INVALID:
             {
                 status &= 0xFD;
                 break;
             }
-            case LORAMAC_STATUS_FREQ_AND_DR_INVALID:
+            case LORAWAN_STATUS_FREQ_AND_DR_INVALID:
             {
                 status &= 0xFC;
                 break;
@@ -1016,7 +1016,7 @@ uint8_t LoRaPHYIN865::dl_channel_request(DlChannelReqParams_t* dlChannelReq)
     }
 
     // Verify if an uplink frequency exists
-    if( Channels[dlChannelReq->ChannelId].Frequency == 0 )
+    if( Channels[dlChannelReq->ChannelId].frequency == 0 )
     {
         status &= 0xFD;
     }
@@ -1024,7 +1024,7 @@ uint8_t LoRaPHYIN865::dl_channel_request(DlChannelReqParams_t* dlChannelReq)
     // Apply Rx1 frequency, if the status is OK
     if( status == 0x03 )
     {
-        Channels[dlChannelReq->ChannelId].Rx1Frequency = dlChannelReq->Rx1Frequency;
+        Channels[dlChannelReq->ChannelId].rx1_frequency = dlChannelReq->Rx1Frequency;
     }
 
     return status;
@@ -1078,13 +1078,13 @@ void LoRaPHYIN865::calculate_backoff(CalcBackOffParams_t* calcBackOff)
 }
 
 bool LoRaPHYIN865::set_next_channel(NextChanParams_t* nextChanParams,
-                                    uint8_t* channel, TimerTime_t* time,
-                                    TimerTime_t* aggregatedTimeOff)
+                                    uint8_t* channel, lorawan_time_t* time,
+                                    lorawan_time_t* aggregatedTimeOff)
 {
     uint8_t nbEnabledChannels = 0;
     uint8_t delayTx = 0;
     uint8_t enabledChannels[IN865_MAX_NB_CHANNELS] = { 0 };
-    TimerTime_t nextTxDelay = 0;
+    lorawan_time_t nextTxDelay = 0;
 
     if( num_active_channels( ChannelsMask, 0, 1 ) == 0 )
     { // Reactivate default channels
@@ -1133,7 +1133,7 @@ bool LoRaPHYIN865::set_next_channel(NextChanParams_t* nextChanParams,
     }
 }
 
-LoRaMacStatus_t LoRaPHYIN865::add_channel(ChannelAddParams_t* channelAdd)
+lorawan_status_t LoRaPHYIN865::add_channel(ChannelAddParams_t* channelAdd)
 {
     uint8_t band = 0;
     bool drInvalid = false;
@@ -1142,19 +1142,19 @@ LoRaMacStatus_t LoRaPHYIN865::add_channel(ChannelAddParams_t* channelAdd)
 
     if( id >= IN865_MAX_NB_CHANNELS )
     {
-        return LORAMAC_STATUS_PARAMETER_INVALID;
+        return LORAWAN_STATUS_PARAMETER_INVALID;
     }
 
     // Validate the datarate range
-    if( val_in_range( channelAdd->NewChannel->DrRange.Fields.Min, IN865_TX_MIN_DATARATE, IN865_TX_MAX_DATARATE ) == 0 )
+    if( val_in_range( channelAdd->NewChannel->dr_range.fields.min, IN865_TX_MIN_DATARATE, IN865_TX_MAX_DATARATE ) == 0 )
     {
         drInvalid = true;
     }
-    if( val_in_range( channelAdd->NewChannel->DrRange.Fields.Max, IN865_TX_MIN_DATARATE, IN865_TX_MAX_DATARATE ) == 0 )
+    if( val_in_range( channelAdd->NewChannel->dr_range.fields.max, IN865_TX_MIN_DATARATE, IN865_TX_MAX_DATARATE ) == 0 )
     {
         drInvalid = true;
     }
-    if( channelAdd->NewChannel->DrRange.Fields.Min > channelAdd->NewChannel->DrRange.Fields.Max )
+    if( channelAdd->NewChannel->dr_range.fields.min > channelAdd->NewChannel->dr_range.fields.max )
     {
         drInvalid = true;
     }
@@ -1163,17 +1163,17 @@ LoRaMacStatus_t LoRaPHYIN865::add_channel(ChannelAddParams_t* channelAdd)
     if( id < IN865_NUMB_DEFAULT_CHANNELS )
     {
         // Validate the datarate range for min: must be DR_0
-        if( channelAdd->NewChannel->DrRange.Fields.Min > DR_0 )
+        if( channelAdd->NewChannel->dr_range.fields.min > DR_0 )
         {
             drInvalid = true;
         }
         // Validate the datarate range for max: must be DR_5 <= Max <= TX_MAX_DATARATE
-        if( val_in_range( channelAdd->NewChannel->DrRange.Fields.Max, DR_5, IN865_TX_MAX_DATARATE ) == 0 )
+        if( val_in_range( channelAdd->NewChannel->dr_range.fields.max, DR_5, IN865_TX_MAX_DATARATE ) == 0 )
         {
             drInvalid = true;
         }
         // We are not allowed to change the frequency
-        if( channelAdd->NewChannel->Frequency != Channels[id].Frequency )
+        if( channelAdd->NewChannel->frequency != Channels[id].frequency )
         {
             freqInvalid = true;
         }
@@ -1182,7 +1182,7 @@ LoRaMacStatus_t LoRaPHYIN865::add_channel(ChannelAddParams_t* channelAdd)
     // Check frequency
     if( freqInvalid == false )
     {
-        if( VerifyTxFreq( channelAdd->NewChannel->Frequency, &band, _radio ) == false )
+        if( VerifyTxFreq( channelAdd->NewChannel->frequency, &band, _radio ) == false )
         {
             freqInvalid = true;
         }
@@ -1191,21 +1191,21 @@ LoRaMacStatus_t LoRaPHYIN865::add_channel(ChannelAddParams_t* channelAdd)
     // Check status
     if( ( drInvalid == true ) && ( freqInvalid == true ) )
     {
-        return LORAMAC_STATUS_FREQ_AND_DR_INVALID;
+        return LORAWAN_STATUS_FREQ_AND_DR_INVALID;
     }
     if( drInvalid == true )
     {
-        return LORAMAC_STATUS_DATARATE_INVALID;
+        return LORAWAN_STATUS_DATARATE_INVALID;
     }
     if( freqInvalid == true )
     {
-        return LORAMAC_STATUS_FREQUENCY_INVALID;
+        return LORAWAN_STATUS_FREQUENCY_INVALID;
     }
 
     memcpy( &(Channels[id]), channelAdd->NewChannel, sizeof( Channels[id] ) );
-    Channels[id].Band = band;
+    Channels[id].band = band;
     ChannelsMask[0] |= ( 1 << id );
-    return LORAMAC_STATUS_OK;
+    return LORAWAN_STATUS_OK;
 }
 
 bool LoRaPHYIN865::remove_channel(ChannelRemoveParams_t* channelRemove)
@@ -1218,7 +1218,7 @@ bool LoRaPHYIN865::remove_channel(ChannelRemoveParams_t* channelRemove)
     }
 
     // Remove the channel from the list of channels
-    const ChannelParams_t empty_channel = { 0, 0, { 0 }, 0 };
+    const channel_params_t empty_channel = { 0, 0, { 0 }, 0 };
     Channels[id] = empty_channel;
 
     return disable_channel( ChannelsMask, id, IN865_MAX_NB_CHANNELS );
@@ -1226,9 +1226,9 @@ bool LoRaPHYIN865::remove_channel(ChannelRemoveParams_t* channelRemove)
 
 void LoRaPHYIN865::set_tx_cont_mode(ContinuousWaveParams_t* continuousWave)
 {
-    int8_t txPowerLimited = LimitTxPower( continuousWave->TxPower, Bands[Channels[continuousWave->Channel].Band].TxMaxPower, continuousWave->Datarate, ChannelsMask );
+    int8_t txPowerLimited = LimitTxPower( continuousWave->TxPower, Bands[Channels[continuousWave->Channel].band].max_tx_pwr, continuousWave->Datarate, ChannelsMask );
     int8_t phyTxPower = 0;
-    uint32_t frequency = Channels[continuousWave->Channel].Frequency;
+    uint32_t frequency = Channels[continuousWave->Channel].frequency;
 
     // Calculate physical TX power
     phyTxPower = compute_tx_power( txPowerLimited, continuousWave->MaxEirp, continuousWave->AntennaGain );

--- a/features/lorawan/lorastack/phy/LoRaPHYIN865.h
+++ b/features/lorawan/lorastack/phy/LoRaPHYIN865.h
@@ -132,7 +132,7 @@ public:
      *
      * \retval True, if the configuration was applied successfully.
      */
-    virtual bool rx_config(RxConfigParams_t* rxConfig, int8_t* datarate );
+    virtual bool rx_config(rx_config_params_t* rxConfig, int8_t* datarate );
 
     /*
      * RX window precise timing
@@ -188,7 +188,7 @@ public:
     virtual void compute_rx_win_params(int8_t datarate,
                                                  uint8_t minRxSymbols,
                                                  uint32_t rxError,
-                                                 RxConfigParams_t *rxConfigParams);
+                                                 rx_config_params_t *rxConfigParams);
 
     /*!
      * \brief TX configuration.
@@ -202,7 +202,7 @@ public:
      * \retval True, if the configuration was applied successfully.
      */
     virtual bool tx_config(TxConfigParams_t* txConfig, int8_t* txPower,
-                                TimerTime_t* txTimeOnAir );
+                                lorawan_time_t* txTimeOnAir );
 
     /*!
      * \brief The function processes a Link ADR request.
@@ -292,8 +292,8 @@ public:
      * \retval The function status [1: OK, 0: Unable to find a channel on the current datarate].
      */
     virtual bool set_next_channel(NextChanParams_t* nextChanParams,
-                                   uint8_t* channel, TimerTime_t* time,
-                                   TimerTime_t* aggregatedTimeOff );
+                                   uint8_t* channel, lorawan_time_t* time,
+                                   lorawan_time_t* aggregatedTimeOff );
 
     /*!
      * \brief Adds a channel.
@@ -302,7 +302,7 @@ public:
      *
      * \retval The status of the operation.
      */
-    virtual LoRaMacStatus_t add_channel(ChannelAddParams_t* channelAdd );
+    virtual lorawan_status_t add_channel(ChannelAddParams_t* channelAdd );
 
     /*!
      * \brief Removes a channel.
@@ -334,18 +334,18 @@ public:
     virtual uint8_t apply_DR_offset(uint8_t downlinkDwellTime, int8_t dr, int8_t drOffset );
 
 private:
-    uint8_t CountNbOfEnabledChannels( bool joined, uint8_t datarate, uint16_t* channelsMask, ChannelParams_t* channels, Band_t* bands, uint8_t* enabledChannels, uint8_t* delayTx );
+    uint8_t CountNbOfEnabledChannels( bool joined, uint8_t datarate, uint16_t* channelsMask, channel_params_t* channels, band_t* bands, uint8_t* enabledChannels, uint8_t* delayTx );
 
     // Global attributes
     /*!
      * LoRaMAC channels
      */
-    ChannelParams_t Channels[IN865_MAX_NB_CHANNELS];
+    channel_params_t Channels[IN865_MAX_NB_CHANNELS];
 
     /*!
      * LoRaMac bands
      */
-    Band_t Bands[IN865_MAX_NB_BANDS];
+    band_t Bands[IN865_MAX_NB_BANDS];
 
     /*!
      * LoRaMac channels mask

--- a/features/lorawan/lorastack/phy/LoRaPHYKR920.h
+++ b/features/lorawan/lorastack/phy/LoRaPHYKR920.h
@@ -130,7 +130,7 @@ public:
      *
      * \retval True, if the configuration was applied successfully.
      */
-    virtual bool rx_config(RxConfigParams_t* rxConfig, int8_t* datarate );
+    virtual bool rx_config(rx_config_params_t* rxConfig, int8_t* datarate );
 
     /*
      * RX window precise timing
@@ -186,7 +186,7 @@ public:
     virtual void compute_rx_win_params(int8_t datarate,
                                                  uint8_t minRxSymbols,
                                                  uint32_t rxError,
-                                                 RxConfigParams_t *rxConfigParams);
+                                                 rx_config_params_t *rxConfigParams);
 
     /*!
      * \brief TX configuration.
@@ -200,7 +200,7 @@ public:
      * \retval True, if the configuration was applied successfully.
      */
     virtual bool tx_config(TxConfigParams_t* txConfig, int8_t* txPower,
-                                TimerTime_t* txTimeOnAir );
+                                lorawan_time_t* txTimeOnAir );
 
     /*!
      * \brief The function processes a Link ADR request.
@@ -290,8 +290,8 @@ public:
      * \retval The function status [1: OK, 0: Unable to find a channel on the current datarate].
      */
     virtual bool set_next_channel(NextChanParams_t* nextChanParams,
-                                   uint8_t* channel, TimerTime_t* time,
-                                   TimerTime_t* aggregatedTimeOff );
+                                   uint8_t* channel, lorawan_time_t* time,
+                                   lorawan_time_t* aggregatedTimeOff );
 
     /*!
      * \brief Adds a channel.
@@ -300,7 +300,7 @@ public:
      *
      * \retval The status of the operation.
      */
-    virtual LoRaMacStatus_t add_channel(ChannelAddParams_t* channelAdd );
+    virtual lorawan_status_t add_channel(ChannelAddParams_t* channelAdd );
 
     /*!
      * \brief Removes a channel.
@@ -331,18 +331,18 @@ public:
      */
     virtual uint8_t apply_DR_offset(uint8_t downlinkDwellTime, int8_t dr, int8_t drOffset );
 
-    uint8_t CountNbOfEnabledChannels( bool joined, uint8_t datarate, uint16_t* channelsMask, ChannelParams_t* channels, Band_t* bands, uint8_t* enabledChannels, uint8_t* delayTx );
+    uint8_t CountNbOfEnabledChannels( bool joined, uint8_t datarate, uint16_t* channelsMask, channel_params_t* channels, band_t* bands, uint8_t* enabledChannels, uint8_t* delayTx );
 
     // Global attributes
     /*!
      * LoRaMAC channels
      */
-    ChannelParams_t Channels[KR920_MAX_NB_CHANNELS];
+    channel_params_t Channels[KR920_MAX_NB_CHANNELS];
 
     /*!
      * LoRaMac bands
      */
-    Band_t Bands[KR920_MAX_NB_BANDS];
+    band_t Bands[KR920_MAX_NB_BANDS];
 
     /*!
      * LoRaMac channels mask

--- a/features/lorawan/lorastack/phy/LoRaPHYUS915.h
+++ b/features/lorawan/lorastack/phy/LoRaPHYUS915.h
@@ -130,7 +130,7 @@ public:
      *
      * \retval True, if the configuration was applied successfully.
      */
-    virtual bool rx_config(RxConfigParams_t* rxConfig, int8_t* datarate );
+    virtual bool rx_config(rx_config_params_t* rxConfig, int8_t* datarate );
 
     /*
      * RX window precise timing
@@ -186,7 +186,7 @@ public:
     virtual void compute_rx_win_params(int8_t datarate,
                                                  uint8_t minRxSymbols,
                                                  uint32_t rxError,
-                                                 RxConfigParams_t *rxConfigParams);
+                                                 rx_config_params_t *rxConfigParams);
 
     /*!
      * \brief TX configuration.
@@ -200,7 +200,7 @@ public:
      * \retval True, if the configuration was applied successfully.
      */
     virtual bool tx_config(TxConfigParams_t* txConfig, int8_t* txPower,
-                                TimerTime_t* txTimeOnAir );
+                                lorawan_time_t* txTimeOnAir );
 
     /*!
      * \brief The function processes a Link ADR request.
@@ -290,8 +290,8 @@ public:
      * \retval The function status [1: OK, 0: Unable to find a channel on the current datarate].
      */
     virtual bool set_next_channel(NextChanParams_t* nextChanParams,
-                                   uint8_t* channel, TimerTime_t* time,
-                                   TimerTime_t* aggregatedTimeOff );
+                                   uint8_t* channel, lorawan_time_t* time,
+                                   lorawan_time_t* aggregatedTimeOff );
 
     /*!
      * \brief Adds a channel.
@@ -300,7 +300,7 @@ public:
      *
      * \retval The status of the operation.
      */
-    virtual LoRaMacStatus_t add_channel(ChannelAddParams_t* channelAdd );
+    virtual lorawan_status_t add_channel(ChannelAddParams_t* channelAdd );
 
     /*!
      * \brief Removes a channel.
@@ -333,18 +333,18 @@ public:
 
 private:
     int8_t LimitTxPower( int8_t txPower, int8_t maxBandTxPower, int8_t datarate, uint16_t* channelsMask );
-    uint8_t CountNbOfEnabledChannels( uint8_t datarate, uint16_t* channelsMask, ChannelParams_t* channels, Band_t* bands, uint8_t* enabledChannels, uint8_t* delayTx );
+    uint8_t CountNbOfEnabledChannels( uint8_t datarate, uint16_t* channelsMask, channel_params_t* channels, band_t* bands, uint8_t* enabledChannels, uint8_t* delayTx );
 
     // Global attributes
     /*!
      * LoRaMAC channels
      */
-    ChannelParams_t Channels[US915_MAX_NB_CHANNELS];
+    channel_params_t Channels[US915_MAX_NB_CHANNELS];
 
     /*!
      * LoRaMac bands
      */
-    Band_t Bands[US915_MAX_NB_BANDS];
+    band_t Bands[US915_MAX_NB_BANDS];
 
     /*!
      * LoRaMac channels mask

--- a/features/lorawan/lorastack/phy/LoRaPHYUS915Hybrid.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHYUS915Hybrid.cpp
@@ -354,7 +354,7 @@ static bool ValidateChannelsMask( uint16_t* channelsMask )
     return chanMaskState;
 }
 
-uint8_t LoRaPHYUS915Hybrid::CountNbOfEnabledChannels( uint8_t datarate, uint16_t* channelsMask, ChannelParams_t* channels, Band_t* bands, uint8_t* enabledChannels, uint8_t* delayTx )
+uint8_t LoRaPHYUS915Hybrid::CountNbOfEnabledChannels( uint8_t datarate, uint16_t* channelsMask, channel_params_t* channels, band_t* bands, uint8_t* enabledChannels, uint8_t* delayTx )
 {
     uint8_t nbEnabledChannels = 0;
     uint8_t delayTransmission = 0;
@@ -365,16 +365,16 @@ uint8_t LoRaPHYUS915Hybrid::CountNbOfEnabledChannels( uint8_t datarate, uint16_t
         {
             if( ( channelsMask[k] & ( 1 << j ) ) != 0 )
             {
-                if( channels[i + j].Frequency == 0 )
+                if( channels[i + j].frequency == 0 )
                 { // Check if the channel is enabled
                     continue;
                 }
-                if( val_in_range( datarate, channels[i + j].DrRange.Fields.Min,
-                                              channels[i + j].DrRange.Fields.Max ) == 0 )
+                if( val_in_range( datarate, channels[i + j].dr_range.fields.min,
+                                              channels[i + j].dr_range.fields.max ) == 0 )
                 { // Check if the current channel selection supports the given datarate
                     continue;
                 }
-                if( bands[channels[i + j].Band].TimeOff > 0 )
+                if( bands[channels[i + j].band].off_time > 0 )
                 { // Check if the band is available for transmission
                     delayTransmission++;
                     continue;
@@ -391,7 +391,7 @@ uint8_t LoRaPHYUS915Hybrid::CountNbOfEnabledChannels( uint8_t datarate, uint16_t
 LoRaPHYUS915Hybrid::LoRaPHYUS915Hybrid(LoRaWANTimeHandler &lora_time)
     : LoRaPHY(lora_time)
 {
-    const Band_t band0 = US915_HYBRID_BAND0;
+    const band_t band0 = US915_HYBRID_BAND0;
     Bands[0] = band0;
 }
 
@@ -544,7 +544,7 @@ PhyParam_t LoRaPHYUS915Hybrid::get_phy_params(GetPhyParams_t* getPhy)
 
 void LoRaPHYUS915Hybrid::set_band_tx_done(SetBandTxDoneParams_t* txDone)
 {
-    set_last_tx_done( txDone->Joined, &Bands[Channels[txDone->Channel].Band], txDone->LastTxDoneTime );
+    set_last_tx_done( txDone->Joined, &Bands[Channels[txDone->Channel].band], txDone->LastTxDoneTime );
 }
 
 void LoRaPHYUS915Hybrid::load_defaults(InitType_t type)
@@ -557,16 +557,16 @@ void LoRaPHYUS915Hybrid::load_defaults(InitType_t type)
             // 125 kHz channels
             for( uint8_t i = 0; i < US915_HYBRID_MAX_NB_CHANNELS - 8; i++ )
             {
-                Channels[i].Frequency = 902300000 + i * 200000;
-                Channels[i].DrRange.Value = ( DR_3 << 4 ) | DR_0;
-                Channels[i].Band = 0;
+                Channels[i].frequency = 902300000 + i * 200000;
+                Channels[i].dr_range.value = ( DR_3 << 4 ) | DR_0;
+                Channels[i].band = 0;
             }
             // 500 kHz channels
             for( uint8_t i = US915_HYBRID_MAX_NB_CHANNELS - 8; i < US915_HYBRID_MAX_NB_CHANNELS; i++ )
             {
-                Channels[i].Frequency = 903000000 + ( i - ( US915_HYBRID_MAX_NB_CHANNELS - 8 ) ) * 1600000;
-                Channels[i].DrRange.Value = ( DR_4 << 4 ) | DR_4;
-                Channels[i].Band = 0;
+                Channels[i].frequency = 903000000 + ( i - ( US915_HYBRID_MAX_NB_CHANNELS - 8 ) ) * 1600000;
+                Channels[i].dr_range.value = ( DR_4 << 4 ) | DR_4;
+                Channels[i].band = 0;
             }
 
             // ChannelsMask
@@ -747,35 +747,35 @@ bool LoRaPHYUS915Hybrid::get_next_ADR(AdrNextParams_t* adrNext, int8_t* drOut,
 }
 
 void LoRaPHYUS915Hybrid::compute_rx_win_params(int8_t datarate, uint8_t minRxSymbols,
-                                               uint32_t rxError, RxConfigParams_t *rxConfigParams)
+                                               uint32_t rxError, rx_config_params_t *rxConfigParams)
 {
     double tSymbol = 0.0;
 
     // Get the datarate, perform a boundary check
-    rxConfigParams->Datarate = MIN( datarate, US915_HYBRID_RX_MAX_DATARATE );
-    rxConfigParams->Bandwidth = GetBandwidth( rxConfigParams->Datarate );
+    rxConfigParams->datarate = MIN( datarate, US915_HYBRID_RX_MAX_DATARATE );
+    rxConfigParams->bandwidth = GetBandwidth( rxConfigParams->datarate );
 
-    tSymbol = compute_symb_timeout_lora( DataratesUS915_HYBRID[rxConfigParams->Datarate], BandwidthsUS915_HYBRID[rxConfigParams->Datarate] );
+    tSymbol = compute_symb_timeout_lora( DataratesUS915_HYBRID[rxConfigParams->datarate], BandwidthsUS915_HYBRID[rxConfigParams->datarate] );
 
-    get_rx_window_params( tSymbol, minRxSymbols, rxError, RADIO_WAKEUP_TIME, &rxConfigParams->WindowTimeout, &rxConfigParams->WindowOffset );
+    get_rx_window_params( tSymbol, minRxSymbols, rxError, RADIO_WAKEUP_TIME, &rxConfigParams->window_timeout, &rxConfigParams->window_offset );
 }
 
-bool LoRaPHYUS915Hybrid::rx_config(RxConfigParams_t* rxConfig, int8_t* datarate)
+bool LoRaPHYUS915Hybrid::rx_config(rx_config_params_t* rxConfig, int8_t* datarate)
 {
-    int8_t dr = rxConfig->Datarate;
+    int8_t dr = rxConfig->datarate;
     uint8_t maxPayload = 0;
     int8_t phyDr = 0;
-    uint32_t frequency = rxConfig->Frequency;
+    uint32_t frequency = rxConfig->frequency;
 
     if( _radio->get_status() != RF_IDLE )
     {
         return false;
     }
 
-    if( rxConfig->RxSlot == RX_SLOT_WIN_1 )
+    if( rxConfig->rx_slot == RX_SLOT_WIN_1 )
     {
         // Apply window 1 frequency
-        frequency = US915_HYBRID_FIRST_RX1_CHANNEL + ( rxConfig->Channel % 8 ) * US915_HYBRID_STEPWIDTH_RX1_CHANNEL;
+        frequency = US915_HYBRID_FIRST_RX1_CHANNEL + ( rxConfig->channel % 8 ) * US915_HYBRID_STEPWIDTH_RX1_CHANNEL;
     }
 
     // Read the physical datarate from the datarates table
@@ -784,9 +784,9 @@ bool LoRaPHYUS915Hybrid::rx_config(RxConfigParams_t* rxConfig, int8_t* datarate)
     _radio->set_channel( frequency );
 
     // Radio configuration
-    _radio->set_rx_config( MODEM_LORA, rxConfig->Bandwidth, phyDr, 1, 0, 8, rxConfig->WindowTimeout, false, 0, false, 0, 0, true, rxConfig->RxContinuous );
+    _radio->set_rx_config( MODEM_LORA, rxConfig->bandwidth, phyDr, 1, 0, 8, rxConfig->window_timeout, false, 0, false, 0, 0, true, rxConfig->is_rx_continuous );
 
-    if( rxConfig->RepeaterSupport == true )
+    if( rxConfig->is_repeater_supported == true )
     {
         maxPayload = MaxPayloadOfDatarateRepeaterUS915_HYBRID[dr];
     }
@@ -801,10 +801,10 @@ bool LoRaPHYUS915Hybrid::rx_config(RxConfigParams_t* rxConfig, int8_t* datarate)
 }
 
 bool LoRaPHYUS915Hybrid::tx_config(TxConfigParams_t* txConfig, int8_t* txPower,
-                                   TimerTime_t* txTimeOnAir)
+                                   lorawan_time_t* txTimeOnAir)
 {
     int8_t phyDr = DataratesUS915_HYBRID[txConfig->Datarate];
-    int8_t txPowerLimited = LimitTxPower( txConfig->TxPower, Bands[Channels[txConfig->Channel].Band].TxMaxPower, txConfig->Datarate, ChannelsMask );
+    int8_t txPowerLimited = LimitTxPower( txConfig->TxPower, Bands[Channels[txConfig->Channel].band].max_tx_pwr, txConfig->Datarate, ChannelsMask );
     uint32_t bandwidth = GetBandwidth( txConfig->Datarate );
     int8_t phyTxPower = 0;
 
@@ -812,7 +812,7 @@ bool LoRaPHYUS915Hybrid::tx_config(TxConfigParams_t* txConfig, int8_t* txPower,
     phyTxPower = compute_tx_power( txPowerLimited, US915_HYBRID_DEFAULT_MAX_ERP, 0 );
 
     // Setup the radio frequency
-    _radio->set_channel( Channels[txConfig->Channel].Frequency );
+    _radio->set_channel( Channels[txConfig->Channel].frequency );
 
     _radio->set_tx_config( MODEM_LORA, phyTxPower, 0, bandwidth, phyDr, 1, 8, false, true, 0, 0, false, 3000 );
 
@@ -1029,13 +1029,13 @@ void LoRaPHYUS915Hybrid::calculate_backoff(CalcBackOffParams_t* calcBackOff)
 }
 
 bool LoRaPHYUS915Hybrid::set_next_channel(NextChanParams_t* nextChanParams,
-                                          uint8_t* channel, TimerTime_t* time,
-                                          TimerTime_t* aggregatedTimeOff)
+                                          uint8_t* channel, lorawan_time_t* time,
+                                          lorawan_time_t* aggregatedTimeOff)
 {
     uint8_t nbEnabledChannels = 0;
     uint8_t delayTx = 0;
     uint8_t enabledChannels[US915_HYBRID_MAX_NB_CHANNELS] = { 0 };
-    TimerTime_t nextTxDelay = 0;
+    lorawan_time_t nextTxDelay = 0;
 
     // Count 125kHz channels
     if( num_active_channels( ChannelsMaskRemaining, 0, 4 ) == 0 )
@@ -1094,21 +1094,21 @@ bool LoRaPHYUS915Hybrid::set_next_channel(NextChanParams_t* nextChanParams,
     }
 }
 
-LoRaMacStatus_t LoRaPHYUS915Hybrid::add_channel(ChannelAddParams_t* channelAdd)
+lorawan_status_t LoRaPHYUS915Hybrid::add_channel(ChannelAddParams_t* channelAdd)
 {
-    return LORAMAC_STATUS_PARAMETER_INVALID;
+    return LORAWAN_STATUS_PARAMETER_INVALID;
 }
 
 bool LoRaPHYUS915Hybrid::remove_channel(ChannelRemoveParams_t* channelRemove)
 {
-    return LORAMAC_STATUS_PARAMETER_INVALID;
+    return LORAWAN_STATUS_PARAMETER_INVALID;
 }
 
 void LoRaPHYUS915Hybrid::set_tx_cont_mode(ContinuousWaveParams_t* continuousWave)
 {
-    int8_t txPowerLimited = LimitTxPower( continuousWave->TxPower, Bands[Channels[continuousWave->Channel].Band].TxMaxPower, continuousWave->Datarate, ChannelsMask );
+    int8_t txPowerLimited = LimitTxPower( continuousWave->TxPower, Bands[Channels[continuousWave->Channel].band].max_tx_pwr, continuousWave->Datarate, ChannelsMask );
     int8_t phyTxPower = 0;
-    uint32_t frequency = Channels[continuousWave->Channel].Frequency;
+    uint32_t frequency = Channels[continuousWave->Channel].frequency;
 
     // Calculate physical TX power
     phyTxPower = compute_tx_power( txPowerLimited, US915_HYBRID_DEFAULT_MAX_ERP, 0 );

--- a/features/lorawan/lorastack/phy/LoRaPHYUS915Hybrid.h
+++ b/features/lorawan/lorastack/phy/LoRaPHYUS915Hybrid.h
@@ -131,7 +131,7 @@ public:
      *
      * \retval True, if the configuration was applied successfully.
      */
-    virtual bool rx_config(RxConfigParams_t* rxConfig, int8_t* datarate );
+    virtual bool rx_config(rx_config_params_t* rxConfig, int8_t* datarate );
 
     /*
      * RX window precise timing
@@ -187,7 +187,7 @@ public:
     virtual void compute_rx_win_params(int8_t datarate,
                                                  uint8_t minRxSymbols,
                                                  uint32_t rxError,
-                                                 RxConfigParams_t *rxConfigParams);
+                                                 rx_config_params_t *rxConfigParams);
 
     /*!
      * \brief TX configuration.
@@ -201,7 +201,7 @@ public:
      * \retval True, if the configuration was applied successfully.
      */
     virtual bool tx_config(TxConfigParams_t* txConfig, int8_t* txPower,
-                                TimerTime_t* txTimeOnAir );
+                                lorawan_time_t* txTimeOnAir );
 
     /*!
      * \brief The function processes a Link ADR request.
@@ -291,8 +291,8 @@ public:
      * \retval The function status [1: OK, 0: Unable to find a channel on the current datarate].
      */
     virtual bool set_next_channel(NextChanParams_t* nextChanParams,
-                                   uint8_t* channel, TimerTime_t* time,
-                                   TimerTime_t* aggregatedTimeOff );
+                                   uint8_t* channel, lorawan_time_t* time,
+                                   lorawan_time_t* aggregatedTimeOff );
 
     /*!
      * \brief Adds a channel.
@@ -301,7 +301,7 @@ public:
      *
      * \retval The status of the operation.
      */
-    virtual LoRaMacStatus_t add_channel(ChannelAddParams_t* channelAdd );
+    virtual lorawan_status_t add_channel(ChannelAddParams_t* channelAdd );
 
     /*!
      * \brief Removes a channel.
@@ -334,18 +334,18 @@ public:
 
 private:
     int8_t LimitTxPower( int8_t txPower, int8_t maxBandTxPower, int8_t datarate, uint16_t* channelsMask );
-    uint8_t CountNbOfEnabledChannels( uint8_t datarate, uint16_t* channelsMask, ChannelParams_t* channels, Band_t* bands, uint8_t* enabledChannels, uint8_t* delayTx );
+    uint8_t CountNbOfEnabledChannels( uint8_t datarate, uint16_t* channelsMask, channel_params_t* channels, band_t* bands, uint8_t* enabledChannels, uint8_t* delayTx );
 
     // Global attributes
     /*!
      * LoRaMAC channels
      */
-    ChannelParams_t Channels[US915_HYBRID_MAX_NB_CHANNELS];
+    channel_params_t Channels[US915_HYBRID_MAX_NB_CHANNELS];
 
     /*!
      * LoRaMac bands
      */
-    Band_t Bands[US915_HYBRID_MAX_NB_BANDS];
+    band_t Bands[US915_HYBRID_MAX_NB_BANDS];
 
     /*!
      * LoRaMac channels mask

--- a/features/lorawan/lorastack/phy/lora_phy_ds.h
+++ b/features/lorawan/lorastack/phy/lora_phy_ds.h
@@ -713,7 +713,7 @@ typedef union uPhyParam
     /*!
      * A pointer to the channels.
      */
-    ChannelParams_t* Channels;
+    channel_params_t* Channels;
 }PhyParam_t;
 
 /*!
@@ -761,7 +761,7 @@ typedef struct sSetBandTxDoneParams
     /*!
      * The last TX done time.
      */
-    TimerTime_t LastTxDoneTime;
+    lorawan_time_t LastTxDoneTime;
 }SetBandTxDoneParams_t;
 
 /*!
@@ -955,7 +955,7 @@ typedef struct sNewChannelReqParams
     /*!
      * A pointer to the new channels.
      */
-    ChannelParams_t* NewChannel;
+    channel_params_t* NewChannel;
     /*!
      * The channel ID.
      */
@@ -1031,11 +1031,11 @@ typedef struct sCalcBackOffParams
     /*!
      * Elapsed time since the start of the node.
      */
-    TimerTime_t ElapsedTime;
+    lorawan_time_t ElapsedTime;
     /*!
      * Time-on-air of the last transmission.
      */
-    TimerTime_t TxTimeOnAir;
+    lorawan_time_t TxTimeOnAir;
 }CalcBackOffParams_t;
 
 /*!
@@ -1046,11 +1046,11 @@ typedef struct sNextChanParams
     /*!
      * The aggregated time-off time.
      */
-    TimerTime_t AggrTimeOff;
+    lorawan_time_t AggrTimeOff;
     /*!
      * The time of the last aggregated TX.
      */
-    TimerTime_t LastAggrTx;
+    lorawan_time_t LastAggrTx;
     /*!
      * The current datarate.
      */
@@ -1073,7 +1073,7 @@ typedef struct sChannelAddParams
     /*!
      * A pointer to the new channel to add.
      */
-    ChannelParams_t* NewChannel;
+    channel_params_t* NewChannel;
     /*!
      * The channel ID to add.
      */

--- a/features/lorawan/system/LoRaWANTimer.cpp
+++ b/features/lorawan/system/LoRaWANTimer.cpp
@@ -34,34 +34,34 @@ void LoRaWANTimeHandler::TimerTimeCounterInit(events::EventQueue *queue)
     _queue = queue;
 }
 
-TimerTime_t LoRaWANTimeHandler::TimerGetCurrentTime( void )
+lorawan_time_t LoRaWANTimeHandler::TimerGetCurrentTime( void )
 {
     const uint32_t current_time = _queue->tick();
-    return (TimerTime_t)current_time;
+    return (lorawan_time_t)current_time;
 }
 
-TimerTime_t LoRaWANTimeHandler::TimerGetElapsedTime( TimerTime_t savedTime )
+lorawan_time_t LoRaWANTimeHandler::TimerGetElapsedTime( lorawan_time_t savedTime )
 {
     return TimerGetCurrentTime() - savedTime;
 }
 
-void LoRaWANTimeHandler::TimerInit( TimerEvent_t *obj, mbed::Callback<void()> callback)
+void LoRaWANTimeHandler::TimerInit( timer_event_t *obj, mbed::Callback<void()> callback)
 {
     obj->value = 0;
-    obj->Callback = callback;
+    obj->callback = callback;
 }
 
-void LoRaWANTimeHandler::TimerStart( TimerEvent_t *obj )
+void LoRaWANTimeHandler::TimerStart( timer_event_t *obj )
 {
-    obj->Timer.get()->attach_us(obj->Callback, obj->value * 1000 );
+    obj->timer.get()->attach_us(obj->callback, obj->value * 1000 );
 }
 
-void LoRaWANTimeHandler::TimerStop( TimerEvent_t *obj )
+void LoRaWANTimeHandler::TimerStop( timer_event_t *obj )
 {
-    obj->Timer.get()->detach( );
+    obj->timer.get()->detach( );
 }
 
-void LoRaWANTimeHandler::TimerSetValue( TimerEvent_t *obj, uint32_t value )
+void LoRaWANTimeHandler::TimerSetValue( timer_event_t *obj, uint32_t value )
 {
     obj->value = value;
 }

--- a/features/lorawan/system/LoRaWANTimer.h
+++ b/features/lorawan/system/LoRaWANTimer.h
@@ -49,14 +49,14 @@ public:
     * \param [in] obj          The structure containing the timer object parameters.
     * \param [in] callback     The function callback called at the end of the timeout.
     */
-    void TimerInit( TimerEvent_t *obj, mbed::Callback<void()> callback);
+    void TimerInit( timer_event_t *obj, mbed::Callback<void()> callback);
 
     /*!
      * \brief Read the current time.
      *
      * \retval time The current time.
      */
-    TimerTime_t TimerGetCurrentTime( void );
+    lorawan_time_t TimerGetCurrentTime( void );
 
     /*!
      * \brief Return the time elapsed since a fixed moment in time.
@@ -64,7 +64,7 @@ public:
      * \param [in] savedTime    The fixed moment in time.
      * \retval time             The elapsed time.
      */
-    TimerTime_t TimerGetElapsedTime( TimerTime_t savedTime );
+    lorawan_time_t TimerGetElapsedTime( lorawan_time_t savedTime );
 
   
 
@@ -73,14 +73,14 @@ public:
      *
      * \param [in] obj The structure containing the timer object parameters.
      */
-    void TimerStart( TimerEvent_t *obj );
+    void TimerStart( timer_event_t *obj );
 
     /*!
      * \brief Stops and removes the timer object from the list of timer events.
      *
      * \param [in] obj The structure containing the timer object parameters.
      */
-    void TimerStop( TimerEvent_t *obj );
+    void TimerStop( timer_event_t *obj );
 
     /*!
      * \brief Set a new timeout value.
@@ -88,7 +88,7 @@ public:
      * \param [in] obj   The structure containing the timer object parameters.
      * \param [in] value The new timeout value.
      */
-    void TimerSetValue( TimerEvent_t *obj, uint32_t value );
+    void TimerSetValue( timer_event_t *obj, uint32_t value );
 
 private:
     events::EventQueue *_queue;

--- a/features/lorawan/system/lorawan_data_structures.h
+++ b/features/lorawan/system/lorawan_data_structures.h
@@ -31,8 +31,8 @@
 /*!
  * \brief Timer time variable definition
  */
-#ifndef TimerTime_t
-typedef uint32_t TimerTime_t;
+#ifndef lorawan_time_t
+typedef uint32_t lorawan_time_t;
 #endif
 
 // Radio wake-up time from sleep - unit ms.
@@ -93,7 +93,7 @@ typedef uint32_t TimerTime_t;
 /**
  * Maximum PHY layer payload size for reception.
  */
-#define LORAMAC_PHY_MAXPAYLOAD                        255
+#define LORAMAC_PHY_MAXPAYLOAD                      255
 
 /**
  *
@@ -102,6 +102,7 @@ typedef uint32_t TimerTime_t;
 // reject if user tries to set more than MTU
 #if MBED_CONF_LORA_TX_MAX_SIZE > 255
     #warning "Cannot set TX Max size more than MTU=255"
+    #define MBED_CONF_LORA_TX_MAX_SIZE              255
 #endif
 
 /*!
@@ -109,8 +110,7 @@ typedef uint32_t TimerTime_t;
  *
  * LoRaWAN Specification V1.0.2, chapter 2.1.
  */
-typedef enum eDeviceClass
-{
+typedef enum {
     /*!
      * LoRaWAN device class A.
      *
@@ -129,17 +129,16 @@ typedef enum eDeviceClass
      * LoRaWAN Specification V1.0.2, chapter 17.
      */
     CLASS_C,
-}DeviceClass_t;
+} device_class_t;
 
 /*!
  * LoRaMAC channel parameters definition.
  */
-typedef union uDrRange
-{
+typedef union {
     /*!
      * Byte-access to the bits.
      */
-    int8_t Value;
+    int8_t value;
     /*!
      * The structure to store the minimum and the maximum datarate.
      */
@@ -152,7 +151,7 @@ typedef union uDrRange
          *
          * The allowed ranges are region-specific. Please refer to \ref DR_0 to \ref DR_15 for details.
          */
-        int8_t Min : 4;
+        int8_t min : 4;
         /*!
          * The maximum data rate.
          *
@@ -160,70 +159,66 @@ typedef union uDrRange
          *
          * The allowed ranges are region-specific. Please refer to \ref DR_0 to \ref DR_15 for details.
          */
-        int8_t Max : 4;
-    }Fields;
-}DrRange_t;
+        int8_t max : 4;
+    } fields;
+} dr_range_t;
 
 /*!
  * LoRaMAC channel definition.
  */
-typedef struct sChannelParams
-{
+typedef struct {
     /*!
      * The frequency in Hz.
      */
-    uint32_t Frequency;
+    uint32_t frequency;
     /*!
      * The alternative frequency for RX window 1.
      */
-    uint32_t Rx1Frequency;
+    uint32_t rx1_frequency;
     /*!
      * The data rate definition.
      */
-    DrRange_t DrRange;
+    dr_range_t dr_range;
     /*!
      * The band index.
      */
-    uint8_t Band;
-}ChannelParams_t;
+    uint8_t band;
+} channel_params_t;
 
 /*!
  * LoRaMAC band parameters definition.
  */
-typedef struct sBand
-{
+typedef struct {
     /*!
      * The duty cycle.
      */
-    uint16_t DCycle;
+    uint16_t duty_cycle;
     /*!
      * The maximum TX power.
      */
-    int8_t TxMaxPower;
+    int8_t max_tx_pwr;
     /*!
-     * The timestamp of the last JoinReq TX frame.
+     * The timestamp of the last Join Request TX frame.
      */
-    TimerTime_t LastJoinTxDoneTime;
+    lorawan_time_t last_join_tx_time;
     /*!
      * The timestamp of the last TX frame.
      */
-    TimerTime_t LastTxDoneTime;
+    lorawan_time_t last_tx_time;
     /*!
      * The device off time.
      */
-    TimerTime_t TimeOff;
-}Band_t;
-
+    lorawan_time_t off_time;
+} band_t;
 
 /*!
  * LoRaMAC receive window 2 channel parameters.
  */
-typedef struct sRx2ChannelParams
-{
+typedef struct {
     /*!
      * The frequency in Hz.
      */
-    uint32_t Frequency;
+    uint32_t frequency;
     /*!
      * The data rate.
      *
@@ -231,14 +226,13 @@ typedef struct sRx2ChannelParams
      *
      * The allowed ranges are region-specific. Please refer to \ref DR_0 to \ref DR_15 for details.
      */
-    uint8_t  Datarate;
-}Rx2ChannelParams_t;
+    uint8_t  datarate;
+} rx2_channel_params;
 
 /*!
  * LoRaMAC receive window enumeration
  */
-typedef enum eLoRaMacRxSlot
-{
+typedef enum {
     /*!
      * LoRaMAC receive window 1
      */
@@ -255,131 +249,128 @@ typedef enum eLoRaMacRxSlot
      * LoRaMAC class b ping slot window
      */
     RX_SLOT_WIN_PING_SLOT
-}LoRaMacRxSlot_t;
+} rx_slot_t;
 
 /*!
  * The global MAC layer parameters.
  */
-typedef struct sLoRaMacParams
-{
+typedef struct {
     /*!
      * The TX power in channels.
      */
-    int8_t ChannelsTxPower;
+    int8_t channel_tx_power;
     /*!
      * The data rate in channels.
      */
-    int8_t ChannelsDatarate;
+    int8_t channel_data_rate;
     /*!
      * The system overall timing error in milliseconds.
      * [-SystemMaxRxError : +SystemMaxRxError]
      * Default: +/-10 ms
      */
-    uint32_t SystemMaxRxError;
+    uint32_t max_sys_rx_error;
     /*!
      * The minimum number of symbols required to detect an RX frame.
      * Default: 6 symbols
      */
-    uint8_t MinRxSymbols;
+    uint8_t min_rx_symb;
     /*!
      * LoRaMac maximum time a reception window stays open.
      */
-    uint32_t MaxRxWindow;
+    uint32_t max_rx_win_time;
     /*!
      * Receive delay 1.
      */
-    uint32_t ReceiveDelay1;
+    uint32_t recv_delay1;
     /*!
      * Receive delay 2.
      */
-    uint32_t ReceiveDelay2;
+    uint32_t recv_delay2;
     /*!
      * Join accept delay 1.
      */
-    uint32_t JoinAcceptDelay1;
+    uint32_t join_accept_delay1;
     /*!
      * Join accept delay 1.
      */
-    uint32_t JoinAcceptDelay2;
+    uint32_t join_accept_delay2;
     /*!
-     * The number of uplink messages repetitions [1:15] (unconfirmed messages only).
+     * The number of uplink messages repetitions (confirmed messages only).
      */
-    uint8_t ChannelsNbRep;
+    uint8_t retry_num;
     /*!
      * The datarate offset between uplink and downlink on first window.
      */
-    uint8_t Rx1DrOffset;
+    uint8_t rx1_dr_offset;
     /*!
      * LoRaMAC 2nd reception window settings.
      */
-    Rx2ChannelParams_t Rx2Channel;
+    rx2_channel_params rx2_channel;
     /*!
      * The uplink dwell time configuration. 0: No limit, 1: 400ms
      */
-    uint8_t UplinkDwellTime;
+    uint8_t uplink_dwell_time;
     /*!
      * The downlink dwell time configuration. 0: No limit, 1: 400ms
      */
-    uint8_t DownlinkDwellTime;
+    uint8_t downlink_dwell_time;
     /*!
      * The maximum possible EIRP.
      */
-    float MaxEirp;
+    float max_eirp;
     /*!
      * The antenna gain of the node.
      */
-    float AntennaGain;
+    float antenna_gain;
 
     /*!
      * Maximum duty cycle
      * \remark Possibility to shutdown the device.
      */
-    uint8_t MaxDCycle;
+    uint8_t max_duty_cycle;
     /*!
      * Aggregated duty cycle management
      */
-    uint16_t AggregatedDCycle;
+    uint16_t aggregated_duty_cycle;
 
     /*!
      * LoRaMac ADR control status
      */
-    bool AdrCtrlOn;
+    bool adr_on;
 } lora_mac_system_params_t;
 
 /*!
  * LoRaMAC multicast channel parameter.
  */
-typedef struct sMulticastParams
-{
+typedef struct multicast_params_s {
     /*!
      * Address.
      */
-    uint32_t Address;
+    uint32_t address;
     /*!
      * Network session key.
      */
-    uint8_t NwkSKey[16];
+    uint8_t nwk_skey[16];
     /*!
      * Application session key.
      */
-    uint8_t AppSKey[16];
+    uint8_t app_skey[16];
     /*!
      * Downlink counter.
      */
-    uint32_t DownLinkCounter;
+    uint32_t dl_frame_counter;
     /*!
      * A reference pointer to the next multicast channel parameters in the list.
      */
-    struct sMulticastParams *Next;
-}MulticastParams_t;
+    struct multicast_params_s *Next;
+} multicast_params_t;
 
 /*!
  * LoRaMAC frame types.
  *
  * LoRaWAN Specification V1.0.2, chapter 4.2.1, table 1.
  */
-typedef enum eLoRaMacFrameType
-{
+typedef enum {
     /*!
      * LoRaMAC join request frame.
      */
@@ -412,15 +403,14 @@ typedef enum eLoRaMacFrameType
      * LoRaMAC proprietary frame.
      */
     FRAME_TYPE_PROPRIETARY           = 0x07,
-}LoRaMacFrameType_t;
+} mac_frame_type_t;
 
 /*!
  * LoRaMAC mote MAC commands.
  *
  * LoRaWAN Specification V1.0.2, chapter 5, table 4.
  */
-typedef enum eLoRaMacMoteCmd
-{
+typedef enum {
     /*!
      * LinkCheckReq
      */
@@ -457,15 +447,14 @@ typedef enum eLoRaMacMoteCmd
      * DlChannelAns
      */
     MOTE_MAC_DL_CHANNEL_ANS          = 0x0A
-}LoRaMacMoteCmd_t;
+} mote_mac_cmds_t;
 
 /*!
  * LoRaMAC server MAC commands.
  *
  * LoRaWAN Specification V1.0.2 chapter 5, table 4.
  */
-typedef enum eLoRaMacSrvCmd
-{
+typedef enum {
     /*!
      * LinkCheckAns
      */
@@ -502,13 +491,12 @@ typedef enum eLoRaMacSrvCmd
      * DlChannelReq
      */
     SRV_MAC_DL_CHANNEL_REQ           = 0x0A,
-}LoRaMacSrvCmd_t;
+} server_mac_cmds_t;
 
 /*!
  * LoRaMAC battery level indicator.
  */
-typedef enum eLoRaMacBatteryLevel
-{
+typedef enum {
     /*!
      * An external power source.
      */
@@ -525,28 +513,27 @@ typedef enum eLoRaMacBatteryLevel
      * Battery level - no measurement available.
      */
     BAT_LEVEL_NO_MEASURE             = 0xFF,
-}LoRaMacBatteryLevel_t;
+} device_battery_level_t;
 
 /*!
  * LoRaMAC header field definition (MHDR field).
  *
  * LoRaWAN Specification V1.0.2, chapter 4.2.
  */
-typedef union uLoRaMacHeader
-{
+typedef union {
     /*!
      * Byte-access to the bits.
      */
-    uint8_t Value;
+    uint8_t value;
     /*!
      * The structure containing single access to header bits.
      */
-    struct sHdrBits
+    struct hdr_bits_s
     {
         /*!
          * Major version.
          */
-        uint8_t Major           : 2;
+        uint8_t major           : 2;
         /*!
          * RFU
          */
@@ -554,54 +541,52 @@ typedef union uLoRaMacHeader
         /*!
          * Message type
          */
-        uint8_t MType           : 3;
-    }Bits;
-}LoRaMacHeader_t;
+        uint8_t mtype           : 3;
+    } bits;
+} loramac_mhdr_t;
 
 /*!
  * LoRaMAC frame control field definition (FCtrl).
  *
  * LoRaWAN Specification V1.0.2, chapter 4.3.1.
  */
-typedef union uLoRaMacFrameCtrl
-{
+typedef union {
     /*!
      * Byte-access to the bits.
      */
-    uint8_t Value;
+    uint8_t value;
     /*!
      * The structure containing single access to bits.
      */
-    struct sCtrlBits
+    struct ctrl_bits_s
     {
         /*!
          * Frame options length.
          */
-        uint8_t FOptsLen        : 4;
+        uint8_t fopts_len        : 4;
         /*!
          * Frame pending bit.
          */
-        uint8_t FPending        : 1;
+        uint8_t fpending        : 1;
         /*!
          * Message acknowledge bit.
          */
-        uint8_t Ack             : 1;
+        uint8_t ack             : 1;
         /*!
          * ADR acknowledgment request bit.
          */
-        uint8_t AdrAckReq       : 1;
+        uint8_t adr_ack_req       : 1;
         /*!
          * ADR control in the frame header.
          */
-        uint8_t Adr             : 1;
-    }Bits;
-}LoRaMacFrameCtrl_t;
+        uint8_t adr             : 1;
+    } bits;
+} loramac_frame_ctrl_t;
 
 /*!
  * The enumeration containing the status of the operation of a MAC service.
  */
-typedef enum eLoRaMacEventInfoStatus
-{
+typedef enum {
     /*!
      * Service performed successfully.
      */
@@ -661,48 +646,47 @@ typedef enum eLoRaMacEventInfoStatus
      * Crypto methods failure
      */
     LORAMAC_EVENT_INFO_STATUS_CRYPTO_FAIL,
-}LoRaMacEventInfoStatus_t;
+} loramac_event_info_status_t;
 
 /*!
- * LoRaMac TX/RX operation state.
+ * LoRaMac service state flags.
  */
-typedef union eLoRaMacFlags_t
-{
+typedef union {
     /*!
      * Byte-access to the bits.
      */
-    uint8_t Value;
+    uint8_t value;
     /*!
      * The structure containing single access to bits.
      */
-    struct sMacFlagBits
+    struct mac_flag_bits_s
     {
         /*!
          * MCPS-Req pending
          */
-        uint8_t McpsReq         : 1;
+        uint8_t mcps_req         : 1;
         /*!
          * MCPS-Ind pending
          */
-        uint8_t McpsInd         : 1;
+        uint8_t mcps_ind         : 1;
         /*!
          * MCPS-Ind pending. Skip indication to the application layer.
          */
-        uint8_t McpsIndSkip     : 1;
+        uint8_t mcps_ind_skip     : 1;
         /*!
          * MLME-Req pending
          */
-        uint8_t MlmeReq         : 1;
+        uint8_t mlme_req         : 1;
         /*!
          * MLME-Ind pending
          */
-        uint8_t MlmeInd         : 1;
+        uint8_t mlme_ind         : 1;
         /*!
          * MAC cycle done
          */
-        uint8_t MacDone         : 1;
-    }Bits;
-}LoRaMacFlags_t;
+        uint8_t mac_done         : 1;
+    } bits;
+} loramac_flags_t;
 
 /*!
  *
@@ -727,8 +711,7 @@ typedef union eLoRaMacFlags_t
  * MCPS-Confirm     | MacMcpsConfirm in \ref LoRaMacPrimitives_t
  * MCPS-Indication  | MacMcpsIndication in \ref LoRaMacPrimitives_t
  */
-typedef enum eMcps
-{
+typedef enum {
     /*!
      * Unconfirmed LoRaMAC frame.
      */
@@ -745,58 +728,42 @@ typedef enum eMcps
      * Proprietary frame.
      */
     MCPS_PROPRIETARY,
-}Mcps_t;
+} mcps_type_t;
 
 /*!
  * LoRaMAC MCPS-Request for an unconfirmed frame.
  */
-typedef struct sMcpsReqUnconfirmed
-{
+typedef struct {
     /*!
      * Frame port field. Must be set if the payload is not empty. Use the
      * application-specific frame port values: [1...223].
      *
      * LoRaWAN Specification V1.0.2, chapter 4.3.2.
      */
-    uint8_t fPort;
-    /*!
-     * A pointer to the buffer of the frame payload.
-     */
-    void *fBuffer;
-    /*!
-     * The size of the frame payload.
-     */
-    uint16_t fBufferSize;
+    uint8_t fport;
+
     /*!
      * Uplink datarate, if ADR is off.
      */
-    int8_t Datarate;
-}McpsReqUnconfirmed_t;
+    int8_t data_rate;
+} mcps_req_unconfirmed_t;
 
 /*!
  * LoRaMAC MCPS-Request for a confirmed frame.
  */
-typedef struct sMcpsReqConfirmed
-{
+typedef struct {
     /*!
      * Frame port field. Must be set if the payload is not empty. Use the
      * application-specific frame port values: [1...223].
      *
      * LoRaWAN Specification V1.0.2, chapter 4.3.2.
      */
-    uint8_t fPort;
-    /*!
-     * A pointer to the buffer of the frame payload.
-     */
-    void *fBuffer;
-    /*!
-     * The size of the frame payload.
-     */
-    uint16_t fBufferSize;
+    uint8_t fport;
+
     /*!
      * Uplink datarate, if ADR is off.
      */
-    int8_t Datarate;
+    int8_t data_rate;
     /*!
      * The number of trials to transmit the frame, if the LoRaMAC layer did not
      * receive an acknowledgment. The MAC performs a datarate adaptation
@@ -814,168 +781,169 @@ typedef struct sMcpsReqConfirmed
      * 7               | max(DR-3,0)
      * 8               | max(DR-3,0)
      *
-     * Note that if NbTrials is set to 1 or 2, the MAC will not decrease
+     * Note that if nb_trials is set to 1 or 2, the MAC will not decrease
      * the datarate, if the LoRaMAC layer did not receive an acknowledgment.
      */
-    uint8_t NbTrials;
-}McpsReqConfirmed_t;
+    uint8_t nb_trials;
+} mcps_req_confirmed_t;
 
 /*!
  * LoRaMAC MCPS-Request for a proprietary frame.
  */
-typedef struct sMcpsReqProprietary
-{
-    /*!
-     * A pointer to the buffer of the frame payload.
-     */
-    void *fBuffer;
-    /*!
-     * The size of the frame payload.
-     */
-    uint16_t fBufferSize;
+typedef struct {
     /*!
      * Uplink datarate, if ADR is off.
      */
-    int8_t Datarate;
-}McpsReqProprietary_t;
+    int8_t data_rate;
+} mcps_req_proprietary_t;
 
 /*!
  * LoRaMAC MCPS-Request structure.
  */
-typedef struct sMcpsReq
-{
+typedef struct {
     /*!
      * MCPS-Request type.
      */
-    Mcps_t Type;
+    mcps_type_t type;
 
     /*!
      * MCPS-Request parameters.
      */
-    union uMcpsParam
+    union
     {
         /*!
          * MCPS-Request parameters for an unconfirmed frame.
          */
-        McpsReqUnconfirmed_t Unconfirmed;
+        mcps_req_unconfirmed_t unconfirmed;
         /*!
          * MCPS-Request parameters for a confirmed frame.
          */
-        McpsReqConfirmed_t Confirmed;
+        mcps_req_confirmed_t confirmed;
         /*!
          * MCPS-Request parameters for a proprietary frame.
          */
-        McpsReqProprietary_t Proprietary;
-    }Req;
-}McpsReq_t;
+        mcps_req_proprietary_t proprietary;
+    } req;
+
+    /** Payload data
+      *
+      * A pointer to the buffer of the frame payload.
+      */
+     void *f_buffer;
+     /** Payload size
+      *
+      * The size of the frame payload.
+      */
+     uint16_t f_buffer_size;
+
+} loramac_mcps_req_t;
 
 /*!
  * LoRaMAC MCPS-Confirm.
  */
-typedef struct sMcpsConfirm
-{
+typedef struct {
     /*!
-     * Holds the previously performed MCPS-Request.
+     * Holds the previously performed MCPS-Request type. i.e., the type of
+     * the MCPS request for which this confirmation is being generated
      */
-    Mcps_t McpsRequest;
+    mcps_type_t req_type;
     /*!
      * The status of the operation.
      */
-    LoRaMacEventInfoStatus_t Status;
+    loramac_event_info_status_t status;
     /*!
      * The uplink datarate.
      */
-    uint8_t Datarate;
+    uint8_t data_rate;
     /*!
      * The transmission power.
      */
-    int8_t TxPower;
+    int8_t tx_power;
     /*!
      * Set if an acknowledgement was received.
      */
-    bool AckReceived;
+    bool ack_received;
     /*!
      * Provides the number of retransmissions.
      */
-    uint8_t NbRetries;
+    uint8_t nb_retries;
     /*!
      * The transmission time on air of the frame.
      */
-    TimerTime_t TxTimeOnAir;
+    lorawan_time_t tx_toa;
     /*!
      * The uplink counter value related to the frame.
      */
-    uint32_t UpLinkCounter;
+    uint32_t ul_frame_counter;
     /*!
      * The uplink frequency related to the frame.
      */
-    uint32_t UpLinkFrequency;
-}McpsConfirm_t;
+    uint32_t ul_frequency;
+} loramac_mcps_confirm_t;
 
 /*!
  * LoRaMAC MCPS-Indication primitive.
  */
-typedef struct sMcpsIndication
-{
+typedef struct {
     /*!
      * MCPS-Indication type.
      */
-    Mcps_t McpsIndication;
+    mcps_type_t type;
     /*!
      * The status of the operation.
      */
-    LoRaMacEventInfoStatus_t Status;
+    loramac_event_info_status_t status;
     /*!
      * Multicast.
      */
-    uint8_t Multicast;
+    uint8_t multicast;
     /*!
      * The application port.
      */
-    uint8_t Port;
+    uint8_t port;
     /*!
      * The downlink datarate.
      */
-    uint8_t RxDatarate;
+    uint8_t rx_datarate;
     /*!
      * Frame pending status.
      */
-    uint8_t FramePending;
+    uint8_t fpending_status;
     /*!
      * A pointer to the received data stream.
      */
-    uint8_t *Buffer;
+    uint8_t *buffer;
     /*!
      * The size of the received data stream.
      */
-    uint8_t BufferSize;
+    uint16_t buffer_size;
     /*!
      * Indicates, if data is available.
      */
-    bool RxData;
+    bool is_data_recvd;
     /*!
      * The RSSI of the received packet.
      */
-    int16_t Rssi;
+    int16_t rssi;
     /*!
      * The SNR of the received packet.
      */
-    uint8_t Snr;
+    uint8_t snr;
     /*!
      * The receive window.
      *
      * [0: Rx window 1, 1: Rx window 2]
      */
-    LoRaMacRxSlot_t RxSlot;
+    rx_slot_t rx_slot;
     /*!
      * Set if an acknowledgement was received.
      */
-    bool AckReceived;
+    bool is_ack_recvd;
     /*!
      * The downlink counter value for the received frame.
      */
-    uint32_t DownLinkCounter;
-}McpsIndication_t;
+    uint32_t dl_frame_counter;
+} loramac_mcps_indication_t;
 
 /*!
  * \brief LoRaMAC management services.
@@ -999,8 +967,7 @@ typedef struct sMcpsIndication
  * MLME-Confirm     | MacMlmeConfirm in \ref LoRaMacPrimitives_t
  * MLME-Indication  | MacMlmeIndication in \ref LoRaMacPrimitives_t
  */
-typedef enum eMlme
-{
+typedef enum {
     /*!
      * Initiates the Over-the-Air activation.
      *
@@ -1030,124 +997,119 @@ typedef enum eMlme
      * soon as possible.
      */
     MLME_SCHEDULE_UPLINK
-}Mlme_t;
+} mlme_type_t;
 
 /*!
  * LoRaMAC MLME-Request for the join service.
  */
-typedef struct sMlmeReqJoin
-{
+typedef struct {
     /*!
      * A globally unique end-device identifier.
      *
      * LoRaWAN Specification V1.0.2, chapter 6.2.1.
      */
-    uint8_t *DevEui;
+    uint8_t *dev_eui;
     /*!
      * An application identifier.
      *
      * LoRaWAN Specification V1.0.2, chapter 6.1.2
      */
-    uint8_t *AppEui;
+    uint8_t *app_eui;
     /*!
      * AES-128 application key.
      *
      * LoRaWAN Specification V1.0.2, chapter 6.2.2.
      */
-    uint8_t *AppKey;
+    uint8_t *app_key;
     /*!
      * The number of trials for the join request.
      */
-    uint8_t NbTrials;
-}MlmeReqJoin_t;
+    uint8_t nb_trials;
+} mlme_join_req_t;
 
 /*!
  * LoRaMAC MLME-Request for TX continuous wave mode.
  */
-typedef struct sMlmeReqTxCw
-{
+typedef struct {
     /*!
      * The time while the radio is kept in continuous wave mode, in seconds.
      */
-    uint16_t Timeout;
+    uint16_t timeout;
     /*!
      * The RF frequency to set (only used with the new way).
      */
-    uint32_t Frequency;
+    uint32_t frequency;
     /*!
      * The RF output power to set (only used with the new way).
      */
-    uint8_t Power;
-}MlmeReqTxCw_t;
+    uint8_t power;
+} mlme_cw_tx_mode_t;
 
 /*!
  * LoRaMAC MLME-Request structure.
  */
-typedef struct sMlmeReq
-{
+typedef struct {
     /*!
      * MLME-Request type.
      */
-    Mlme_t Type;
+    mlme_type_t type;
 
     /*!
      * MLME-Request parameters.
      */
-    union uMlmeParam
-    {
+    union {
         /*!
          * MLME-Request parameters for a join request.
          */
-        MlmeReqJoin_t Join;
+        mlme_join_req_t join;
         /*!
          * MLME-Request parameters for TX continuous mode request.
          */
-        MlmeReqTxCw_t TxCw;
-    }Req;
-}MlmeReq_t;
+        mlme_cw_tx_mode_t cw_tx_mode;
+    } req;
+} loramac_mlme_req_t;
 
 /*!
  * LoRaMAC MLME-Confirm primitive.
  */
-typedef struct sMlmeConfirm
-{
+typedef struct {
     /*!
-     * The previously performed MLME-Request.
+     * The previously performed MLME-Request. i.e., the request type
+     * for which the confirmation is being generated
      */
-    Mlme_t MlmeRequest;
+    mlme_type_t req_type;
     /*!
      * The status of the operation.
      */
-    LoRaMacEventInfoStatus_t Status;
+    loramac_event_info_status_t status;
     /*!
      * The transmission time on air of the frame.
      */
-    TimerTime_t TxTimeOnAir;
+    lorawan_time_t tx_toa;
     /*!
      * The demodulation margin. Contains the link margin [dB] of the last LinkCheckReq
      * successfully received.
      */
-    uint8_t DemodMargin;
+    uint8_t demod_margin;
     /*!
      * The number of gateways which received the last LinkCheckReq.
      */
-    uint8_t NbGateways;
+    uint8_t nb_gateways;
     /*!
      * The number of retransmissions.
      */
-    uint8_t NbRetries;
-}MlmeConfirm_t;
+    uint8_t nb_retries;
+} loramac_mlme_confirm_t;
 
 /*!
  * LoRaMAC MLME-Indication primitive
  */
-typedef struct sMlmeIndication
-{
+typedef struct {
     /*!
      * MLME-Indication type
      */
-    Mlme_t MlmeIndication;
-}MlmeIndication_t;
+    mlme_type_t indication_type;
+} loramac_mlme_indication_t;
 
 /*!
  * LoRa MAC Information Base (MIB).
@@ -1194,8 +1156,7 @@ typedef struct sMlmeIndication
  * MIB-Set          | \ref LoRaMacMibSetRequestConfirm
  * MIB-Get          | \ref LoRaMacMibGetRequestConfirm
  */
-typedef enum eMib
-{
+typedef enum {
     /*!
      * LoRaWAN device class.
      *
@@ -1392,333 +1353,283 @@ typedef enum eMib
      * radioTxPower = ( int8_t )floor( maxEirp - antennaGain )
      */
     MIB_ANTENNA_GAIN
-}Mib_t;
+} mib_type_t;
 
 /*!
  * LoRaMAC MIB parameters.
  */
-typedef union uMibParam
-{
+typedef union {
     /*!
      * LoRaWAN device class.
      *
      * Related MIB type: \ref MIB_DEVICE_CLASS
      */
-    DeviceClass_t Class;
+    device_class_t dev_class;
     /*!
      * LoRaWAN network joined attribute
      *
      * Related MIB type: \ref MIB_NETWORK_JOINED
      */
-    bool IsNetworkJoined;
+    bool is_nwk_joined;
     /*!
      * Activation state of ADR
      *
      * Related MIB type: \ref MIB_ADR
      */
-    bool AdrEnable;
+    bool is_adr_enable;
     /*!
      * Network identifier
      *
      * Related MIB type: \ref MIB_NET_ID
      */
-    uint32_t NetID;
+    uint32_t net_id;
     /*!
      * End-device address
      *
      * Related MIB type: \ref MIB_DEV_ADDR
      */
-    uint32_t DevAddr;
+    uint32_t dev_addr;
     /*!
      * Network session key
      *
      * Related MIB type: \ref MIB_NWK_SKEY
      */
-    uint8_t *NwkSKey;
+    uint8_t *nwk_skey;
     /*!
      * Application session key
      *
      * Related MIB type: \ref MIB_APP_SKEY
      */
-    uint8_t *AppSKey;
+    uint8_t *app_skey;
     /*!
      * Enable or disable a public network
      *
      * Related MIB type: \ref MIB_PUBLIC_NETWORK
      */
-    bool EnablePublicNetwork;
+    bool enable_public_nwk;
     /*!
      * Enable or disable repeater support
      *
      * Related MIB type: \ref MIB_REPEATER_SUPPORT
      */
-    bool EnableRepeaterSupport;
+    bool enable_repeater_support;
     /*!
      * LoRaWAN channel
      *
      * Related MIB type: \ref MIB_CHANNELS
      */
-    ChannelParams_t* ChannelList;
+    channel_params_t* channel_list;
      /*!
      * Channel for the receive window 2
      *
      * Related MIB type: \ref MIB_RX2_CHANNEL
      */
-    Rx2ChannelParams_t Rx2Channel;
+    rx2_channel_params rx2_channel;
      /*!
      * Channel for the receive window 2
      *
      * Related MIB type: \ref MIB_RX2_DEFAULT_CHANNEL
      */
-    Rx2ChannelParams_t Rx2DefaultChannel;
+    rx2_channel_params default_rx2_channel;
     /*!
      * Channel mask
      *
      * Related MIB type: \ref MIB_CHANNELS_MASK
      */
-    uint16_t* ChannelsMask;
+    uint16_t* channel_mask;
     /*!
      * Default channel mask
      *
      * Related MIB type: \ref MIB_CHANNELS_DEFAULT_MASK
      */
-    uint16_t* ChannelsDefaultMask;
+    uint16_t* default_channel_mask;
     /*!
      * Number of frame repetitions
      *
      * Related MIB type: \ref MIB_CHANNELS_NB_REP
      */
-    uint8_t ChannelNbRep;
+    uint8_t channel_nb_rep;
     /*!
      * Maximum receive window duration
      *
      * Related MIB type: \ref MIB_MAX_RX_WINDOW_DURATION
      */
-    uint32_t MaxRxWindow;
+    uint32_t max_rx_window;
     /*!
      * Receive delay 1
      *
      * Related MIB type: \ref MIB_RECEIVE_DELAY_1
      */
-    uint32_t ReceiveDelay1;
+    uint32_t recv_delay1;
     /*!
      * Receive delay 2
      *
      * Related MIB type: \ref MIB_RECEIVE_DELAY_2
      */
-    uint32_t ReceiveDelay2;
+    uint32_t recv_delay2;
     /*!
      * Join accept delay 1
      *
      * Related MIB type: \ref MIB_JOIN_ACCEPT_DELAY_1
      */
-    uint32_t JoinAcceptDelay1;
+    uint32_t join_accept_delay1;
     /*!
      * Join accept delay 2
      *
      * Related MIB type: \ref MIB_JOIN_ACCEPT_DELAY_2
      */
-    uint32_t JoinAcceptDelay2;
+    uint32_t join_accept_delay2;
     /*!
      * Channels data rate
      *
      * Related MIB type: \ref MIB_CHANNELS_DEFAULT_DATARATE
      */
-    int8_t ChannelsDefaultDatarate;
+    int8_t default_channel_data_rate;
     /*!
      * Channels data rate
      *
      * Related MIB type: \ref MIB_CHANNELS_DATARATE
      */
-    int8_t ChannelsDatarate;
+    int8_t channel_data_rate;
     /*!
      * Channels TX power
      *
      * Related MIB type: \ref MIB_CHANNELS_DEFAULT_TX_POWER
      */
-    int8_t ChannelsDefaultTxPower;
+    int8_t default_channel_tx_pwr;
     /*!
      * Channels TX power
      *
      * Related MIB type: \ref MIB_CHANNELS_TX_POWER
      */
-    int8_t ChannelsTxPower;
+    int8_t channel_tx_pwr;
     /*!
      * LoRaWAN uplink counter
      *
      * Related MIB type: \ref MIB_UPLINK_COUNTER
      */
-    uint32_t UpLinkCounter;
+    uint32_t ul_frame_counter;
     /*!
      * LoRaWAN downlink counter
      *
      * Related MIB type: \ref MIB_DOWNLINK_COUNTER
      */
-    uint32_t DownLinkCounter;
+    uint32_t dl_frame_counter;
     /*!
      * Multicast channel
      *
      * Related MIB type: \ref MIB_MULTICAST_CHANNEL
      */
-    MulticastParams_t* MulticastList;
+    multicast_params_t* multicast_list;
     /*!
      * System overall timing error in milliseconds
      *
      * Related MIB type: \ref MIB_SYSTEM_MAX_RX_ERROR
      */
-    uint32_t SystemMaxRxError;
+    uint32_t max_rx_sys_error;
     /*!
      * Minimum required number of symbols to detect an RX frame
      *
      * Related MIB type: \ref MIB_MIN_RX_SYMBOLS
      */
-    uint8_t MinRxSymbols;
+    uint8_t min_rx_symb;
     /*!
      * Antenna gain
      *
      * Related MIB type: \ref MIB_ANTENNA_GAIN
      */
-    float AntennaGain;
-}MibParam_t;
+    float antenna_gain;
+} mib_params_t;
 
 /*!
  * LoRaMAC MIB-RequestConfirm structure
  */
-typedef struct eMibRequestConfirm
-{
+typedef struct {
     /*!
      * MIB-Request type
      */
-    Mib_t Type;
+    mib_type_t type;
 
     /*!
      * MLME-RequestConfirm parameters
      */
-    MibParam_t Param;
-}MibRequestConfirm_t;
+    mib_params_t param;
+}loramac_mib_req_confirm_t;
 
 /*!
  * LoRaMAC TX information
  */
-typedef struct sLoRaMacTxInfo
-{
+typedef struct {
     /*!
      * Defines the size of the applicable payload that can be processed.
      */
-    uint8_t MaxPossiblePayload;
+    uint8_t max_possible_payload_size;
     /*!
      * The current payload size, dependent on the current datarate.
      */
-    uint8_t CurrentPayloadSize;
-}LoRaMacTxInfo_t;
+    uint8_t current_payload_size;
+} loramac_tx_info_t;
 
-/*!
- * LoRaMAC status.
+/** LoRaMAC status.
+ *
  */
-typedef enum eLoRaMacStatus
-{
-    /*!
-     * Service started successfully.
-     */
-    LORAMAC_STATUS_OK,
-    /*!
-     * Service not started - LoRaMAC is busy.
-     */
-    LORAMAC_STATUS_BUSY,
-    /*!
-     * Service unknown.
-     */
-    LORAMAC_STATUS_SERVICE_UNKNOWN,
-    /*!
-     * Service not started - invalid parameter.
-     */
-    LORAMAC_STATUS_PARAMETER_INVALID,
-    /*!
-     * Service not started - invalid frequency.
-     */
-    LORAMAC_STATUS_FREQUENCY_INVALID,
-    /*!
-     * Service not started - invalid datarate.
-     */
-    LORAMAC_STATUS_DATARATE_INVALID,
-    /*!
-     * Service not started - invalid frequency and datarate.
-     */
-    LORAMAC_STATUS_FREQ_AND_DR_INVALID,
-    /*!
-     * Service not started - the device is not in a LoRaWAN.
-     */
-    LORAMAC_STATUS_NO_NETWORK_JOINED,
-    /*!
-     * Service not started - payload length error.
-     */
-    LORAMAC_STATUS_LENGTH_ERROR,
-    /*!
-     * Service not started - the device is switched off.
-     */
-    LORAMAC_STATUS_DEVICE_OFF,
-    /*!
-     * Service not started - the specified region is not supported
-     * or not activated with preprocessor definitions.
-     */
-    LORAMAC_STATUS_REGION_NOT_SUPPORTED,
-    /*!
-     * Crypto methods failure.
-     */
-    LORAMAC_STATUS_CRYPTO_FAIL,
-}LoRaMacStatus_t;
+typedef enum lorawan_status {
+    LORAWAN_STATUS_OK = 0,                         /**< Service started successfully */
+    LORAWAN_STATUS_BUSY = -1000,                   /**< Service not started - LoRaMAC is busy */
+    LORAWAN_STATUS_WOULD_BLOCK = -1001,            /**< LoRaMAC cannot send at the moment or have nothing to read */
+    LORAWAN_STATUS_SERVICE_UNKNOWN = -1002,        /**< Service unknown */
+    LORAWAN_STATUS_PARAMETER_INVALID = -1003,      /**< Service not started - invalid parameter */
+    LORAWAN_STATUS_FREQUENCY_INVALID = -1004,      /**< Service not started - invalid frequency */
+    LORAWAN_STATUS_DATARATE_INVALID = -1005,       /**< Service not started - invalid datarate */
+    LORAWAN_STATUS_FREQ_AND_DR_INVALID = -1006,    /**< Service not started - invalid frequency and datarate */
+    LORAWAN_STATUS_NO_NETWORK_JOINED = -1009,      /**< Service not started - the device is not in a LoRaWAN */
+    LORAWAN_STATUS_LENGTH_ERROR = -1010,           /**< Service not started - payload lenght error */
+    LORAWAN_STATUS_DEVICE_OFF = -1011,             /**< Service not started - the device is switched off */
+    LORAWAN_STATUS_NOT_INITIALIZED = -1012,        /**< Service not started - stack not initialized */
+    LORAWAN_STATUS_UNSUPPORTED = -1013,            /**< Service not supported */
+    LORAWAN_STATUS_CRYPTO_FAIL = -1014,            /**< Service not started - crypto failure */
+    LORAWAN_STATUS_PORT_INVALID = -1015,           /**< Invalid port */
+    LORAWAN_STATUS_CONNECT_IN_PROGRESS = -1016,    /**< Services started - Connection in progress */
+    LORAWAN_STATUS_NO_ACTIVE_SESSIONS = -1017,            /**< Services not started - No active session */
+    LORAWAN_STATUS_IDLE = -1018,                   /**< Services started - Idle at the moment */
+#if defined(LORAWAN_COMPLIANCE_TEST)
+    LORAWAN_STATUS_COMPLIANCE_TEST_ON = -1019,     /**< Compliance test - is on-going */
+#endif
+} lorawan_status_t;
 
 /*!
  * LoRaMAC events structure.
  * Used to notify upper layers of MAC events.
  */
-typedef struct sLoRaMacPrimitives
-{
+typedef struct {
     /*!
      * \brief   MCPS-Confirm primitive.
      *
      * \param   [OUT] MCPS-Confirm parameters.
      */
-    mbed::Callback<void(McpsConfirm_t*)> MacMcpsConfirm;
+    mbed::Callback<void(loramac_mcps_confirm_t*)> mcps_confirm;
 
     /*!
      * \brief   MCPS-Indication primitive.
      *
      * \param   [OUT] MCPS-Indication parameters.
      */
-    mbed::Callback<void(McpsIndication_t*)> MacMcpsIndication;
+    mbed::Callback<void(loramac_mcps_indication_t*)> mcps_indication;
 
     /*!
      * \brief   MLME-Confirm primitive.
      *
      * \param   [OUT] MLME-Confirm parameters.
      */
-    mbed::Callback<void(MlmeConfirm_t*)> MacMlmeConfirm;
+    mbed::Callback<void(loramac_mlme_confirm_t*)> mlme_confirm;
 
     /*!
      * \brief   MLME-Indication primitive
      *
      * \param   [OUT] MLME-Indication parameters
      */
-    mbed::Callback<void(MlmeIndication_t*)> MacMlmeIndication;
-}LoRaMacPrimitives_t;
-
-/*!
- * LoRaMAC callback structure.
- */
-typedef struct sLoRaMacCallback
-{
-    /*!
-     * \brief   Measures the battery level.
-     *
-     * \retval  The battery level [0: node is connected to an external
-     *          power source, 1..254: battery level, where 1 is the minimum
-     *          and 254 is the maximum value, 255: the node was not able
-     *          to measure the battery level].
-     */
-    uint8_t ( *GetBatteryLevel )( void );
-
-}LoRaMacCallback_t;
+    mbed::Callback<void(loramac_mlme_indication_t*)> mlme_indication;
+}loramac_primitives_t;
 
 /** End-device states.
  *
@@ -1751,7 +1662,7 @@ typedef enum lorawan_connect_type {
  * A structure representing the LoRaWAN Over The Air Activation
  * parameters.
  */
-typedef struct lorawan_connect_otaa {
+typedef struct {
     /** End-device identifier
      *
      * LoRaWAN Specification V1.0.2, chapter 6.2.1
@@ -1779,7 +1690,7 @@ typedef struct lorawan_connect_otaa {
  * A structure representing the LoRaWAN Activation By Personalization
  * parameters.
  */
-typedef struct lorawan_connect_abp {
+typedef struct {
     /** Network identifier
      *
      * LoRaWAN Specification V1.0.2, chapter 6.1.1
@@ -1802,104 +1713,10 @@ typedef struct lorawan_connect_abp {
     uint8_t *app_skey;
 } lorawan_connect_abp_t;
 
-/** LoRaMAC data services
- *
+/**
+ * Stack level TX message structure
  */
-typedef enum lora_mac_mcps {
-    LORA_MCPS_UNCONFIRMED = 0,  /**< Unconfirmed LoRaMAC frame */
-    LORA_MCPS_CONFIRMED,        /**< Confirmed LoRaMAC frame */
-    LORA_MCPS_MULTICAST,        /**< Multicast LoRaMAC frame */
-    LORA_MCPS_PROPRIETARY,      /**< Proprietary frame */
-} lora_mac_mcps_t;
-
-/** LoRaMAC management services
- *
- */
-typedef enum lora_mac_mlme {
-    LORA_MLME_JOIN,         /**< Initiates the Over-the-Air activation */
-    LORA_MLME_LINK_CHECK,   /**< LinkCheckReq - Connectivity validation */
-    LORA_MLME_TXCW,         /**< Sets Tx continuous wave mode */
-    LORA_MLME_TXCW_1,       /**< Sets Tx continuous wave mode (new LoRa-Alliance CC definition) */
-} lora_mac_mlme_t;
-
-/** Unconfirmed message.
- *
- * A message for an unconfirmed frame.
- */
-typedef struct lora_mac_unconfirmed {
-    /** Frame port field.
-     *
-     * Must be set if the payload is not empty. Use the
-     * application-specific frame port values: [1...223]
-     *
-     * LoRaWAN Specification V1.0.2, chapter 4.3.2
-     */
-    uint8_t f_port;
-    /** Uplink datarate
-     *
-     * Used if ADR is off
-     */
-    int8_t datarate;
-} lora_mac_unconfirmed_t;
-
-/** Confirmed message.
- *
- * A message for a confirmed frame.
- */
-typedef struct lora_mac_confirmed {
-    /** Frame port field.
-     *
-     * Must be set if the payload is not empty. Use the
-     * application-specific frame port values: [1...223]
-     *
-     * LoRaWAN Specification V1.0.2, chapter 4.3.2
-     */
-    uint8_t f_port;
-    /** Uplink datarate.
-     *
-     * Used if ADR is off.
-     */
-    int8_t datarate;
-    /** Number of trials.
-     *
-     * The number of trials to transmit the frame, if the LoRaMAC layer did not
-     * receive an acknowledgment. The MAC performs a datarate adaptation
-     * according to the LoRaWAN Specification V1.0.2, chapter 18.4, as in
-     * the following table:
-     *
-     * Transmission nb | Data Rate
-     * ----------------|-----------
-     * 1 (first)       | DR
-     * 2               | DR
-     * 3               | max(DR-1,0)
-     * 4               | max(DR-1,0)
-     * 5               | max(DR-2,0)
-     * 6               | max(DR-2,0)
-     * 7               | max(DR-3,0)
-     * 8               | max(DR-3,0)
-     *
-     * Note that if NbTrials is set to 1 or 2, the MAC does not decrease
-     * the datarate, if the LoRaMAC layer did not receive an acknowledgment.
-     */
-    uint8_t nb_trials;
-} lora_mac_confirmed_t;
-
-/** A proprietary message.
- *
- * A message for a proprietary frame.
- */
-typedef struct lora_mac_proprietary {
-    /** Uplink datarate.
-     *
-     *  Used if ADR is off.
-     */
-    int8_t datarate;
-} lora_mac_proprietary_t;
-
-/** LoRaMAC message structure.
- *
- */
-typedef struct lora_mac_tx_message {
+typedef struct {
 
     /**
      * TX Ongoing flag
@@ -1914,7 +1731,7 @@ typedef struct lora_mac_tx_message {
     /**
      * Message type
      */
-    lora_mac_mcps_t type;
+    mcps_type_t type;
     /** Message parameters.
      *
      */
@@ -1923,17 +1740,17 @@ typedef struct lora_mac_tx_message {
          *
          * The message parameters for an unconfirmed frame.
          */
-        lora_mac_unconfirmed_t unconfirmed;
+        mcps_req_unconfirmed_t unconfirmed;
         /** A confirmed frame.
          *
          * The message parameters for a confirmed frame.
          */
-        lora_mac_confirmed_t confirmed;
+        mcps_req_confirmed_t confirmed;
         /** A proprietary frame.
          *
          * The message parameters for a proprietary frame.
          */
-        lora_mac_proprietary_t proprietary;
+        mcps_req_proprietary_t proprietary;
     } message_u;
 
     /** Payload data
@@ -1953,476 +1770,48 @@ typedef struct lora_mac_tx_message {
      */
     uint16_t pending_size;
 
-} lora_mac_tx_message_t;
-
-/** LoRaMAC status.
- *
- */
-typedef enum lora_mac_status {
-    LORA_MAC_STATUS_OK = 0,                         /**< Service started successfully */
-    LORA_MAC_STATUS_BUSY = -1000,                   /**< Service not started - LoRaMAC is busy */
-    LORA_MAC_STATUS_WOULD_BLOCK = -1001,            /**< LoRaMAC cannot send at the moment or have nothing to read */
-    LORA_MAC_STATUS_SERVICE_UNKNOWN = -1002,        /**< Service unknown */
-    LORA_MAC_STATUS_PARAMETER_INVALID = -1003,      /**< Service not started - invalid parameter */
-    LORA_MAC_STATUS_FREQUENCY_INVALID = -1004,      /**< Service not started - invalid frequency */
-    LORA_MAC_STATUS_DATARATE_INVALID = -1005,       /**< Service not started - invalid datarate */
-    LORA_MAC_STATUS_FREQ_AND_DR_INVALID = -1006,    /**< Service not started - invalid frequency and datarate */
-    LORA_MAC_STATUS_NO_NETWORK_JOINED = -1009,      /**< Service not started - the device is not in a LoRaWAN */
-    LORA_MAC_STATUS_LENGTH_ERROR = -1010,           /**< Service not started - payload lenght error */
-    LORA_MAC_STATUS_DEVICE_OFF = -1011,             /**< Service not started - the device is switched off */
-    LORA_MAC_STATUS_NOT_INITIALIZED = -1012,        /**< Service not started - stack not initialized */
-    LORA_MAC_STATUS_UNSUPPORTED = -1013,            /**< Service not supported */
-    LORA_MAC_STATUS_CRYPTO_FAIL = -1014,            /**< Service not started - crypto failure */
-    LORA_MAC_STATUS_PORT_INVALID = -1015,           /**< Invalid port */
-    LORA_MAC_STATUS_CONNECT_IN_PROGRESS = -1016,    /**< Services started - Connection in progress */
-    LORA_MAC_STATUS_NO_ACTIVE_SESSIONS = -1017,            /**< Services not started - No active session */
-    LORA_MAC_STATUS_IDLE = -1018,                   /**< Services started - Idle at the moment */
-#if defined(LORAWAN_COMPLIANCE_TEST)
-    LORA_MAC_STATUS_COMPLIANCE_TEST_ON = -1019,         /**< Compliance test - is on-going */
-#endif
-} lora_mac_status_t;
-
-/**
- *
- * Enumeration containing the status of the operation of a MAC service
- */
-typedef enum lora_mac_event_info_status {
-    LORA_EVENT_INFO_STATUS_OK = 0,                           /**< Service performed successfully */
-    LORA_EVENT_INFO_STATUS_ERROR,                            /**< An error occurred during the execution of the service */
-    LORA_EVENT_INFO_STATUS_TX_TIMEOUT,                       /**< A TX timeout occurred */
-    LORA_EVENT_INFO_STATUS_RX1_TIMEOUT,                      /**< An RX timeout occurred on receive window 1 */
-    LORA_EVENT_INFO_STATUS_RX2_TIMEOUT,                      /**< An RX timeout occurred on receive window 2 */
-    LORA_EVENT_INFO_STATUS_RX1_ERROR,                        /**< An RX error occurred on receive window 1 */
-    LORA_EVENT_INFO_STATUS_RX2_ERROR,                        /**< An RX error occurred on receive window 2 */
-    LORA_EVENT_INFO_STATUS_JOIN_FAIL,                        /**< An error occurred in the join procedure */
-    LORA_EVENT_INFO_STATUS_DOWNLINK_REPEATED,                /**< A frame with an invalid downlink counter */
-    LORA_EVENT_INFO_STATUS_TX_DR_PAYLOAD_SIZE_ERROR,         /**< Payload size is not applicable for the datarate */
-    LORA_EVENT_INFO_STATUS_DOWNLINK_TOO_MANY_FRAMES_LOSS,    /**< The node has lost MAX_FCNT_GAP or more frames. */
-    LORA_EVENT_INFO_STATUS_ADDRESS_FAIL,                     /**< An address error occurred */
-    LORA_EVENT_INFO_STATUS_MIC_FAIL,                         /**< Message integrity check failure */
-    LORA_EVENT_INFO_STATUS_CRYPTO_FAIL                       /**< Crypto error*/
-} lora_mac_event_info_status_t;
-
-/**
- * LoRaMAC MLME-Request for TX continuous wave mode.
- */
-typedef struct mlme_req_tx_cw {
-    /**
-     * The time while the radio is kept in continuous wave mode, in seconds.
-     */
-    uint16_t timeout;
-    /**
-     * RF frequency to set (only used with the new way).
-     */
-    uint32_t frequency;
-    /**
-     * RF output power to set (only used with the new way).
-     */
-    uint8_t power;
-} mlme_req_tx_cw_t;
-
-/**
- * LoRaMAC MLME-Request structure
- */
-typedef struct lora_mac_mlme_req {
-    /**
-     * MLME-Request type
-     */
-    lora_mac_mlme_t type;
-
-    /**
-     * MLME-Request parameters
-     */
-    union mlme_param {
-        /**
-         * MLME-Request parameters for a join request
-         */
-        lorawan_connect_otaa_t join;
-        /**
-         * MLME-Request parameters for TX continuous mode request
-         */
-        mlme_req_tx_cw_t tx_cw;
-    } req;
-} lora_mac_mlme_req_t;
-
-/**
- * LoRaMAC MCPS-Request structure
- */
-typedef struct lora_mac_mcps_req {
-    /**
-     * MCPS-Request type
-     */
-    lora_mac_mcps_t type;
-
-    /**
-     * MCPS-Request parameters
-     */
-    union mcps_param
-    {
-        /**
-         * MCPS-Request parameters for an unconfirmed frame.
-         */
-        lora_mac_unconfirmed_t unconfirmed;
-        /**
-         * MCPS-Request parameters for a confirmed frame.
-         */
-        lora_mac_confirmed_t confirmed;
-        /**
-         * MCPS-Request parameters for a proprietary frame.
-         */
-        lora_mac_proprietary_t proprietary;
-    } req;
-    /** Payload data
-     *
-     * A pointer to the buffer of the frame payload.
-     */
-    void *f_buffer;
-    /** Payload size
-     *
-     * The size of the frame payload.
-     */
-    uint16_t f_buffer_size;
-} lora_mac_mcps_req_t;
-
-/** LoRaMAC MLME-Confirm
- *
- */
-typedef struct lora_mac_mlme_confirm {
-    /** The previous MLME-Request.
-     *
-     * The previously performed MLME-Request.
-     */
-    lora_mac_mlme_t mlme_request;
-    /** The status of the operation.
-     *
-     * The current status of the MAC service operation.
-     */
-    lora_mac_event_info_status_t status;
-    /** Time on air.
-     *
-     * The transmission time on air of the frame.
-     */
-    TimerTime_t tx_time_on_air;
-    /** Demodulation margin.
-     *
-     * The link margin [dB] of the last LinkCheckReq successfully received.
-     */
-    uint8_t demod_margin;
-    /** The number of gateways.
-     *
-     * The number of gateways that received the last LinkCheckReq.
-     */
-    uint8_t nb_gateways;
-    /** The retransmission counter.
-     *
-     * The number of retransmissions.
-     */
-    uint8_t nb_retries;
-} lora_mac_mlme_confirm_t;
-
-/** LoRaMAC MCPS-Confirm
- *
- */
-typedef struct lora_mac_mcps_confirm {
-    /** MCPS-request
-     *
-     * Holds the previously performed MCPS-Request.
-     */
-    lora_mac_mcps_t mcps_request;
-    /** The status of the operation.
-     *
-     * The current status of MAC service operation.
-     */
-    lora_mac_event_info_status_t status;
-    /** Uplink datarate
-     *
-     */
-    uint8_t datarate;
-    /** Transmission power
-     *
-     */
-    int8_t tx_power;
-    /** ACK-received
-     *
-     * Set if an acknowledgement was received.
-     */
-    bool ack_received;
-    /** Retransmission counter
-     *
-     * Provides the number of retransmissions.
-     */
-    uint8_t nb_retries;
-    /** Time on air
-     *
-     * The transmission time on air of the frame.
-     */
-    TimerTime_t tx_time_on_air;
-    /** Uplink counter
-     *
-     * The uplink counter value related to the frame.
-     */
-    uint32_t uplink_counter;
-    /** Uplink frequency
-     *
-     * The uplink frequency related to the frame.
-     */
-    uint32_t uplink_frequency;
-} lora_mac_mcps_confirm_t;
-
-/** LoRaMAC MCPS-Indication
- *
- */
-typedef struct lora_mac_mcps_indication {
-    /** MCPS-Indication type
-     *
-     */
-    lora_mac_mcps_t mcps_indication;
-    /** The status of the operation
-     *
-     * The current status of MAC service operation.
-     */
-    lora_mac_event_info_status_t status;
-    /** Multicast
-     *
-     * This is a multicast message.
-     */
-    uint8_t multicast;
-    /** Application port
-     *
-     */
-    uint8_t port;
-    /** Downlink datarate
-     *
-     */
-    uint8_t rx_datarate;
-    /** Frame pending
-     *
-     * The frame is pending.
-     */
-    uint8_t frame_pending;
-    /** Payload data
-     *
-     * A pointer to the received data stream.
-     */
-    uint8_t buffer[LORAMAC_PHY_MAXPAYLOAD];
-    /** Payload size
-     *
-     * The size of the received data stream.
-     */
-    uint16_t buffer_size;
-    /** RX-data indication
-     *
-     * Indicates, if data is available.
-     */
-    bool rx_data;
-    /** Packet RSSI
-     *
-     * The RSSI of the received packet.
-     */
-    int16_t rssi;
-    /** Packet SNR
-     *
-     * The SNR of the received packet.
-     */
-    uint8_t snr;
-    /** Receive window
-     *
-     * [0: Rx window 1, 1: Rx window 2]
-     */
-    uint8_t rx_slot;
-    /** ACK-received
-     *
-     * Set if an acknowledgement was received.
-     */
-    bool ack_received;
-    /** Downlink counter
-     *
-     * The downlink counter value for the received frame.
-     */
-    uint32_t downlink_counter;
-} lora_mac_mcps_indication_t;
+} loramac_tx_message_t;
 
 /** lora_mac_rx_message_type_t
  *
  * An enum representing a structure for RX messages.
  */
-typedef enum lora_mac_rx_message_type {
+typedef enum  {
     LORAMAC_RX_MLME_CONFIRM = 0,    /**< lora_mac_mlme_confirm_t */
     LORAMAC_RX_MCPS_CONFIRM,        /**< lora_mac_mcps_confirm_t */
     LORAMAC_RX_MCPS_INDICATION      /**< lora_mac_mcps_indication_t */
-} lora_mac_rx_message_type_t;
+} rx_msg_type;
 
 /** lora_mac_rx_message_by_type_t union
  *
  * A union representing a structure for RX messages.
  */
-typedef union lora_mac_rx_message_by_type_t {
-    lora_mac_mlme_confirm_t mlme_confirm;
-    lora_mac_mcps_confirm_t mcps_confirm;
-    lora_mac_mcps_indication_t mcps_indication;
-} lora_mac_rx_message_by_type_t;
+typedef union {
+    loramac_mlme_confirm_t mlme_confirm;
+    loramac_mcps_confirm_t mcps_confirm;
+    loramac_mcps_indication_t mcps_indication;
+} rx_message_u;
 
-/** lora_mac_rx_message_t
+/** loramac_rx_message_t
  *
  * A structure representing a structure for an RX message.
  */
-typedef struct lora_mac_rx_message {
+typedef struct {
     bool receive_ready;
-    lora_mac_rx_message_type_t type;
-    lora_mac_rx_message_by_type_t rx_message;
+    rx_msg_type type;
+    rx_message_u msg;
     uint16_t pending_size;
     uint16_t prev_read_size;
-} lora_mac_rx_message_t;
-
-/** lora_mac_dr_range_t union
- *
- * A union representing a structure for the minimum and maximum data rate.
- */
-typedef union lora_mac_dr_range {
-    /** Byte-access
-     *
-     * Byte-access to the bits.
-     */
-    int8_t value;
-    /** lora_mac_fields_s
-     *
-     * A structure to store the minimum and maximum data rate.
-     */
-    struct lora_mac_fields {
-        /** Minimum data rate
-         *
-         * EU868 - [DR_0, DR_1, DR_2, DR_3, DR_4, DR_5, DR_6, DR_7]
-         *
-         * US915 - [DR_0, DR_1, DR_2, DR_3, DR_4]
-         */
-        int8_t min :4;
-        /** Maximum data rate
-         *
-         * EU868 - [DR_0, DR_1, DR_2, DR_3, DR_4, DR_5, DR_6, DR_7]
-         *
-         * US915 - [DR_0, DR_1, DR_2, DR_3, DR_4]
-         */
-        int8_t max :4;
-    } lora_mac_fields_s;
-} lora_mac_dr_range_t;
-
-/** LoRaWAN device class definition
- *
- */
-typedef enum lora_mac_device_class {
-    LORA_CLASS_A, /**< LoRaWAN device class A */
-    LORA_CLASS_B, /**< LoRaWAN device class B */
-    LORA_CLASS_C, /**< LoRaWAN device class C */
-} lora_mac_device_class_t;
-
-/** LoRaMAC channel definition
- *
- */
-typedef struct lora_mac_channel_params {
-    /** Frequency in Hz
-     *
-     */
-    uint32_t frequency;
-    /** Alternative frequency for RX window 1
-     *
-     */
-    uint32_t rx1_frequency;
-    /** Data rate definition
-     *
-     */
-    lora_mac_dr_range_t dr_range;
-    /** Band index
-     *
-     */
-    uint8_t band;
-} lora_mac_channel_params_t;
+} loramac_rx_message_t;
 
 /**
  * Structure to hold A list of LoRa Channels
  */
 typedef struct lora_channels_s {
     uint8_t id;
-    lora_mac_channel_params_t ch_param;
-} lora_channels_t;
+    channel_params_t ch_param;
+} loramac_channel_t;
 
-/** LoRaMAC receive window 2 channel parameters
- *
- */
-typedef struct lora_mac_rx2_channel_params {
-    /** Frequency in Hz
-     *
-     */
-    uint32_t frequency;
-    /** Data rate
-     *
-     * EU868 - [DR_0, DR_1, DR_2, DR_3, DR_4, DR_5, DR_6, DR_7]
-     *
-     * US915 - [DR_8, DR_9, DR_10, DR_11, DR_12, DR_13]
-     */
-    uint8_t datarate;
-} lora_mac_rx2_channel_params_t;
-
-/** LoRaMAC multicast channel parameter
- *
- */
-typedef struct lora_mac_multicast_params {
-    /** Address
-     *
-     */
-    uint32_t address;
-    /** Network session key
-     *
-     */
-    uint8_t nwk_skey[16];
-    /** Application session key
-     *
-     */
-    uint8_t app_skey[16];
-    /** Downlink counter
-     *
-     */
-    uint32_t downlink_counter;
-    /** Next multicast
-     *
-     * A reference pointer to the next multicast channel parameters in the list
-     */
-    struct lora_mac_multicast_params *next;
-} lora_mac_multicast_params_t;
-
-/** Enum lora_mac_mib_t
- *
- */
-typedef enum lora_mac_mib {
-    LORA_MIB_DEVICE_CLASS,              /**< LoRaWAN device class */
-    LORA_MIB_NETWORK_JOINED,            /**< LoRaWAN network joined attribute */
-    LORA_MIB_ADR,                       /**< Adaptive data rate */
-    LORA_MIB_NET_ID,                    /**< Network identifier */
-    LORA_MIB_DEV_ADDR,                  /**< End-device address */
-    LORA_MIB_NWK_SKEY,                  /**< Network session key */
-    LORA_MIB_APP_SKEY,                  /**< Application session key */
-    LORA_MIB_PUBLIC_NETWORK,            /**< Set the network type to public or private */
-    LORA_MIB_REPEATER_SUPPORT,          /**< Support the operation with repeaters */
-    LORA_MIB_CHANNELS,                  /**< Communication channels */
-    LORA_MIB_RX2_CHANNEL,               /**< Set receive window 2 channel */
-    LORA_MIB_RX2_DEFAULT_CHANNEL,       /**< Set receive window 2 channel */
-    LORA_MIB_CHANNELS_MASK,             /**< LoRaWAN channels mask */
-    LORA_MIB_CHANNELS_DEFAULT_MASK,     /**< LoRaWAN default channels mask */
-    LORA_MIB_CHANNELS_NB_REP,           /**< Set the number of repetitions on a channel */
-    LORA_MIB_MAX_RX_WINDOW_DURATION,    /**< Maximum receive window duration in [ms] */
-    LORA_MIB_RECEIVE_DELAY_1,           /**< Receive delay 1 in [ms] */
-    LORA_MIB_RECEIVE_DELAY_2,           /**< Receive delay 2 in [ms] */
-    LORA_MIB_JOIN_ACCEPT_DELAY_1,       /**< Join accept delay 1 in [ms] */
-    LORA_MIB_JOIN_ACCEPT_DELAY_2,       /**< Join accept delay 2 in [ms] */
-    LORA_MIB_CHANNELS_DEFAULT_DATARATE, /**< Default data rate of a channel */
-    LORA_MIB_CHANNELS_DATARATE,         /**< Data rate of a channel */
-    LORA_MIB_CHANNELS_TX_POWER,         /**< Transmission power of a channel */
-    LORA_MIB_CHANNELS_DEFAULT_TX_POWER, /**< Transmission power of a channel */
-    LORA_MIB_UPLINK_COUNTER,            /**< LoRaWAN uplink counter */
-    LORA_MIB_DOWNLINK_COUNTER,          /**< LoRaWAN downlink counter */
-    LORA_MIB_MULTICAST_CHANNEL,         /**< Multicast channels */
-    LORA_MIB_SYSTEM_MAX_RX_ERROR,       /**< System overall timing error in milliseconds. */
-    LORA_MIB_MIN_RX_SYMBOLS,            /**< Minimum number of symbols required to detect an RX frame */
-} lora_mac_mib_t;
 
 /** lorawan_connect_t structure
  *
@@ -2477,7 +1866,7 @@ typedef struct lorawan_session {
  *
  * A structure for data in commission.
  */
-typedef struct lora_dev_commission {
+typedef struct {
     /** Connection information
      *
      * Saves information for etc. keys
@@ -2495,179 +1884,7 @@ typedef struct lora_dev_commission {
      * Related MIB type: LORA_MIB_DOWNLINK_COUNTER
      */
     uint32_t downlink_counter;
-} lora_dev_commission_t;
-
-/** LoRaMAC MIB parameters
- *
- */
-typedef union lora_mac_mib_param {
-    /** LoRaWAN device class
-     *
-     * Related MIB type: \ref MIB_DEVICE_CLASS
-     */
-    lora_mac_device_class_t lora_class;
-    /** LoRaWAN network joined attribute
-     *
-     * Related MIB type: \ref MIB_NETWORK_JOINED
-     */
-    bool is_network_joined;
-    /** Activation state of ADR
-     *
-     * Related MIB type: \ref MIB_ADR
-     */
-    bool adr_enable;
-    /** Network identifier
-     *
-     * Related MIB type: \ref MIB_NET_ID
-     */
-    uint32_t net_id;
-    /** End-device address
-     *
-     * Related MIB type: \ref MIB_DEV_ADDR
-     */
-    uint32_t dev_addr;
-    /** Network session key
-     *
-     * Related MIB type: \ref MIB_NWK_SKEY
-     */
-    uint8_t *nwk_skey;
-    /** Application session key
-     *
-     * Related MIB type: \ref MIB_APP_SKEY
-     */
-    uint8_t *app_skey;
-    /** Enable public network
-     *
-     * Enable or disable a public network
-     * Related MIB type: \ref MIB_PUBLIC_NETWORK
-     */
-    bool enable_public_network;
-    /** Enable repeater support
-     *
-     * Enable or disable repeater support
-     * Related MIB type: \ref MIB_REPEATER_SUPPORT
-     */
-    bool enable_repeater_support;
-    /** LoRaWAN Channel
-     *
-     * Related MIB type: \ref MIB_CHANNELS
-     */
-    lora_mac_channel_params_t *channel_list;
-    /** Channel rx 2
-     *
-     * Channel for the receive window 2
-     * Related MIB type: \ref MIB_RX2_CHANNEL
-     */
-    lora_mac_rx2_channel_params_t rx2_channel;
-    /** Default channel rx 2
-     *
-     * Channel for the receive window 2
-     * Related MIB type: \ref MIB_RX2_DEFAULT_CHANNEL
-     */
-    lora_mac_rx2_channel_params_t rx2_default_channel;
-    /** Channel mask
-     *
-     * Related MIB type: \ref MIB_CHANNELS_MASK
-     */
-    uint16_t *channels_mask;
-    /** Default channel mask
-     *
-     * Related MIB type: \ref MIB_CHANNELS_DEFAULT_MASK
-     */
-    uint16_t *channels_default_mask;
-    /** Frame repetition number
-     *
-     * Number of frame repetitions
-     * Related MIB type: \ref MIB_CHANNELS_NB_REP
-     */
-    uint8_t channel_nb_rep;
-    /** Maximum receive window duration
-     *
-     * Related MIB type: \ref MIB_MAX_RX_WINDOW_DURATION
-     */
-    uint32_t max_rx_window;
-    /** Receive delay 1
-     *
-     * Related MIB type: \ref MIB_RECEIVE_DELAY_1
-     */
-    uint32_t receive_delay1;
-    /** Receive delay 2
-     *
-     * Related MIB type: \ref MIB_RECEIVE_DELAY_2
-     */
-    uint32_t receive_delay2;
-    /** Join accept delay 1
-     *
-     * Related MIB type: \ref MIB_JOIN_ACCEPT_DELAY_1
-     */
-    uint32_t join_accept_delay1;
-    /** Join accept delay 2
-     *
-     * Related MIB type: \ref MIB_JOIN_ACCEPT_DELAY_2
-     */
-    uint32_t join_accept_delay2;
-    /** Channels default data rate
-     *
-     * Related MIB type: \ref MIB_CHANNELS_DEFAULT_DATARATE
-     */
-    int8_t channels_default_datarate;
-    /** Channels data rate
-     *
-     * Related MIB type: \ref MIB_CHANNELS_DATARATE
-     */
-    int8_t channels_datarate;
-    /** Channels default TX power
-     *
-     * Related MIB type: \ref MIB_CHANNELS_DEFAULT_TX_POWER
-     */
-    int8_t channels_default_tx_power;
-    /** Channels TX power
-     *
-     * Related MIB type: \ref MIB_CHANNELS_TX_POWER
-     */
-    int8_t channels_tx_power;
-    /** LoRaWAN uplink counter
-     *
-     * Related MIB type: \ref MIB_UPLINK_COUNTER
-     */
-    uint32_t uplink_counter;
-    /** LoRaWAN downlink counter
-     *
-     * Related MIB type: \ref MIB_DOWNLINK_COUNTER
-     */
-    uint32_t downlink_counter;
-    /** Multicast channel
-     *
-     * Related MIB type: \ref MIB_MULTICAST_CHANNEL
-     */
-    lora_mac_multicast_params_t *multicast_list;
-    /** Maximum RX error timing
-     *
-     * System overall timing error in milliseconds.
-     * Related MIB type: \ref MIB_SYSTEM_MAX_RX_ERROR
-     */
-    uint32_t system_max_rx_error;
-    /** Minimum RX symbols
-     *
-     * Minimum required number of symbols to detect an RX frame
-     * Related MIB type: \ref MIB_MIN_RX_SYMBOLS
-     */
-    uint8_t min_rx_symbols;
-} lora_mac_mib_param_t;
-
-/** LoRaMAC MIB-RequestConfirm structure
- *
- */
-typedef struct lora_mac_mib_request_confirm {
-    /** MIB-Request type
-     *
-     */
-    lora_mac_mib_t type;
-    /** MIB-RequestConfirm parameters
-     *
-     */
-    lora_mac_mib_param_t param;
-} lora_mac_mib_request_confirm_t;
+} lorawan_dev_commission_t;
 
 #if defined(LORAWAN_COMPLIANCE_TEST)
 /**  LoRaWAN compliance tests support data
@@ -2720,7 +1937,7 @@ typedef struct compliance_test {
 /** Structure containing the uplink status
  *
  */
-typedef struct loramac_uplink_status {
+typedef struct {
     /** Is acked
      *
      */
@@ -2750,7 +1967,7 @@ typedef struct loramac_uplink_status {
 /** A structure containing the downlink status
  *
  */
-typedef struct loramac_downlink_status {
+typedef struct {
     /** RSSI of downlink
      *
      */
@@ -2782,71 +1999,68 @@ typedef struct loramac_downlink_status {
 } loramac_downlink_status_t;
 
 /*!
- * The parameter structure for the function RegionRxConfig.
+ * The parameter structure for the function for regional rx configuration.
  */
-typedef struct sRxConfigParams
-{
+typedef struct {
     /*!
      * The RX channel.
      */
-    uint8_t Channel;
+    uint8_t channel;
     /*!
      * The RX datarate.
      */
-    int8_t Datarate;
+    int8_t datarate;
     /*!
      * The RX bandwidth.
      */
-    uint8_t Bandwidth;
+    uint8_t bandwidth;
     /*!
      * The RX datarate offset.
      */
-    int8_t DrOffset;
+    int8_t dr_offset;
     /*!
      * The RX frequency.
      */
-    uint32_t Frequency;
+    uint32_t frequency;
     /*!
      * The RX window timeout
      */
-     uint32_t WindowTimeout;
+     uint32_t window_timeout;
     /*!
      * The RX window offset
      */
-    int32_t WindowOffset;
+    int32_t window_offset;
     /*!
      * The downlink dwell time.
      */
-    uint8_t DownlinkDwellTime;
+    uint8_t dl_dwell_time;
     /*!
      * Set to true, if a repeater is supported.
      */
-    bool RepeaterSupport;
+    bool is_repeater_supported;
     /*!
      * Set to true, if RX should be continuous.
      */
-    bool RxContinuous;
+    bool is_rx_continuous;
     /*!
      * Sets the RX window.
      */
-    LoRaMacRxSlot_t RxSlot;
-}RxConfigParams_t;
+    rx_slot_t rx_slot;
+} rx_config_params_t;
 
 /*!
  * \brief Timer object description
  */
-typedef struct TimerEvent_s
-{
+typedef struct {
     uint32_t value;
-    mbed::Callback<void()> Callback;
-    SingletonPtr<mbed::Ticker> Timer;
-} TimerEvent_t;
+    mbed::Callback<void()> callback;
+    SingletonPtr<mbed::Ticker> timer;
+} timer_event_t;
 
 /*!
  * LoRaMac internal states
  */
-enum eLoRaMacState
-{
+typedef enum {
     LORAMAC_IDLE          = 0x00000000,
     LORAMAC_TX_RUNNING    = 0x00000001,
     LORAMAC_RX            = 0x00000002,
@@ -2855,259 +2069,259 @@ enum eLoRaMacState
     LORAMAC_TX_DELAYED    = 0x00000010,
     LORAMAC_TX_CONFIG     = 0x00000020,
     LORAMAC_RX_ABORT      = 0x00000040,
-};
+} loramac_internal_state;
 
 typedef struct {
     /*!
      * Device IEEE EUI
      */
-    uint8_t *LoRaMacDevEui;
+    uint8_t *dev_eui;
 
     /*!
      * Application IEEE EUI
      */
-    uint8_t *LoRaMacAppEui;
+    uint8_t *app_eui;
 
     /*!
      * AES encryption/decryption cipher application key
      */
-    uint8_t *LoRaMacAppKey;
+    uint8_t *app_key;
 
     /*!
      * AES encryption/decryption cipher network session key
      */
-    uint8_t LoRaMacNwkSKey[16];
+    uint8_t nwk_skey[16];
 
     /*!
      * AES encryption/decryption cipher application session key
      */
-    uint8_t LoRaMacAppSKey[16];
+    uint8_t app_skey[16];
 
-} lora_mac_keys;
+} loramac_keys;
 
 typedef struct {
       /*!
        * Aggregated duty cycle management
        */
-      TimerTime_t AggregatedLastTxDoneTime;
-      TimerTime_t AggregatedTimeOff;
+      lorawan_time_t aggregated_last_tx_time;
+      lorawan_time_t aggregated_timeoff;
 
       /*!
        * Stores the time at LoRaMac initialization.
        *
        * \remark Used for the BACKOFF_DC computation.
        */
-      TimerTime_t LoRaMacInitializationTime;
+      lorawan_time_t mac_init_time;
 
 
       /*!
        * Last transmission time on air
        */
-      TimerTime_t TxTimeOnAir;
+      lorawan_time_t tx_toa;
 
       /*!
        * LoRaMac timer used to check the LoRaMacState (runs every second)
        */
-      TimerEvent_t MacStateCheckTimer;
+      timer_event_t mac_state_check_timer;
 
       /*!
        * LoRaMac duty cycle delayed Tx timer
        */
-      TimerEvent_t TxDelayedTimer;
+      timer_event_t tx_delayed_timer;
 
       /*!
        * LoRaMac reception windows timers
        */
-      TimerEvent_t RxWindowTimer1;
-      TimerEvent_t RxWindowTimer2;
+      timer_event_t rx_window1_timer;
+      timer_event_t rx_window2_timer;
 
       /*!
        * Acknowledge timeout timer. Used for packet retransmissions.
        */
-      TimerEvent_t AckTimeoutTimer;
+      timer_event_t ack_timeout_timer;
 
-  } lora_mac_timers;
+} lorawan_timers;
 
 typedef struct {
 
     /*!
      * Actual device class
      */
-    DeviceClass_t LoRaMacDeviceClass;
+    device_class_t dev_class;
 
     /*!
      * Holds the type of current Receive window slot
      */
-     LoRaMacRxSlot_t RxSlot;
+     rx_slot_t rx_slot;
 
     /*!
      * Indicates if the node is connected to a private or public network
      */
-    bool PublicNetwork;
+    bool is_nwk_public;
 
     /*!
      * Indicates if the node supports repeaters
      */
-    bool RepeaterSupport;
+    bool is_repeater_supported;
 
     /*!
      * IsPacketCounterFixed enables the MIC field tests by fixing the
-     * UpLinkCounter value
+     * ul_frame_counter value
      */
-    bool IsUpLinkCounterFixed;
+    bool is_ul_frame_counter_fixed;
 
     /*!
      * Used for test purposes. Disables the opening of the reception windows.
      */
-    bool IsRxWindowsEnabled;
+    bool is_rx_window_enabled;
 
     /*!
      * Indicates if the MAC layer has already joined a network.
      */
-    bool IsLoRaMacNetworkJoined;
+    bool is_nwk_joined;
 
     /*!
      * If the node has sent a FRAME_TYPE_DATA_CONFIRMED_UP this variable indicates
      * if the nodes needs to manage the server acknowledgement.
      */
-    bool NodeAckRequested;
+    bool is_node_ack_requested;
 
     /*!
      * If the server has sent a FRAME_TYPE_DATA_CONFIRMED_DOWN this variable indicates
      * if the ACK bit must be set for the next transmission
      */
-    bool SrvAckRequested;
+    bool is_srv_ack_requested;
 
     /*!
      * Enables/Disables duty cycle management (Test only)
      */
-    bool DutyCycleOn;
+    bool is_dutycycle_on;
 
     /*!
      * Set to true, if the last uplink was a join request
      */
-    bool LastTxIsJoinRequest;
+    bool is_last_tx_join_request;
 
     /*!
      * Indicates if the AckTimeout timer has expired or not
      */
-    bool AckTimeoutRetry;
+    bool is_ack_retry_timeout_expired;
 
     /*!
      * Current channel index
      */
-    uint8_t Channel;
+    uint8_t channel;
 
     /*!
      * Current channel index
      */
-    uint8_t LastTxChannel;
+    uint8_t last_channel_idx;
 
     /*!
      * Uplink messages repetitions counter
      */
-    uint8_t ChannelsNbRepCounter;
+    uint8_t ul_nb_rep_counter;
 
     /*!
      * Buffer containing the data to be sent or received.
      */
-    uint8_t LoRaMacBuffer[LORAMAC_PHY_MAXPAYLOAD];
-
-    /*!
-     * Length of the payload in LoRaMacBuffer
-     */
-    uint8_t LoRaMacTxPayloadLen;
-
-    /*!
-     * Buffer containing the upper layer data.
-     */
-    uint8_t LoRaMacRxPayload[LORAMAC_PHY_MAXPAYLOAD];
-
-    /*!
-     * Number of trials to get a frame acknowledged
-     */
-    uint8_t AckTimeoutRetries;
-
-    /*!
-     * Number of trials to get a frame acknowledged
-     */
-    uint8_t AckTimeoutRetriesCounter;
-
-    /*!
-     * Number of trials for the Join Request
-     */
-    uint8_t JoinRequestTrials;
-
-    /*!
-     * Maximum number of trials for the Join Request
-     */
-    uint8_t MaxJoinRequestTrials;
-
-    /*!
-     * Mac keys
-     */
-    lora_mac_keys keys;
-
-    /*!
-     * LoRaMac tx/rx operation state
-     */
-    LoRaMacFlags_t LoRaMacFlags;
+    uint8_t buffer[LORAMAC_PHY_MAXPAYLOAD];
 
     /*!
      * Length of packet in LoRaMacBuffer
      */
-    uint16_t LoRaMacBufferPktLen;
+    uint16_t buffer_pkt_len;
+
+    /*!
+     * Buffer containing the upper layer data.
+     */
+    uint8_t payload[LORAMAC_PHY_MAXPAYLOAD];
+
+    /*!
+     * Length of the payload in LoRaMacBuffer
+     */
+    uint8_t payload_length;
+
+    /*!
+     * Number of trials to get a frame acknowledged
+     */
+    uint8_t max_ack_timeout_retries;
+
+    /*!
+     * Number of trials to get a frame acknowledged
+     */
+    uint8_t ack_timeout_retry_counter;
+
+    /*!
+     * Maximum number of trials for the Join Request
+     */
+    uint8_t max_join_request_trials;
+
+    /*!
+     * Number of trials for the Join Request
+     */
+    uint8_t join_request_trial_counter;
+
+    /*!
+     * Mac keys
+     */
+    loramac_keys keys;
+
+    /*!
+     * LoRaMac tx/rx operation state
+     */
+    loramac_flags_t flags;
 
     /*!
      * Device nonce is a random value extracted by issuing a sequence of RSSI
      * measurements
      */
-    uint16_t LoRaMacDevNonce;
+    uint16_t dev_nonce;
 
     /*!
      * Network ID ( 3 bytes )
      */
-    uint32_t LoRaMacNetID;
+    uint32_t net_id;
 
     /*!
      * Mote Address
      */
-    uint32_t LoRaMacDevAddr;
+    uint32_t dev_addr;
 
     /*!
      * LoRaMAC frame counter. Each time a packet is sent the counter is incremented.
      * Only the 16 LSB bits are sent
      */
-    uint32_t UpLinkCounter;
+    uint32_t ul_frame_counter;
 
     /*!
      * LoRaMAC frame counter. Each time a packet is received the counter is incremented.
      * Only the 16 LSB bits are received
      */
-    uint32_t DownLinkCounter;
+    uint32_t dl_frame_counter;
 
     /*!
      * Counts the number of missed ADR acknowledgements
      */
-    uint32_t AdrAckCounter;
+    uint32_t adr_ack_counter;
 
     /*!
      * LoRaMac internal state
      */
-    uint32_t LoRaMacState;
+    uint32_t mac_state;
 
     /*!
      * LoRaMac reception windows delay
      * \remark normal frame: RxWindowXDelay = ReceiveDelayX - RADIO_WAKEUP_TIME
      *         join frame  : RxWindowXDelay = JoinAcceptDelayX - RADIO_WAKEUP_TIME
      */
-    uint32_t RxWindow1Delay;
-    uint32_t RxWindow2Delay;
+    uint32_t rx_window1_delay;
+    uint32_t rx_window2_delay;
 
     /*!
      * Timer objects and stored values
      */
-    lora_mac_timers timers;
+    lorawan_timers timers;
 
     /*!
      * LoRaMac parameters
@@ -3122,15 +2336,15 @@ typedef struct {
     /*!
      * Receive Window configurations for PHY layer
      */
-    RxConfigParams_t RxWindow1Config;
-    RxConfigParams_t RxWindow2Config;
+    rx_config_params_t rx_window1_config;
+    rx_config_params_t rx_window2_config;
 
     /*!
      * Multicast channels linked list
      */
-    MulticastParams_t *MulticastChannels;
+    multicast_params_t *multicast_channels;
 
-} lora_mac_protocol_params;
+} loramac_protocol_params;
 
 /** LoRaWAN callback functions
  *
@@ -3147,11 +2361,11 @@ typedef enum lora_events {
     RX_TIMEOUT,
     RX_ERROR,
     JOIN_FAILURE,
-} lora_events_t;
+} lorawan_events_t;
 
 typedef struct  {
      // Mandatory. Event Callback must be provided
-     mbed::Callback<void(lora_events_t)> events;
+     mbed::Callback<void(lorawan_events_t)> events;
 
      // Rest are optional
      // If the user do not assign these callbacks, these callbacks would return
@@ -3159,11 +2373,16 @@ typedef struct  {
      // link_check_resp callback and other such callbacks will be maped in
      // future releases of Mbed-OS
      mbed::Callback<void(uint8_t, uint8_t)> link_check_resp;
- }lorawan_app_callbacks_t;
+
+     // Battery level callback goes in the down direction, i.e., it informs
+     // the stack about the battery level by calling a function provided
+     // by the upper layers
+     mbed::Callback<uint8_t(void)> battery_level;
+ } lorawan_app_callbacks_t;
 
 typedef struct lora_channelplan {
     uint8_t nb_channels;    // number of channels
-    lora_channels_t *channels;
-} lora_channelplan_t;
+    loramac_channel_t *channels;
+} lorawan_channelplan_t;
 
 #endif /* LORAWAN_SYSTEM_LORAWAN_DATA_STRUCTURES_H_ */

--- a/features/netsocket/LoRaWANBase.h
+++ b/features/netsocket/LoRaWANBase.h
@@ -31,20 +31,20 @@ public:
      *
      * @param queue A pointer to EventQueue provided by the application.
      *
-     * @return         LORA_MAC_STATUS_OK on success, a negative error code on
+     * @return         LORAWAN_STATUS_OK on success, a negative error code on
      *                 failure.
      */
-    virtual lora_mac_status_t initialize(events::EventQueue *queue) = 0;
+    virtual lorawan_status_t initialize(events::EventQueue *queue) = 0;
 
     /** Connect OTAA or ABP by setup.
      *
      * Connect by Over The Air Activation or Activation By Personalization.
      * The connection type is selected at the setup.
      *
-     * @return         LORA_MAC_STATUS_OK on success, a negative error code on
+     * @return         LORAWAN_STATUS_OK on success, a negative error code on
      *                 failure.
      */
-    virtual lora_mac_status_t connect() = 0;
+    virtual lorawan_status_t connect() = 0;
 
     /** Connect OTAA or ABP by parameters
      *
@@ -53,16 +53,16 @@ public:
      * You need to define the parameters in the main application.
      *
      * @param connect       Options how end-device will connect to gateway
-     * @return              LORA_MAC_STATUS_OK on success, negative error code
+     * @return              LORAWAN_STATUS_OK on success, negative error code
      *                      on failure
      */
-    virtual lora_mac_status_t connect(const lorawan_connect_t &connect) = 0;
+    virtual lorawan_status_t connect(const lorawan_connect_t &connect) = 0;
 
     /** Disconnects the current session.
      *
-     * @return         LORA_MAC_STATUS_OK on success, a negative error code on failure.
+     * @return         LORAWAN_STATUS_OK on success, a negative error code on failure.
      */
-    virtual lora_mac_status_t disconnect() = 0;
+    virtual lorawan_status_t disconnect() = 0;
 
     /** Validate the connectivity with the network.
      *
@@ -74,7 +74,7 @@ public:
      *
      * This API is usable only when the link check response is callback set by
      * the application. See add_lora_app_callbacks API. If the above mentioned
-     * callback is not set, a LORA_MAC_STATUS_PARAMETER_INVALID error is thrown.
+     * callback is not set, a LORAWAN_STATUS_PARAMETER_INVALID error is thrown.
      *
      * First parameter to callback function is the demodulation margin and
      * the second parameter is the number of gateways that successfully received
@@ -85,11 +85,11 @@ public:
      * remove_link_check_request() API.
      *
      * @param cb        A callback function to receive link check response
-     * @return          LORA_MAC_STATUS_OK on successfully queuing a request, or
+     * @return          LORAWAN_STATUS_OK on successfully queuing a request, or
      *                  a negative error code on failure.
      *
      */
-    virtual lora_mac_status_t add_link_check_request() = 0;
+    virtual lorawan_status_t add_link_check_request() = 0;
 
     /** Detaches Link Request MAC command.
      *
@@ -102,30 +102,30 @@ public:
      * @param data_rate   Intended data rate e.g., DR_0, DR_1 etc.
      *                    Caution is advised as the macro DR_* can mean different
      *                    things while being in a different region.
-     * @return            LORA_MAC_STATUS_OK if everything goes well, otherwise
+     * @return            LORAWAN_STATUS_OK if everything goes well, otherwise
      *                    a negative error code.
      */
-    virtual lora_mac_status_t set_datarate(uint8_t data_rate) = 0;
+    virtual lorawan_status_t set_datarate(uint8_t data_rate) = 0;
 
     /** Enables adaptive data rate (ADR)
      *
      * Underlying LoRaPHY and LoRaMac layers handle the data rate automatically
      * for the user based upon radio conditions (network congestion).
      *
-     * @return             LORA_MAC_STATUS_OK on success, negative error code
+     * @return             LORAWAN_STATUS_OK on success, negative error code
      *                     on failure.
      */
-    virtual lora_mac_status_t enable_adaptive_datarate() = 0;
+    virtual lorawan_status_t enable_adaptive_datarate() = 0;
 
     /** Disables adaptive data rate
      *
      * When adaptive data rate (ADR) is disabled, user can either set a certain
      * data rate or the Mac layer will choose a default value.
      *
-     * @return             LORA_MAC_STATUS_OK on success, negative error code
+     * @return             LORAWAN_STATUS_OK on success, negative error code
      *                     on failure.
      */
-    virtual lora_mac_status_t disable_adaptive_datarate() = 0;
+    virtual lorawan_status_t disable_adaptive_datarate() = 0;
 
     /** Sets up retry counter for confirmed messages
      *
@@ -141,25 +141,25 @@ public:
      *
      * @param count     number of retries for confirmed messages
      *
-     * @return          LORA_MAC_STATUS_OK or a negative error code
+     * @return          LORAWAN_STATUS_OK or a negative error code
      */
-    virtual lora_mac_status_t set_confirmed_msg_retries(uint8_t count) = 0;
+    virtual lorawan_status_t set_confirmed_msg_retries(uint8_t count) = 0;
 
     /** Sets channel plan
      *
      * @param channel_plan  The defined channel plans to be set.
      * @return              0 on success, a negative error code on failure.
      */
-    virtual lora_mac_status_t set_channel_plan(const lora_channelplan_t &channel_plan) = 0;
+    virtual lorawan_status_t set_channel_plan(const lorawan_channelplan_t &channel_plan) = 0;
 
     /** Gets the current channel plan.
      *
      * @param  channel_plan     The current channel information.
      *
-     * @return                  LORA_MAC_STATUS_OK on success, a negative error
+     * @return                  LORAWAN_STATUS_OK on success, a negative error
      *                          code on failure.
      */
-    virtual lora_mac_status_t get_channel_plan(lora_channelplan_t &channel_plan) = 0;
+    virtual lorawan_status_t get_channel_plan(lorawan_channelplan_t &channel_plan) = 0;
 
     /** Removes currently active channel plan
      *
@@ -167,10 +167,10 @@ public:
      * allowed to be removed. So when a plan is abolished, only non-default
      * channels are removed.
      *
-     * @return                  LORA_MAC_STATUS_OK on success, negative error
+     * @return                  LORAWAN_STATUS_OK on success, negative error
      *                          code on failure
      */
-    virtual lora_mac_status_t remove_channel_plan() = 0;
+    virtual lorawan_status_t remove_channel_plan() = 0;
 
     /** Removes a given single channel
      *
@@ -179,10 +179,10 @@ public:
      *
      * @param    index          The channel index
      *
-     * @return                  LORA_MAC_STATUS_OK on success, negative error
+     * @return                  LORAWAN_STATUS_OK on success, negative error
      *                          code on failure
      */
-    virtual lora_mac_status_t remove_channel(uint8_t index) = 0;
+    virtual lorawan_status_t remove_channel(uint8_t index) = 0;
 
     /** Send message to gateway
      *
@@ -215,7 +215,7 @@ public:
      *
      *
      * @return                  The number of bytes sent, or
-     *                          LORA_MAC_STATUS_WOULD_BLOCK if another TX is
+     *                          LORAWAN_STATUS_WOULD_BLOCK if another TX is
      *                          ongoing, or a negative error code on failure.
      */
     virtual int16_t send(uint8_t port, const uint8_t* data,
@@ -256,7 +256,7 @@ public:
      * @return                  It could be one of these:
      *                             i)   0 if there is nothing else to read.
      *                             ii)  Number of bytes written to user buffer.
-     *                             iii) LORA_MAC_STATUS_WOULD_BLOCK if there is
+     *                             iii) LORAWAN_STATUS_WOULD_BLOCK if there is
      *                                  nothing available to read at the moment.
      *                             iv)  A negative error code on failure.
      */
@@ -331,7 +331,7 @@ public:
      * @param callbacks         A pointer to the structure containing application
      *                          callbacks.
      */
-    virtual lora_mac_status_t add_app_callbacks(lorawan_app_callbacks_t *callbacks) = 0;
+    virtual lorawan_status_t add_app_callbacks(lorawan_app_callbacks_t *callbacks) = 0;
 };
 
 #endif /* LORAWAN_BASE_H_ */


### PR DESCRIPTION
Baseline is changed to use a single set of data structures that simplifies the
code in the LoRaWANStack and Mac layer. We are now following certian rules for naming
data structures.

- All structures visible outside their domain are prefixed as 'lorawan_'
- All mac structures are prefixed as 'loramac_'
- All subsystem or module strucutures carry their name in prefix, like 'mcps_'

PHY layer still have legacy camel case data structures which will be entertained
later while we will be simplifying PHY layer.
Test cases are also updated with the new data structure naming conventions.

One major difference from the previous baseline is the removal of static buffer
from mcps indication. And we do not copy data from stack buffer to rx_msg buffer.
This saves at least 512 bytes.

It may look like now that if we have received something but the user have not read
from the buffer, then the buffer will be overwritten and we will lose previous frame.
Yes, we will. But the same will happen even if we would have copied the buffer into rx_msg
because then the rx_msg gets overwritten. So we decide to abandon copying the buffer at
multiple locations. We inform the user about reception, if the user doesn't read and
the data gets overwritten, then so be it.

