### PR TITLE
Change region configuration help format

### DIFF
--- a/features/lorawan/mbed_lib.json
+++ b/features/lorawan/mbed_lib.json
@@ -2,16 +2,7 @@
     "name": "lora",
     "config": {
         "phy": {
-            "help": ["Select LoRa PHY layer. See README.md for more information. Default: 0 = LORA_PHY_EU868",
-            "                                                                             1 = LORA_PHY_AS923",
-            "                                                                             2 = LORA_PHY_AU915",
-            "                                                                             3 = LORA_PHY_CN470",
-            "                                                                             4 = LORA_PHY_CN779",
-            "                                                                             5 = LORA_PHY_EU433",
-            "                                                                             6 = LORA_PHY_IN865",
-            "                                                                             7 = LORA_PHY_KR920",
-            "                                                                             8 = LORA_PHY_US915",
-            "                                                                             9 = LORA_PHY_US915_HYBRID"],
+            "help": "LoRa PHY region. 0 = EU868 (default), 1 = AS923, 2 = AU915, 3 = CN470, 4 = CN779, 5 = EU433, 6 = IN865, 7 = KR920, 8 = US915, 9 = US915_HYBRID",
             "value": "0"
         },
         "over-the-air-activation": {


### PR DESCRIPTION
New mbed os configuration parser no longer seems to allow multiline help description.