### PR TITLE
Remove redundant event from timer callbacks

### DIFF
--- a/features/lorawan/lorastack/mac/LoRaMac.cpp
+++ b/features/lorawan/lorastack/mac/LoRaMac.cpp
@@ -178,41 +178,6 @@ void LoRaMac::handle_fhss_change_channel(uint8_t cur_channel)
     //(void)ret;
 }
 
-void LoRaMac::handle_mac_state_check_timer_event(void)
-{
-    const int ret = ev_queue->call(this, &LoRaMac::on_mac_state_check_timer_event);
-    MBED_ASSERT(ret != 0);
-    (void)ret;
-}
-
-void LoRaMac::handle_delayed_tx_timer_event(void)
-{
-    const int ret = ev_queue->call(this, &LoRaMac::on_tx_delayed_timer_event);
-    MBED_ASSERT(ret != 0);
-    (void)ret;
-}
-
-void LoRaMac::handle_ack_timeout()
-{
-    const int ret = ev_queue->call(this, &LoRaMac::on_ack_timeout_timer_event);
-    MBED_ASSERT(ret != 0);
-    (void)ret;
-}
-
-void LoRaMac::handle_rx1_timer_event(void)
-{
-    const int ret = ev_queue->call(this, &LoRaMac::on_rx_window1_timer_event);
-    MBED_ASSERT(ret != 0);
-    (void)ret;
-}
-
-void LoRaMac::handle_rx2_timer_event(void)
-{
-    const int ret = ev_queue->call(this, &LoRaMac::on_rx_window2_timer_event);
-    MBED_ASSERT(ret != 0);
-    (void)ret;
-}
-
 /***************************************************************************
  * Radio event callbacks - delegated to Radio driver                       *
  **************************************************************************/
@@ -287,7 +252,9 @@ void LoRaMac::prepare_rx_done_abort(void)
     _params.mac_state |= LORAMAC_RX_ABORT;
 
     if (_params.is_node_ack_requested) {
-        handle_ack_timeout();
+        const int ret = ev_queue->call(this, &LoRaMac::on_ack_timeout_timer_event);
+        MBED_ASSERT(ret != 0);
+        (void)ret;
     }
 
     _params.flags.bits.mcps_ind = 1;
@@ -847,7 +814,10 @@ void LoRaMac::on_mac_state_check_timer_event(void)
                         } else {
                             _params.flags.bits.mac_done = 0;
                             // Sends the same frame again
-                            handle_delayed_tx_timer_event();
+                            const int ret = ev_queue->call(this, &LoRaMac::on_tx_delayed_timer_event);
+                            MBED_ASSERT(ret != 0);
+                            (void)ret;
+
                         }
                     }
                 } else {
@@ -871,7 +841,9 @@ void LoRaMac::on_mac_state_check_timer_event(void)
                     } else {
                         _params.flags.bits.mac_done = 0;
                         // Sends the same frame again
-                        handle_delayed_tx_timer_event();
+                        const int ret = ev_queue->call(this, &LoRaMac::on_tx_delayed_timer_event);
+                        MBED_ASSERT(ret != 0);
+                        (void)ret;
                     }
                 }
             }
@@ -1381,7 +1353,10 @@ void LoRaMac::reset_mac_parameters(void)
 
 void LoRaMac::open_continuous_rx2_window (void)
 {
-    handle_rx2_timer_event();
+    const int ret = ev_queue->call(this, &LoRaMac::on_rx_window2_timer_event);
+    MBED_ASSERT(ret != 0);
+    (void)ret;
+
     _params.rx_slot = RX_SLOT_WIN_CLASS_C;
 }
 
@@ -1780,15 +1755,15 @@ lorawan_status_t LoRaMac::initialize(loramac_primitives_t *primitives,
 
     // Initialize timers
     _lora_time.init(_params.timers.mac_state_check_timer,
-                    mbed::callback(this, &LoRaMac::handle_mac_state_check_timer_event));
+                    mbed::callback(this, &LoRaMac::on_mac_state_check_timer_event));
     _lora_time.init(_params.timers.tx_delayed_timer,
-                    mbed::callback(this, &LoRaMac::handle_delayed_tx_timer_event));
+                    mbed::callback(this, &LoRaMac::on_tx_delayed_timer_event));
     _lora_time.init(_params.timers.rx_window1_timer,
-                    mbed::callback(this, &LoRaMac::handle_rx1_timer_event));
+                    mbed::callback(this, &LoRaMac::on_rx_window1_timer_event));
     _lora_time.init(_params.timers.rx_window2_timer,
-                    mbed::callback(this, &LoRaMac::handle_rx2_timer_event));
+                    mbed::callback(this, &LoRaMac::on_rx_window2_timer_event));
     _lora_time.init(_params.timers.ack_timeout_timer,
-                    mbed::callback(this, &LoRaMac::handle_ack_timeout));
+                    mbed::callback(this, &LoRaMac::on_ack_timeout_timer_event));
 
     // Store the current initialization time
     _params.timers.mac_init_time = _lora_time.get_current_time();

--- a/features/lorawan/lorastack/mac/LoRaMac.h
+++ b/features/lorawan/lorastack/mac/LoRaMac.h
@@ -617,18 +617,11 @@ private:
      */
     void handle_cad_done(bool cad);
     void handle_tx_done(void);
-    void handle_rx_done(uint8_t *payload, uint16_t size, int16_t rssi,
-                        int8_t snr);
+    void handle_rx_done(uint8_t *payload, uint16_t size, int16_t rssi, int8_t snr);
     void handle_rx_error(void);
     void handle_rx_timeout(void);
     void handle_tx_timeout(void);
     void handle_fhss_change_channel(uint8_t cur_channel);
-    void handle_rx1_timer_event(void);
-    void handle_rx2_timer_event(void);
-    void handle_ack_timeout(void);
-    void handle_delayed_tx_timer_event(void);
-    void handle_mac_state_check_timer_event(void);
-    void handle_next_tx_timer_event(void);
 
 private:
     /**


### PR DESCRIPTION
Since our timers are now already using events, we no longer need to
defer timer callback calls.
