### PR TITLE
Style changes for LoRaWANTimer to match Mbed-OS guidelines

### DIFF
--- a/features/lorawan/LoRaWANStack.cpp
+++ b/features/lorawan/LoRaWANStack.cpp
@@ -153,7 +153,7 @@ lorawan_status_t LoRaWANStack::initialize_mac_layer(EventQueue *queue)
     _compliance_test.app_data_buffer = compliance_test_buffer;
 #endif
 
-    _lora_time.TimerTimeCounterInit(queue);
+    _lora_time.activate_timer_subsystem(queue);
     _loramac.LoRaMacInitialization(&LoRaMacPrimitives, &_lora_phy, queue);
 
     loramac_mib_req_confirm_t mib_req;
@@ -680,7 +680,7 @@ int16_t LoRaWANStack::handle_tx(uint8_t port, const uint8_t* data,
 
     // send user the length of data which is scheduled now.
     // user should take care of the pending data.
-    return (status == LORAWAN_STATUS_OK) ? _tx_msg.f_buffer_size : status;
+    return (status == LORAWAN_STATUS_OK) ? _tx_msg.f_buffer_size : (int16_t) status;
 }
 
 int16_t LoRaWANStack::handle_rx(const uint8_t port, uint8_t* data,

--- a/features/lorawan/lorastack/mac/LoRaMac.cpp
+++ b/features/lorawan/lorastack/mac/LoRaMac.cpp
@@ -221,7 +221,7 @@ void LoRaMac::OnRadioTxDone( void )
     get_phy_params_t getPhy;
     phy_param_t phyParam;
     set_band_txdone_params_t txDone;
-    lorawan_time_t curTime = _lora_time.TimerGetCurrentTime( );
+    lorawan_time_t curTime = _lora_time.get_current_time( );
     loramac_mlme_confirm_t mlme_confirm = mlme.get_confirmation();
 
     if( _params.dev_class != CLASS_C )
@@ -236,16 +236,16 @@ void LoRaMac::OnRadioTxDone( void )
     // Setup timers
     if( _params.is_rx_window_enabled == true )
     {
-        _lora_time.TimerStart( _params.timers.rx_window1_timer, _params.rx_window1_delay );
+        _lora_time.start( _params.timers.rx_window1_timer, _params.rx_window1_delay );
         if( _params.dev_class != CLASS_C )
         {
-            _lora_time.TimerStart( _params.timers.rx_window2_timer, _params.rx_window2_delay );
+            _lora_time.start( _params.timers.rx_window2_timer, _params.rx_window2_delay );
         }
         if( ( _params.dev_class == CLASS_C ) || ( _params.is_node_ack_requested == true ) )
         {
             getPhy.attribute = PHY_ACK_TIMEOUT;
             phyParam = lora_phy->get_phy_params(&getPhy);
-            _lora_time.TimerStart( _params.timers.ack_timeout_timer, _params.rx_window2_delay + phyParam.value );
+            _lora_time.start( _params.timers.ack_timeout_timer, _params.rx_window2_delay + phyParam.value );
         }
     }
     else
@@ -300,7 +300,7 @@ void LoRaMac::PrepareRxDoneAbort( void )
     _params.flags.bits.mac_done = 1;
 
     // Trig OnMacCheckTimerEvent call as soon as possible
-    _lora_time.TimerStart( _params.timers.mac_state_check_timer, 1 );
+    _lora_time.start( _params.timers.mac_state_check_timer, 1 );
 }
 
 void LoRaMac::OnRadioRxDone( uint8_t *payload, uint16_t size, int16_t rssi, int8_t snr )
