### PR TITLE
Add check for event call

### DIFF
--- a/features/lorawan/LoRaWANStack.cpp
+++ b/features/lorawan/LoRaWANStack.cpp
@@ -797,7 +797,9 @@ void LoRaWANStack::mlme_confirm_handler(loramac_mlme_confirm_t *mlme_confirm)
                 lora_state_machine();
 
                 if (_callbacks.events) {
-                    _queue->call(_callbacks.events, JOIN_FAILURE);
+                    const int ret = _queue->call(_callbacks.events, JOIN_FAILURE);
+                    MBED_ASSERT(ret != 0);
+                    (void)ret;
                 }
             }
             break;
@@ -815,9 +817,11 @@ void LoRaWANStack::mlme_confirm_handler(loramac_mlme_confirm_t *mlme_confirm)
                 {
                     // normal operation as oppose to compliance testing
                     if (_callbacks.link_check_resp) {
-                        _queue->call(_callbacks.link_check_resp,
-                                     mlme_confirm->demod_margin,
-                                     mlme_confirm->nb_gateways);
+                        const int ret = _queue->call(_callbacks.link_check_resp,
+                                                     mlme_confirm->demod_margin,
+                                                     mlme_confirm->nb_gateways);
+                        MBED_ASSERT(ret != 0);
+                        (void)ret;
                     }
                 }
             }
@@ -862,7 +866,9 @@ void LoRaWANStack::mcps_confirm_handler(loramac_mcps_confirm_t *mcps_confirm)
         // If sending timed out, we have a special event for that
         if (mcps_confirm->status == LORAMAC_EVENT_INFO_STATUS_TX_TIMEOUT) {
             if (_callbacks.events) {
-                _queue->call(_callbacks.events, TX_TIMEOUT);
+                const int ret = _queue->call(_callbacks.events, TX_TIMEOUT);
+                MBED_ASSERT(ret != 0);
+                (void)ret;
             }
             return;
         } if (mcps_confirm->status == LORAMAC_EVENT_INFO_STATUS_RX2_TIMEOUT) {
@@ -871,7 +877,9 @@ void LoRaWANStack::mcps_confirm_handler(loramac_mcps_confirm_t *mcps_confirm)
 
         // Otherwise send a general TX_ERROR event
         if (_callbacks.events) {
-            _queue->call(_callbacks.events, TX_ERROR);
+            const int ret = _queue->call(_callbacks.events, TX_ERROR);
+            MBED_ASSERT(ret != 0);
+            (void)ret;
         }
         return;
     }
@@ -893,7 +901,9 @@ void LoRaWANStack::mcps_confirm_handler(loramac_mcps_confirm_t *mcps_confirm)
     _lw_session.uplink_counter = mcps_confirm->ul_frame_counter;
     _tx_msg.tx_ongoing = false;
      if (_callbacks.events) {
-         _queue->call(_callbacks.events, TX_DONE);
+         const int ret = _queue->call(_callbacks.events, TX_DONE);
+         MBED_ASSERT(ret != 0);
+         (void)ret;
      }
 }
 
