### PR TITLE
[IOTCELL-346] Removing default value storage

### DIFF
--- a/features/lorawan/LoRaWANStack.cpp
+++ b/features/lorawan/LoRaWANStack.cpp
@@ -244,7 +244,7 @@ lorawan_status_t LoRaWANStack::send_compliance_test_frame_to_mac()
         mcps_req.f_buffer_size = _tx_msg.f_buffer_size;
         mcps_req.req.unconfirmed.data_rate = default_datarate.Value;
 
-        tr_info("Transmit unconfirmed compliance test frame %d bytes.", mcps_req.req.unconfirmed.fbuffer_size);
+        tr_info("Transmit unconfirmed compliance test frame %d bytes.", mcps_req.f_buffer_size);
 
         for (uint8_t i = 0; i < mcps_req.f_buffer_size; ++i) {
             tr_info("Byte %d, data is 0x%x", i+1, ((uint8_t*)mcps_req.f_buffer)[i]);
@@ -257,7 +257,7 @@ lorawan_status_t LoRaWANStack::send_compliance_test_frame_to_mac()
         mcps_req.req.confirmed.nb_trials = _num_retry;
         mcps_req.req.confirmed.data_rate = default_datarate.Value;
 
-        tr_info("Transmit confirmed compliance test frame %d bytes.", mcps_req.req.confirmed.fbuffer_size);
+        tr_info("Transmit confirmed compliance test frame %d bytes.", mcps_req.f_buffer_size);
 
         for (uint8_t i = 0; i < mcps_req.f_buffer_size; ++i) {
             tr_info("Byte %d, data is 0x%x", i+1, ((uint8_t*)mcps_req.f_buffer)[i]);

--- a/features/lorawan/lorastack/mac/LoRaMac.cpp
+++ b/features/lorawan/lorastack/mac/LoRaMac.cpp
@@ -1225,6 +1225,8 @@ lorawan_status_t LoRaMac::ScheduleTx( void )
 {
     lorawan_time_t dutyCycleTimeOff = 0;
     NextChanParams_t nextChan;
+    GetPhyParams_t getPhy;
+    PhyParam_t phyParam;
 
     // Check if the device is off
     if( _params.sys_params.max_duty_cycle == 255 )
@@ -1251,7 +1253,9 @@ lorawan_status_t LoRaMac::ScheduleTx( void )
                                       &_params.timers.aggregated_timeoff ) == false )
     {
         // Set the default datarate
-        _params.sys_params.channel_data_rate = _params.def_sys_params.channel_data_rate;
+        getPhy.Attribute = PHY_DEF_TX_DR;
+        phyParam = lora_phy->get_phy_params( &getPhy );
+        _params.sys_params.channel_data_rate = phyParam.Value;
         // Update datarate in the function parameters
         nextChan.Datarate = _params.sys_params.channel_data_rate;
     }
@@ -1330,6 +1334,9 @@ void LoRaMac::CalculateBackOff( uint8_t channel )
 
 void LoRaMac::ResetMacParameters( void )
 {
+    GetPhyParams_t getPhy;
+    PhyParam_t phyParam;
+
     _params.is_nwk_joined = false;
 
     // Counters
@@ -1352,14 +1359,37 @@ void LoRaMac::ResetMacParameters( void )
 
     _params.is_rx_window_enabled = true;
 
-    _params.sys_params.channel_tx_power = _params.def_sys_params.channel_tx_power;
-    _params.sys_params.channel_data_rate = _params.def_sys_params.channel_data_rate;
-    _params.sys_params.rx1_dr_offset = _params.def_sys_params.rx1_dr_offset;
-    _params.sys_params.rx2_channel = _params.def_sys_params.rx2_channel;
-    _params.sys_params.uplink_dwell_time = _params.def_sys_params.uplink_dwell_time;
-    _params.sys_params.downlink_dwell_time = _params.def_sys_params.downlink_dwell_time;
-    _params.sys_params.max_eirp = _params.def_sys_params.max_eirp;
-    _params.sys_params.antenna_gain = _params.def_sys_params.antenna_gain;
+    getPhy.Attribute = PHY_DEF_TX_POWER;
+    phyParam = lora_phy->get_phy_params( &getPhy );
+
+    _params.sys_params.channel_tx_power = phyParam.Value;
+
+    getPhy.Attribute = PHY_DEF_TX_DR;
+    phyParam = lora_phy->get_phy_params( &getPhy );
+    _params.sys_params.channel_data_rate = phyParam.Value;
+
+    getPhy.Attribute = PHY_DEF_DR1_OFFSET;
+    phyParam = lora_phy->get_phy_params( &getPhy );
+    _params.sys_params.rx1_dr_offset = phyParam.Value;
+
+    getPhy.Attribute = PHY_DEF_RX2_FREQUENCY;
+    phyParam = lora_phy->get_phy_params( &getPhy );
+    _params.sys_params.rx2_channel.frequency = phyParam.Value;
+    getPhy.Attribute = PHY_DEF_RX2_DR;
+    phyParam = lora_phy->get_phy_params( &getPhy );
+    _params.sys_params.rx2_channel.datarate = phyParam.Value;
+
+    getPhy.Attribute = PHY_DEF_UPLINK_DWELL_TIME;
+    phyParam = lora_phy->get_phy_params( &getPhy );
+    _params.sys_params.uplink_dwell_time = phyParam.Value;
+
+    getPhy.Attribute = PHY_DEF_MAX_EIRP;
+    phyParam = lora_phy->get_phy_params( &getPhy );
+    _params.sys_params.max_eirp = phyParam.Value;
+
+    getPhy.Attribute = PHY_DEF_ANTENNA_GAIN;
+    phyParam = lora_phy->get_phy_params( &getPhy );
+    _params.sys_params.antenna_gain = phyParam.Value;
 
     _params.is_node_ack_requested = false;
     _params.is_srv_ack_requested = false;
@@ -1727,75 +1757,66 @@ lorawan_status_t LoRaMac::LoRaMacInitialization(loramac_primitives_t *primitives
 
     getPhy.Attribute = PHY_DEF_TX_POWER;
     phyParam = lora_phy->get_phy_params( &getPhy );
-    _params.def_sys_params.channel_tx_power = phyParam.Value;
+    _params.sys_params.channel_tx_power = phyParam.Value;
 
     getPhy.Attribute = PHY_DEF_TX_DR;
     phyParam = lora_phy->get_phy_params( &getPhy );
-    _params.def_sys_params.channel_data_rate = phyParam.Value;
+    _params.sys_params.channel_data_rate = phyParam.Value;
 
     getPhy.Attribute = PHY_MAX_RX_WINDOW;
     phyParam = lora_phy->get_phy_params( &getPhy );
-    _params.def_sys_params.max_rx_win_time = phyParam.Value;
+    _params.sys_params.max_rx_win_time = phyParam.Value;
 
     getPhy.Attribute = PHY_RECEIVE_DELAY1;
     phyParam = lora_phy->get_phy_params( &getPhy );
-    _params.def_sys_params.recv_delay1 = phyParam.Value;
+    _params.sys_params.recv_delay1 = phyParam.Value;
 
     getPhy.Attribute = PHY_RECEIVE_DELAY2;
     phyParam = lora_phy->get_phy_params( &getPhy );
-    _params.def_sys_params.recv_delay2 = phyParam.Value;
+    _params.sys_params.recv_delay2 = phyParam.Value;
 
     getPhy.Attribute = PHY_JOIN_ACCEPT_DELAY1;
     phyParam = lora_phy->get_phy_params( &getPhy );
-    _params.def_sys_params.join_accept_delay1 = phyParam.Value;
+    _params.sys_params.join_accept_delay1 = phyParam.Value;
 
     getPhy.Attribute = PHY_JOIN_ACCEPT_DELAY2;
     phyParam = lora_phy->get_phy_params( &getPhy );
-    _params.def_sys_params.join_accept_delay2 = phyParam.Value;
+    _params.sys_params.join_accept_delay2 = phyParam.Value;
 
     getPhy.Attribute = PHY_DEF_DR1_OFFSET;
     phyParam = lora_phy->get_phy_params( &getPhy );
-    _params.def_sys_params.rx1_dr_offset = phyParam.Value;
+    _params.sys_params.rx1_dr_offset = phyParam.Value;
 
     getPhy.Attribute = PHY_DEF_RX2_FREQUENCY;
     phyParam = lora_phy->get_phy_params( &getPhy );
-    _params.def_sys_params.rx2_channel.frequency = phyParam.Value;
+    _params.sys_params.rx2_channel.frequency = phyParam.Value;
 
     getPhy.Attribute = PHY_DEF_RX2_DR;
     phyParam = lora_phy->get_phy_params( &getPhy );
-    _params.def_sys_params.rx2_channel.datarate = phyParam.Value;
+    _params.sys_params.rx2_channel.datarate = phyParam.Value;
 
     getPhy.Attribute = PHY_DEF_UPLINK_DWELL_TIME;
     phyParam = lora_phy->get_phy_params( &getPhy );
-    _params.def_sys_params.uplink_dwell_time = phyParam.Value;
+    _params.sys_params.uplink_dwell_time = phyParam.Value;
 
     getPhy.Attribute = PHY_DEF_DOWNLINK_DWELL_TIME;
     phyParam = lora_phy->get_phy_params( &getPhy );
-    _params.def_sys_params.downlink_dwell_time = phyParam.Value;
+    _params.sys_params.downlink_dwell_time = phyParam.Value;
 
     getPhy.Attribute = PHY_DEF_MAX_EIRP;
     phyParam = lora_phy->get_phy_params( &getPhy );
-    _params.def_sys_params.max_eirp = phyParam.fValue;
+    _params.sys_params.max_eirp = phyParam.fValue;
 
     getPhy.Attribute = PHY_DEF_ANTENNA_GAIN;
     phyParam = lora_phy->get_phy_params( &getPhy );
-    _params.def_sys_params.antenna_gain = phyParam.fValue;
+    _params.sys_params.antenna_gain = phyParam.fValue;
 
     lora_phy->load_defaults(INIT_TYPE_INIT);
 
     // Init parameters which are not set in function ResetMacParameters
-    _params.def_sys_params.retry_num = 1;
-    _params.def_sys_params.max_sys_rx_error = 10;
-    _params.def_sys_params.min_rx_symb = 6;
-
-    _params.sys_params.max_sys_rx_error = _params.def_sys_params.max_sys_rx_error;
-    _params.sys_params.min_rx_symb = _params.def_sys_params.min_rx_symb;
-    _params.sys_params.max_rx_win_time = _params.def_sys_params.max_rx_win_time;
-    _params.sys_params.recv_delay1 = _params.def_sys_params.recv_delay1;
-    _params.sys_params.recv_delay2 = _params.def_sys_params.recv_delay2;
-    _params.sys_params.join_accept_delay1 = _params.def_sys_params.join_accept_delay1;
-    _params.sys_params.join_accept_delay2 = _params.def_sys_params.join_accept_delay2;
-    _params.sys_params.retry_num = _params.def_sys_params.retry_num;
+    _params.sys_params.max_sys_rx_error = 10;
+    _params.sys_params.min_rx_symb = 6;
+    _params.sys_params.retry_num = 1;
 
     ResetMacParameters( );
 
@@ -1831,8 +1852,8 @@ lorawan_status_t LoRaMac::LoRaMacQueryTxPossible( uint8_t size, loramac_tx_info_
     AdrNextParams_t adrNext;
     GetPhyParams_t getPhy;
     PhyParam_t phyParam;
-    int8_t datarate = _params.def_sys_params.channel_data_rate;
-    int8_t txPower = _params.def_sys_params.channel_tx_power;
+    int8_t datarate = _params.sys_params.channel_data_rate;
+    int8_t txPower = _params.sys_params.channel_tx_power;
     uint8_t fOptLen = mac_commands.GetLength() + mac_commands.GetRepeatLength();
 
     if( txInfo == NULL )

--- a/features/lorawan/lorastack/mac/LoRaMacMib.cpp
+++ b/features/lorawan/lorastack/mac/LoRaMacMib.cpp
@@ -158,7 +158,7 @@ lorawan_status_t LoRaMacMib::set_request(loramac_mib_req_confirm_t *mibSet,
             verify.DatarateParams.DownlinkDwellTime = params->sys_params.downlink_dwell_time;
 
             if (_lora_phy->verify(&verify, PHY_RX_DR) == true) {
-                params->def_sys_params.rx2_channel = mibSet->param.default_rx2_channel;
+                params->sys_params.rx2_channel = mibSet->param.default_rx2_channel;
             } else {
                 status = LORAWAN_STATUS_PARAMETER_INVALID;
             }
@@ -215,7 +215,7 @@ lorawan_status_t LoRaMacMib::set_request(loramac_mib_req_confirm_t *mibSet,
             verify.DatarateParams.Datarate = mibSet->param.default_channel_data_rate;
 
             if (_lora_phy->verify(&verify, PHY_DEF_TX_DR) == true) {
-                params->def_sys_params.channel_data_rate = verify.DatarateParams.Datarate;
+                params->sys_params.channel_data_rate = verify.DatarateParams.Datarate;
             } else {
                 status = LORAWAN_STATUS_PARAMETER_INVALID;
             }
@@ -236,7 +236,7 @@ lorawan_status_t LoRaMacMib::set_request(loramac_mib_req_confirm_t *mibSet,
             verify.TxPower = mibSet->param.default_channel_tx_pwr;
 
             if (_lora_phy->verify(&verify, PHY_DEF_TX_POWER) == true) {
-                params->def_sys_params.channel_tx_power = verify.TxPower;
+                params->sys_params.channel_tx_power = verify.TxPower;
             } else {
                 status = LORAWAN_STATUS_PARAMETER_INVALID;
             }
@@ -261,15 +261,11 @@ lorawan_status_t LoRaMacMib::set_request(loramac_mib_req_confirm_t *mibSet,
             break;
         }
         case MIB_SYSTEM_MAX_RX_ERROR: {
-            params->sys_params.max_sys_rx_error =
-                    params->def_sys_params.max_sys_rx_error =
-                            mibSet->param.max_rx_sys_error;
+            params->sys_params.max_sys_rx_error = mibSet->param.max_rx_sys_error;
             break;
         }
         case MIB_MIN_RX_SYMBOLS: {
-            params->sys_params.min_rx_symb =
-                    params->def_sys_params.min_rx_symb =
-                            mibSet->param.min_rx_symb;
+            params->sys_params.min_rx_symb = mibSet->param.min_rx_symb;
             break;
         }
         case MIB_ANTENNA_GAIN: {
@@ -290,6 +286,7 @@ lorawan_status_t LoRaMacMib::get_request(loramac_mib_req_confirm_t *mibGet,
     lorawan_status_t status = LORAWAN_STATUS_OK;
     GetPhyParams_t getPhy;
     PhyParam_t phyParam;
+    rx2_channel_params rx2_channel;
 
     if( mibGet == NULL )
     {
@@ -358,7 +355,15 @@ lorawan_status_t LoRaMacMib::get_request(loramac_mib_req_confirm_t *mibGet,
         }
         case MIB_RX2_DEFAULT_CHANNEL:
         {
-            mibGet->param.rx2_channel = params->def_sys_params.rx2_channel;
+            getPhy.Attribute = PHY_DEF_RX2_DR;
+            phyParam = _lora_phy->get_phy_params( &getPhy );
+            rx2_channel.datarate = phyParam.Value;
+
+            getPhy.Attribute = PHY_DEF_RX2_FREQUENCY;
+            phyParam = _lora_phy->get_phy_params( &getPhy );
+            rx2_channel.frequency = phyParam.Value;
+
+            mibGet->param.rx2_channel = rx2_channel;
             break;
         }
         case MIB_CHANNELS_DEFAULT_MASK:
@@ -409,7 +414,9 @@ lorawan_status_t LoRaMacMib::get_request(loramac_mib_req_confirm_t *mibGet,
         }
         case MIB_CHANNELS_DEFAULT_DATARATE:
         {
-            mibGet->param.default_channel_data_rate = params->def_sys_params.channel_data_rate;
+            getPhy.Attribute = PHY_DEF_TX_DR;
+            phyParam = _lora_phy->get_phy_params( &getPhy );
+            mibGet->param.default_channel_data_rate = phyParam.Value;
             break;
         }
         case MIB_CHANNELS_DATARATE:
@@ -419,7 +426,9 @@ lorawan_status_t LoRaMacMib::get_request(loramac_mib_req_confirm_t *mibGet,
         }
         case MIB_CHANNELS_DEFAULT_TX_POWER:
         {
-            mibGet->param.default_channel_tx_pwr = params->def_sys_params.channel_tx_power;
+            getPhy.Attribute = PHY_DEF_TX_POWER;
+            phyParam = _lora_phy->get_phy_params( &getPhy );
+            mibGet->param.default_channel_tx_pwr = phyParam.Value;
             break;
         }
         case MIB_CHANNELS_TX_POWER:

--- a/features/lorawan/system/lorawan_data_structures.h
+++ b/features/lorawan/system/lorawan_data_structures.h
@@ -2329,11 +2329,6 @@ typedef struct {
     lora_mac_system_params_t sys_params;
 
     /*!
-     * LoRaMac default parameters
-     */
-    lora_mac_system_params_t def_sys_params;
-
-    /*!
      * Receive Window configurations for PHY layer
      */
     rx_config_params_t rx_window1_config;


### PR DESCRIPTION
We now save roughly 500 bytes by removing storage of default
parameters in the loramac_params_t data structure. We use Mib to
get default values from PHY whenever needed instead.

loramac_sys_arams_t now contains only the runtime values set during operation
whenever defaults are needed we directly query the PHY layer or via Mib as the
need maybe.