@@ -348,7 +348,7 @@ void LoRaMac::OnRadioRxDone( uint8_t *payload, uint16_t size, int16_t rssi, int8
 
     lora_phy->put_radio_to_sleep();
 
-    _lora_time.TimerStop( _params.timers.rx_window2_timer );
+    _lora_time.stop( _params.timers.rx_window2_timer );
 
     macHdr.value = payload[pktHeaderLen++];
 
@@ -701,7 +701,7 @@ void LoRaMac::OnRadioRxDone( uint8_t *payload, uint16_t size, int16_t rssi, int8
 
                             // Stop the AckTimeout timer as no more retransmissions
                             // are needed.
-                            _lora_time.TimerStop( _params.timers.ack_timeout_timer );
+                            _lora_time.stop( _params.timers.ack_timeout_timer );
                         }
                         else
                         {
@@ -711,7 +711,7 @@ void LoRaMac::OnRadioRxDone( uint8_t *payload, uint16_t size, int16_t rssi, int8
                             {
                                 // Stop the AckTimeout timer as no more retransmissions
                                 // are needed.
-                                _lora_time.TimerStop( _params.timers.ack_timeout_timer );
+                                _lora_time.stop( _params.timers.ack_timeout_timer );
                             }
                         }
                     }
@@ -749,7 +749,7 @@ void LoRaMac::OnRadioRxDone( uint8_t *payload, uint16_t size, int16_t rssi, int8
     _params.flags.bits.mac_done = 1;
 
     // Trig OnMacCheckTimerEvent call as soon as possible
-    _lora_time.TimerStart( _params.timers.mac_state_check_timer, 1 );
+    _lora_time.start( _params.timers.mac_state_check_timer, 1 );
 }
 
 void LoRaMac::OnRadioTxTimeout( void )
@@ -790,9 +790,9 @@ void LoRaMac::OnRadioRxError( void )
 
         mlme.get_confirmation().status = LORAMAC_EVENT_INFO_STATUS_RX1_ERROR;
 
-        if( _lora_time.TimerGetElapsedTime( _params.timers.aggregated_last_tx_time ) >= _params.rx_window2_delay )
+        if( _lora_time.get_elapsed_time( _params.timers.aggregated_last_tx_time ) >= _params.rx_window2_delay )
         {
-            _lora_time.TimerStop( _params.timers.rx_window2_timer );
+            _lora_time.stop( _params.timers.rx_window2_timer );
             _params.flags.bits.mac_done = 1;
         }
     }
@@ -828,9 +828,9 @@ void LoRaMac::OnRadioRxTimeout( void )
         }
         mlme.get_confirmation().status = LORAMAC_EVENT_INFO_STATUS_RX1_TIMEOUT;
 
-        if( _lora_time.TimerGetElapsedTime( _params.timers.aggregated_last_tx_time ) >= _params.rx_window2_delay )
+        if( _lora_time.get_elapsed_time( _params.timers.aggregated_last_tx_time ) >= _params.rx_window2_delay )
         {
-            _lora_time.TimerStop( _params.timers.rx_window2_timer );
+            _lora_time.stop( _params.timers.rx_window2_timer );
             _params.flags.bits.mac_done = 1;
         }
     }
@@ -859,7 +859,7 @@ void LoRaMac::OnMacStateCheckTimerEvent( void )
     phy_param_t phyParam;
     bool txTimeout = false;
 