@@ -911,7 +921,9 @@ void LoRaWANStack::mcps_indication_handler(loramac_mcps_indication_t *mcps_indic
 
     if (mcps_indication->status != LORAMAC_EVENT_INFO_STATUS_OK) {
         if (_callbacks.events) {
-            _queue->call(_callbacks.events, RX_ERROR);
+            const int ret = _queue->call(_callbacks.events, RX_ERROR);
+            MBED_ASSERT(ret != 0);
+            (void)ret;
         }
         return;
     }
@@ -968,7 +980,9 @@ void LoRaWANStack::mcps_indication_handler(loramac_mcps_indication_t *mcps_indic
                     // to the size 255 bytes
                     tr_debug("Cannot receive more than buffer capacity!");
                     if (_callbacks.events) {
-                        _queue->call(_callbacks.events, RX_ERROR);
+                        const int ret = _queue->call(_callbacks.events, RX_ERROR);
+                        MBED_ASSERT(ret != 0);
+                        (void)ret;
                     }
                     return;
                 } else {
@@ -984,7 +998,9 @@ void LoRaWANStack::mcps_indication_handler(loramac_mcps_indication_t *mcps_indic
                 tr_debug("Received %d bytes", _rx_msg.msg.mcps_indication.buffer_size);
                 _rx_msg.receive_ready = true;
                 if (_callbacks.events) {
-                    _queue->call(_callbacks.events, RX_DONE);
+                    const int ret = _queue->call(_callbacks.events, RX_DONE);
+                    MBED_ASSERT(ret != 0);
+                    (void)ret;
                 }
 
                 // If fPending bit is set we try to generate an empty packet
@@ -1216,7 +1232,9 @@ lorawan_status_t LoRaWANStack::lora_state_machine()
 
             tr_debug("LoRaWAN protocol has been shut down.");
             if (_callbacks.events) {
-                _queue->call(_callbacks.events, DISCONNECTED);
+                const int ret = _queue->call(_callbacks.events, DISCONNECTED);
+                MBED_ASSERT(ret != 0);
+                (void)ret;
             }
             status = LORAWAN_STATUS_DEVICE_OFF;
             break;
@@ -1260,7 +1278,9 @@ lorawan_status_t LoRaWANStack::lora_state_machine()
             _lw_session.active = true;
             // Tell the application that we are connected
             if (_callbacks.events) {
-                _queue->call(_callbacks.events, CONNECTED);
+                const int ret = _queue->call(_callbacks.events, CONNECTED);
+                MBED_ASSERT(ret != 0);
+                (void)ret;
             }
             break;
         case DEVICE_STATE_ABP_CONNECTING:
@@ -1294,7 +1314,9 @@ lorawan_status_t LoRaWANStack::lora_state_machine()
             // Session is now active
             _lw_session.active = true;
             if (_callbacks.events) {
-                _queue->call(_callbacks.events, CONNECTED);
+                const int ret = _queue->call(_callbacks.events, CONNECTED);
+                MBED_ASSERT(ret != 0);
+                (void)ret;
             }
             break;
         case DEVICE_STATE_SEND:
@@ -1312,13 +1334,17 @@ lorawan_status_t LoRaWANStack::lora_state_machine()
                     case LORAWAN_STATUS_CRYPTO_FAIL:
                         tr_error("Crypto failed. Clearing TX buffers");
                         if (_callbacks.events) {
-                            _queue->call(_callbacks.events, TX_CRYPTO_ERROR);
+                            const int ret = _queue->call(_callbacks.events, TX_CRYPTO_ERROR);
+                            MBED_ASSERT(ret != 0);
+                            (void)ret;
                         }
                         break;
                     default:
                         tr_error("Failure to schedule TX!");
                         if (_callbacks.events) {
-                            _queue->call(_callbacks.events, TX_SCHEDULING_ERROR);
+                            const int ret = _queue->call(_callbacks.events, TX_SCHEDULING_ERROR);
+                            MBED_ASSERT(ret != 0);
+                            (void)ret;
                         }
                         break;
                 }

--- a/features/lorawan/LoRaWANStack.cpp
+++ b/features/lorawan/LoRaWANStack.cpp
@@ -827,7 +827,6 @@ void LoRaWANStack::mlme_confirm_handler(loramac_mlme_confirm_t *mlme_confirm)
             }
             break;
         default:
-            return;
             break;
     }
 }
@@ -1269,7 +1268,6 @@ lorawan_status_t LoRaWANStack::lora_state_machine()
                 return LORAWAN_STATUS_CONNECT_IN_PROGRESS;
             } else {
                 status = LORAWAN_STATUS_PARAMETER_INVALID;
-                break;
             }
             break;
         case DEVICE_STATE_JOINED:

--- a/features/lorawan/lorastack/mac/LoRaMac.cpp
+++ b/features/lorawan/lorastack/mac/LoRaMac.cpp
@@ -129,64 +129,88 @@ LoRaMac::~LoRaMac()
  **************************************************************************/
 void LoRaMac::handle_tx_done(void)
 {
-    ev_queue->call(this, &LoRaMac::OnRadioTxDone);
+    const int ret = ev_queue->call(this, &LoRaMac::OnRadioTxDone);
+    MBED_ASSERT(ret != 0);
+    (void)ret;
 }
 
 void LoRaMac::handle_rx_done(uint8_t *payload, uint16_t size, int16_t rssi, int8_t snr)
 {
-    ev_queue->call(this, &LoRaMac::OnRadioRxDone, payload, size, rssi, snr);
+    const int ret = ev_queue->call(this, &LoRaMac::OnRadioRxDone, payload, size, rssi, snr);
+    MBED_ASSERT(ret != 0);
+    (void)ret;
 }
 
 void LoRaMac::handle_rx_error(void)
 {
-    ev_queue->call(this, &LoRaMac::OnRadioRxError);
+    const int ret = ev_queue->call(this, &LoRaMac::OnRadioRxError);
+    MBED_ASSERT(ret != 0);
+    (void)ret;
 }
 
 void LoRaMac::handle_rx_timeout(void)
 {
-    ev_queue->call(this, &LoRaMac::OnRadioRxTimeout);
+    const int ret = ev_queue->call(this, &LoRaMac::OnRadioRxTimeout);
+    MBED_ASSERT(ret != 0);
+    (void)ret;
 }
 
 void LoRaMac::handle_tx_timeout(void)
 {
-    ev_queue->call(this, &LoRaMac::OnRadioTxTimeout);
+    const int ret = ev_queue->call(this, &LoRaMac::OnRadioTxTimeout);
+    MBED_ASSERT(ret != 0);
+    (void)ret;
 }
 
 void LoRaMac::handle_cad_done(bool cad)
 {
     //TODO Not implemented yet
-    //ev_queue->call(this, &LoRaMac::OnRadioCadDone, cad);
+    //const int ret = ev_queue->call(this, &LoRaMac::OnRadioCadDone, cad);
+    //MBED_ASSERT(ret != 0);
+    //(void)ret;
 }
 
 void LoRaMac::handle_fhss_change_channel(uint8_t cur_channel)
 {
     // TODO Not implemented yet
-    //ev_queue->call(this, &LoRaMac::OnRadioFHSSChangeChannel, cur_channel);
+    //const int ret = ev_queue->call(this, &LoRaMac::OnRadioFHSSChangeChannel, cur_channel);
+    //MBED_ASSERT(ret != 0);
+    //(void)ret;
 }
 
 void LoRaMac::handle_mac_state_check_timer_event(void)
 {
-    ev_queue->call(this, &LoRaMac::OnMacStateCheckTimerEvent);
+    const int ret = ev_queue->call(this, &LoRaMac::OnMacStateCheckTimerEvent);
+    MBED_ASSERT(ret != 0);
+    (void)ret;
 }
 
 void LoRaMac::handle_delayed_tx_timer_event(void)
 {
-    ev_queue->call(this, &LoRaMac::OnTxDelayedTimerEvent);
+    const int ret = ev_queue->call(this, &LoRaMac::OnTxDelayedTimerEvent);
+    MBED_ASSERT(ret != 0);
+    (void)ret;
 }
 
 void LoRaMac::handle_ack_timeout()
 {
-    ev_queue->call(this, &LoRaMac::OnAckTimeoutTimerEvent);
+    const int ret = ev_queue->call(this, &LoRaMac::OnAckTimeoutTimerEvent);
+    MBED_ASSERT(ret != 0);
+    (void)ret;
 }
 
 void LoRaMac::handle_rx1_timer_event(void)
 {
-    ev_queue->call(this, &LoRaMac::OnRxWindow1TimerEvent);
+    const int ret = ev_queue->call(this, &LoRaMac::OnRxWindow1TimerEvent);
+    MBED_ASSERT(ret != 0);
+    (void)ret;
 }
 
 void LoRaMac::handle_rx2_timer_event(void)
 {
-    ev_queue->call(this, &LoRaMac::OnRxWindow2TimerEvent);
+    const int ret = ev_queue->call(this, &LoRaMac::OnRxWindow2TimerEvent);
+    MBED_ASSERT(ret != 0);
+    (void)ret;
 }
 
 /***************************************************************************

--- a/features/lorawan/lorastack/mac/LoRaMacMcps.cpp
+++ b/features/lorawan/lorastack/mac/LoRaMacMcps.cpp
@@ -121,7 +121,7 @@ lorawan_status_t LoRaMacMcps::set_request(loramac_mcps_req_t *mcpsRequest,
 
     // Apply the minimum possible datarate.
     // Some regions have limitations for the minimum datarate.
-    datarate = MAX(datarate, phyParam.Value);
+    datarate = MAX(datarate, (int8_t)phyParam.Value);
 
     if (readyToSend == true) {
         if (params->sys_params.adr_on == false) {


### PR DESCRIPTION
In order to track possible event allocation failure, return value of event call
needs to be checked.
This commit adds assert to check that event allocation has succeeded.

This PR also fixes few build warnings.