-    _lora_time.TimerStop( _params.timers.mac_state_check_timer );
+    _lora_time.stop( _params.timers.mac_state_check_timer );
 
     if( _params.flags.bits.mac_done == 1 )
     {
@@ -1044,7 +1044,7 @@ void LoRaMac::OnMacStateCheckTimerEvent( void )
     else
     {
         // Operation not finished restart timer
-        _lora_time.TimerStart( _params.timers.mac_state_check_timer, MAC_STATE_CHECK_TIMEOUT );
+        _lora_time.start( _params.timers.mac_state_check_timer, MAC_STATE_CHECK_TIMEOUT );
     }
 
     // Handle MCPS indication
@@ -1077,7 +1077,7 @@ void LoRaMac::OnTxDelayedTimerEvent( void )
 
     lorawan_status_t status = LORAWAN_STATUS_OK;
 
-    _lora_time.TimerStop( _params.timers.tx_delayed_timer );
+    _lora_time.stop( _params.timers.tx_delayed_timer );
     _params.mac_state &= ~LORAMAC_TX_DELAYED;
 
     if( ( _params.flags.bits.mlme_req == 1 ) && ( mlme.get_confirmation().req_type == MLME_JOIN ) )
@@ -1107,7 +1107,7 @@ void LoRaMac::OnTxDelayedTimerEvent( void )
 
 void LoRaMac::OnRxWindow1TimerEvent( void )
 {
-    _lora_time.TimerStop( _params.timers.rx_window1_timer );
+    _lora_time.stop( _params.timers.rx_window1_timer );
     _params.rx_slot= RX_SLOT_WIN_1;
 
     _params.rx_window1_config.channel = _params.channel;
@@ -1128,7 +1128,7 @@ void LoRaMac::OnRxWindow1TimerEvent( void )
 
 void LoRaMac::OnRxWindow2TimerEvent( void )
 {
-    _lora_time.TimerStop( _params.timers.rx_window2_timer );
+    _lora_time.stop( _params.timers.rx_window2_timer );
 
     _params.rx_window2_config.channel = _params.channel;
     _params.rx_window2_config.frequency = _params.sys_params.rx2_channel.frequency;
@@ -1155,7 +1155,7 @@ void LoRaMac::OnRxWindow2TimerEvent( void )
 
 void LoRaMac::OnAckTimeoutTimerEvent( void )
 {
-    _lora_time.TimerStop( _params.timers.ack_timeout_timer );
+    _lora_time.stop( _params.timers.ack_timeout_timer );
 
     if( _params.is_node_ack_requested == true )
     {
@@ -1324,7 +1324,7 @@ lorawan_status_t LoRaMac::ScheduleTx( void )
         _params.mac_state |= LORAMAC_TX_DELAYED;
         tr_debug("Next Transmission in %lu ms", dutyCycleTimeOff);
 
-        _lora_time.TimerStart( _params.timers.tx_delayed_timer, dutyCycleTimeOff );
+        _lora_time.start( _params.timers.tx_delayed_timer, dutyCycleTimeOff );
 
         return LORAWAN_STATUS_OK;
     }
@@ -1338,7 +1338,7 @@ void LoRaMac::CalculateBackOff( uint8_t channel )
     _params.is_dutycycle_on = MBED_CONF_LORA_DUTY_CYCLE_ON;
     calcBackOff.dc_enabled = _params.is_dutycycle_on;
     calcBackOff.channel = channel;
-    calcBackOff.elapsed_time = _lora_time.TimerGetElapsedTime( _params.timers.mac_init_time );
+    calcBackOff.elapsed_time = _lora_time.get_elapsed_time( _params.timers.mac_init_time );
     calcBackOff.tx_toa = _params.timers.tx_toa;
     calcBackOff.last_tx_was_join_req = _params.is_last_tx_join_request;
 
@@ -1667,7 +1667,7 @@ lorawan_status_t LoRaMac::SendFrameOnChannel( uint8_t channel )
     mlme.get_confirmation().tx_toa = _params.timers.tx_toa;
 
     // Starts the MAC layer status check timer
-    _lora_time.TimerStart( _params.timers.mac_state_check_timer, MAC_STATE_CHECK_TIMEOUT );
+    _lora_time.start( _params.timers.mac_state_check_timer, MAC_STATE_CHECK_TIMEOUT );
 
     if( _params.is_nwk_joined == false )
     {
@@ -1696,7 +1696,7 @@ lorawan_status_t LoRaMac::SetTxContinuousWave( uint16_t timeout )
     lora_phy->set_tx_cont_mode(&continuousWave);
 
     // Starts the MAC layer status check timer
-    _lora_time.TimerStart( _params.timers.mac_state_check_timer, MAC_STATE_CHECK_TIMEOUT );
+    _lora_time.start( _params.timers.mac_state_check_timer, MAC_STATE_CHECK_TIMEOUT );
 
     _params.mac_state |= LORAMAC_TX_RUNNING;
 
@@ -1717,7 +1717,7 @@ lorawan_status_t LoRaMac::SetTxContinuousWave1( uint16_t timeout, uint32_t frequ
     lora_phy->set_tx_cont_mode(&continuousWave);
 
     // Starts the MAC layer status check timer
-    _lora_time.TimerStart( _params.timers.mac_state_check_timer, MAC_STATE_CHECK_TIMEOUT );
+    _lora_time.start( _params.timers.mac_state_check_timer, MAC_STATE_CHECK_TIMEOUT );
 
     _params.mac_state |= LORAMAC_TX_RUNNING;
 
@@ -1845,19 +1845,19 @@ lorawan_status_t LoRaMac::LoRaMacInitialization(loramac_primitives_t *primitives
     lora_phy->put_radio_to_sleep();
 
     // Initialize timers
-    _lora_time.TimerInit(_params.timers.mac_state_check_timer,
+    _lora_time.init(_params.timers.mac_state_check_timer,
                          mbed::callback(this, &LoRaMac::handle_mac_state_check_timer_event));
-    _lora_time.TimerInit(_params.timers.tx_delayed_timer,
+    _lora_time.init(_params.timers.tx_delayed_timer,
                          mbed::callback(this, &LoRaMac::handle_delayed_tx_timer_event));
-    _lora_time.TimerInit(_params.timers.rx_window1_timer,
+    _lora_time.init(_params.timers.rx_window1_timer,
                          mbed::callback(this, &LoRaMac::handle_rx1_timer_event));
-    _lora_time.TimerInit(_params.timers.rx_window2_timer,
+    _lora_time.init(_params.timers.rx_window2_timer,
                          mbed::callback(this, &LoRaMac::handle_rx2_timer_event));
-    _lora_time.TimerInit(_params.timers.ack_timeout_timer,
+    _lora_time.init(_params.timers.ack_timeout_timer,
                          mbed::callback(this, &LoRaMac::handle_ack_timeout));
 
     // Store the current initialization time
-    _params.timers.mac_init_time = _lora_time.TimerGetCurrentTime();
+    _params.timers.mac_init_time = _lora_time.get_current_time();
 
     return LORAWAN_STATUS_OK;
 }
@@ -1865,11 +1865,11 @@ lorawan_status_t LoRaMac::LoRaMacInitialization(loramac_primitives_t *primitives
 void LoRaMac::disconnect()
 {
     // Cancel all timers
-    _lora_time.TimerStop(_params.timers.mac_state_check_timer);
-    _lora_time.TimerStop(_params.timers.tx_delayed_timer);
-    _lora_time.TimerStop(_params.timers.rx_window1_timer);
-    _lora_time.TimerStop(_params.timers.rx_window2_timer);
-    _lora_time.TimerStop(_params.timers.ack_timeout_timer);
+    _lora_time.stop(_params.timers.mac_state_check_timer);
+    _lora_time.stop(_params.timers.tx_delayed_timer);
+    _lora_time.stop(_params.timers.rx_window1_timer);
+    _lora_time.stop(_params.timers.rx_window2_timer);
+    _lora_time.stop(_params.timers.ack_timeout_timer);
 
     // Put radio to sleep
     lora_phy->put_radio_to_sleep();
@@ -2109,13 +2109,13 @@ radio_events_t *LoRaMac::GetPhyEventHandlers()
 
 lorawan_status_t LoRaMac::LoRaMacSetTxTimer( uint32_t TxDutyCycleTime )
 {
-    _lora_time.TimerStart(tx_next_packet_timer, TxDutyCycleTime);
+    _lora_time.start(tx_next_packet_timer, TxDutyCycleTime);
     return LORAWAN_STATUS_OK;
 }
 
  lorawan_status_t LoRaMac::LoRaMacStopTxTimer( )
 {
-    _lora_time.TimerStop(tx_next_packet_timer);
+    _lora_time.stop(tx_next_packet_timer);
     return LORAWAN_STATUS_OK;
 }
 

--- a/features/lorawan/lorastack/phy/LoRaPHY.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHY.cpp
@@ -266,9 +266,9 @@ lorawan_time_t LoRaPHY::update_band_timeoff(bool joined, bool duty_cycle,
     for (uint8_t i = 0; i < nb_bands; i++) {
 
         if (joined == false) {
-            uint32_t txDoneTime =  MAX(_lora_time.TimerGetElapsedTime(bands[i].last_join_tx_time),
+            uint32_t txDoneTime =  MAX(_lora_time.get_elapsed_time(bands[i].last_join_tx_time),
                                         (duty_cycle == true) ?
-                                        _lora_time.TimerGetElapsedTime(bands[i].last_tx_time) : 0);
+                                        _lora_time.get_elapsed_time(bands[i].last_tx_time) : 0);
 
             if (bands[i].off_time <= txDoneTime) {
                 bands[i].off_time = 0;
@@ -282,12 +282,12 @@ lorawan_time_t LoRaPHY::update_band_timeoff(bool joined, bool duty_cycle,
             // if network has been joined
             if (duty_cycle == true) {
 
-                if( bands[i].off_time <= _lora_time.TimerGetElapsedTime(bands[i].last_tx_time)) {
+                if( bands[i].off_time <= _lora_time.get_elapsed_time(bands[i].last_tx_time)) {
                     bands[i].off_time = 0;
                 }
 
                 if(bands[i].off_time != 0 ) {
-                    next_tx_delay = MIN(bands[i].off_time - _lora_time.TimerGetElapsedTime(bands[i].last_tx_time),
+                    next_tx_delay = MIN(bands[i].off_time - _lora_time.get_elapsed_time(bands[i].last_tx_time),
                                        next_tx_delay);
                 }
             } else {
@@ -1221,7 +1221,7 @@ bool LoRaPHY::set_next_channel(channel_selection_params_t* params,
     }
 
     if (params->aggregate_timeoff
-            <= _lora_time.TimerGetElapsedTime(params->last_aggregate_tx_time)) {
+            <= _lora_time.get_elapsed_time(params->last_aggregate_tx_time)) {
         // Reset Aggregated time off
         *aggregate_timeoff = 0;
 
@@ -1238,7 +1238,7 @@ bool LoRaPHY::set_next_channel(channel_selection_params_t* params,
     } else {
         delay_tx++;
         next_tx_delay = params->aggregate_timeoff
-                - _lora_time.TimerGetElapsedTime(params->last_aggregate_tx_time);
+                - _lora_time.get_elapsed_time(params->last_aggregate_tx_time);
     }
 
     if (channel_count > 0) {

--- a/features/lorawan/lorastack/phy/LoRaPHYAS923.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHYAS923.cpp
@@ -349,7 +349,7 @@ bool LoRaPHYAS923::set_next_channel(channel_selection_params_t* next_channel_pra
         channel_masks[0] |= LC(1) + LC(2);
     }
 
-    if (next_channel_prams->aggregate_timeoff <= _lora_time.TimerGetElapsedTime(next_channel_prams->last_aggregate_tx_time)) {
+    if (next_channel_prams->aggregate_timeoff <= _lora_time.get_elapsed_time(next_channel_prams->last_aggregate_tx_time)) {
         // Reset Aggregated time off
         *aggregate_timeoff = 0;
 
@@ -366,7 +366,7 @@ bool LoRaPHYAS923::set_next_channel(channel_selection_params_t* next_channel_pra
                                                     enabled_channels, &delay_tx);
     }  else {
         delay_tx++;
-        next_tx_delay = next_channel_prams->aggregate_timeoff - _lora_time.TimerGetElapsedTime(next_channel_prams->last_aggregate_tx_time);
+        next_tx_delay = next_channel_prams->aggregate_timeoff - _lora_time.get_elapsed_time(next_channel_prams->last_aggregate_tx_time);
     }
 
     if (nb_enabled_channels > 0) {

--- a/features/lorawan/lorastack/phy/LoRaPHYAU915.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHYAU915.cpp
@@ -575,7 +575,7 @@ bool LoRaPHYAU915::set_next_channel(channel_selection_params_t* next_chan_params
         }
     }
 
-    if (next_chan_params->aggregate_timeoff <= _lora_time.TimerGetElapsedTime(next_chan_params->last_aggregate_tx_time)) {
+    if (next_chan_params->aggregate_timeoff <= _lora_time.get_elapsed_time(next_chan_params->last_aggregate_tx_time)) {
         // Reset Aggregated time off
         *aggregated_timeOff = 0;
 
@@ -592,7 +592,7 @@ bool LoRaPHYAU915::set_next_channel(channel_selection_params_t* next_chan_params
                                                      enabled_channels, &delay_tx);
     } else {
         delay_tx++;
-        next_tx_delay = next_chan_params->aggregate_timeoff - _lora_time.TimerGetElapsedTime(next_chan_params->last_aggregate_tx_time);
+        next_tx_delay = next_chan_params->aggregate_timeoff - _lora_time.get_elapsed_time(next_chan_params->last_aggregate_tx_time);
     }
 
     if (nb_enabled_channels > 0) {

--- a/features/lorawan/lorastack/phy/LoRaPHYKR920.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHYKR920.cpp
@@ -419,7 +419,7 @@ bool LoRaPHYKR920::set_next_channel(channel_selection_params_t* params,
         channel_masks[0] |= LC(1) + LC(2) + LC(3);
     }
 
-    if (params->aggregate_timeoff <= _lora_time.TimerGetElapsedTime(params->last_aggregate_tx_time)) {
+    if (params->aggregate_timeoff <= _lora_time.get_elapsed_time(params->last_aggregate_tx_time)) {
         // Reset Aggregated time off
         *aggregate_timeoff = 0;
 
@@ -433,7 +433,7 @@ bool LoRaPHYKR920::set_next_channel(channel_selection_params_t* params,
                                                      enabled_channels, &delay_tx);
     } else {
         delay_tx++;
-        nextTxDelay = params->aggregate_timeoff - _lora_time.TimerGetElapsedTime(params->last_aggregate_tx_time);
+        nextTxDelay = params->aggregate_timeoff - _lora_time.get_elapsed_time(params->last_aggregate_tx_time);
     }
 
     if (nb_enabled_channels > 0) {

--- a/features/lorawan/lorastack/phy/LoRaPHYUS915.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHYUS915.cpp
@@ -625,7 +625,7 @@ bool LoRaPHYUS915::set_next_channel(channel_selection_params_t* params,
         }
     }
 
-    if (params->aggregate_timeoff <= _lora_time.TimerGetElapsedTime(params->last_aggregate_tx_time)) {
+    if (params->aggregate_timeoff <= _lora_time.get_elapsed_time(params->last_aggregate_tx_time)) {
         // Reset Aggregated time off
         *aggregate_timeOff = 0;
 
@@ -639,7 +639,7 @@ bool LoRaPHYUS915::set_next_channel(channel_selection_params_t* params,
                                                     enabled_channels, &delay_tx);
     } else {
         delay_tx++;
-        next_tx_delay = params->aggregate_timeoff - _lora_time.TimerGetElapsedTime(params->last_aggregate_tx_time);
+        next_tx_delay = params->aggregate_timeoff - _lora_time.get_elapsed_time(params->last_aggregate_tx_time);
     }
 
     if (nb_enabled_channels > 0) {

--- a/features/lorawan/lorastack/phy/LoRaPHYUS915Hybrid.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHYUS915Hybrid.cpp
@@ -626,7 +626,7 @@ bool LoRaPHYUS915Hybrid::set_next_channel(channel_selection_params_t* params,
         }
     }
 
-    if (params->aggregate_timeoff <= _lora_time.TimerGetElapsedTime( params->last_aggregate_tx_time)) {
+    if (params->aggregate_timeoff <= _lora_time.get_elapsed_time( params->last_aggregate_tx_time)) {
         // Reset Aggregated time off
         *aggregate_timeOff = 0;
 
@@ -643,7 +643,7 @@ bool LoRaPHYUS915Hybrid::set_next_channel(channel_selection_params_t* params,
                                                     enabled_channels, &delay_tx);
     } else {
         delay_tx++;
-        next_tx_delay = params->aggregate_timeoff - _lora_time.TimerGetElapsedTime(params->last_aggregate_tx_time);
+        next_tx_delay = params->aggregate_timeoff - _lora_time.get_elapsed_time(params->last_aggregate_tx_time);
     }
 
     if (nb_enabled_channels > 0) {

--- a/features/lorawan/system/LoRaWANTimer.cpp
+++ b/features/lorawan/system/LoRaWANTimer.cpp
@@ -29,35 +29,35 @@ LoRaWANTimeHandler::~LoRaWANTimeHandler()
 {
 }
 
-void LoRaWANTimeHandler::TimerTimeCounterInit(events::EventQueue *queue)
+void LoRaWANTimeHandler::activate_timer_subsystem(events::EventQueue *queue)
 {
     _queue = queue;
 }
 
-lorawan_time_t LoRaWANTimeHandler::TimerGetCurrentTime( void )
+lorawan_time_t LoRaWANTimeHandler::get_current_time( void )
 {
     const uint32_t current_time = _queue->tick();
     return (lorawan_time_t)current_time;
 }
 
-lorawan_time_t LoRaWANTimeHandler::TimerGetElapsedTime( lorawan_time_t savedTime )
+lorawan_time_t LoRaWANTimeHandler::get_elapsed_time(lorawan_time_t saved_time)
 {
-    return TimerGetCurrentTime() - savedTime;
+    return get_current_time() - saved_time;
 }
 
-void LoRaWANTimeHandler::TimerInit( timer_event_t &obj, mbed::Callback<void()> callback)
+void LoRaWANTimeHandler::init(timer_event_t &obj, mbed::Callback<void()> callback)
 {
     obj.callback = callback;
     obj.timer_id = 0;
 }
 
-void LoRaWANTimeHandler::TimerStart( timer_event_t &obj, const uint32_t timeout )
+void LoRaWANTimeHandler::start(timer_event_t &obj, const uint32_t timeout)
 {
     obj.timer_id = _queue->call_in(timeout, obj.callback);
     MBED_ASSERT(obj.timer_id != 0);
 }
 
-void LoRaWANTimeHandler::TimerStop( timer_event_t &obj )
+void LoRaWANTimeHandler::stop(timer_event_t &obj)
 {
     _queue->cancel(obj.timer_id);
     obj.timer_id = 0;

--- a/features/lorawan/system/LoRaWANTimer.h
+++ b/features/lorawan/system/LoRaWANTimer.h
@@ -31,55 +31,50 @@ public:
     LoRaWANTimeHandler();
     ~LoRaWANTimeHandler();
 
-    /*!
-     * \brief Initializes the timer used to get the current time.
+    /** Activates the timer subsystem.
      *
-     * \remark The current time corresponds to the time since system startup.
+     * Embeds EventQueue object to timer subsystem which is subsequently
+     * used to extract timer information.
      *
-     * \param [in] queue  Handle to EventQueue object
+     * @param [in] queue  Handle to EventQueue object
      */
-    void TimerTimeCounterInit(events::EventQueue *queue);
+    void activate_timer_subsystem(events::EventQueue *queue);
 
-    /*!
-     * \brief Read the current time.
+    /** Read the current time.
      *
-     * \retval time The current time.
+     * @return time The current time.
      */
-    lorawan_time_t TimerGetCurrentTime( void );
+    lorawan_time_t get_current_time(void);
 
-    /*!
-     * \brief Return the time elapsed since a fixed moment in time.
+    /** Return the time elapsed since a fixed moment in time.
      *
-     * \param [in] savedTime    The fixed moment in time.
-     * \retval time             The elapsed time.
+     * @param [in] saved_time    The fixed moment in time.
+     * @return     time          The elapsed time.
      */
-    lorawan_time_t TimerGetElapsedTime( lorawan_time_t savedTime );
+    lorawan_time_t get_elapsed_time(lorawan_time_t saved_time);
 
-    /*!
-     * \brief Initializes the timer object.
+    /** Initializes the timer object.
      *
-     * \remark The TimerSetValue function must be called before starting the timer.
-     *         This function initializes the timestamp and reloads the value at 0.
+     * @remark The TimerSetValue function must be called before starting the timer.
+     *         This function initializes the time-stamp and reloads the value at 0.
      *
-     * \param [in] obj          The structure containing the timer object parameters.
-     * \param [in] callback     The function callback called at the end of the timeout.
+     * @param [in] obj          The structure containing the timer object parameters.
+     * @param [in] callback     The function callback called at the end of the timeout.
      */
-     void TimerInit( timer_event_t &obj, mbed::Callback<void()> callback);
+     void init(timer_event_t &obj, mbed::Callback<void()> callback);
 
-    /*!
-     * \brief Starts and adds the timer object to the list of timer events.
+    /** Starts and adds the timer object to the list of timer events.
      *
-     * \param [in] obj The structure containing the timer object parameters.
-     * \param [in] timeout The new timeout value.
+     * @param [in] obj     The structure containing the timer object parameters.
+     * @param [in] timeout The new timeout value.
      */
-    void TimerStart( timer_event_t &obj, const uint32_t timeout );
+    void start(timer_event_t &obj, const uint32_t timeout);
 
-    /*!
-     * \brief Stops and removes the timer object from the list of timer events.
+    /** Stops and removes the timer object from the list of timer events.
      *
-     * \param [in] obj The structure containing the timer object parameters.
+     * @param [in] obj The structure containing the timer object parameters.
      */
-    void TimerStop( timer_event_t &obj );
+    void stop(timer_event_t &obj);
 
 private:
     events::EventQueue *_queue;


### PR DESCRIPTION
    Style changes for LoRaWANTimer & a warning fix
    
    Method naming, doxygen style etc are made to follow Mbed-OS guidelines.
    A warning fix in LoRaWANstack.
